### PR TITLE
Remove `as` clauses

### DIFF
--- a/definitions/infra-container/golden_metrics.yml
+++ b/definitions/infra-container/golden_metrics.yml
@@ -2,19 +2,15 @@ cpuUsage:
   title: CPU usage (cores)
   query:
     select: max(docker.container.cpuUsedCores) or max(k8s.container.cpuUsedCores)
-      as 'CPU used cores'
 cpuUtilization:
   title: CPU Utilization (%)
   query:
     select: max(docker.container.cpuPercent) or max(k8s.container.cpuCoresUtilization)
-      AS 'CPU Utilization (%)'
 memoryUsage:
   title: Memory usage (bytes)
   query:
     select: max(docker.container.memoryUsageBytes) or max(k8s.container.memoryUtilization)
-      AS 'Memory used (bytes)'
 storageUsage:
   title: Storage usage (bytes)
   query:
     select: max(docker.container.ioTotalBytes) or max(k8s.container.fsUsedPercent)
-      AS 'Storage used (bytes)'

--- a/definitions/infra-postgresqlinstance/golden_metrics.yml
+++ b/definitions/infra-postgresqlinstance/golden_metrics.yml
@@ -1,21 +1,21 @@
 scheduledCheckpoints:
   title: Scheduled checkpoints
   query:
-    select: average(bgwriter.checkpointsScheduledPerSecond) as 'Scheduled checkpoints'
+    select: average(bgwriter.checkpointsScheduledPerSecond)
     from: PostgresqlInstanceSample
     facet: entityName
     eventId: entityGuid
 requestedCheckpoints:
   title: Requested checkpoints
   query:
-    select: average(bgwriter.checkpointsRequestedPerSecond) as 'Requested checkpoints'
+    select: average(bgwriter.checkpointsRequestedPerSecond)
     from: PostgresqlInstanceSample
     facet: entityName
     eventId: entityGuid
 buffersAllocated:
   title: Buffers allocated
   query:
-    select: average(bgwriter.buffersAllocatedPerSecond) as 'Buffers allocated'
+    select: average(bgwriter.buffersAllocatedPerSecond)
     from: PostgresqlInstanceSample
     facet: entityName
     eventId: entityGuid


### PR DESCRIPTION
We're going to use the metric name by default, injected by the backend
at query time.

Signed-off-by: Galo Navarro <gnavarro@newrelic.com>

### Relevant information

Describe what you have done and any details that you think are relevant or that you might want to discuss with us. 

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
