### PR TITLE
Validate GM select doesn't use alias explicitly

### DIFF
--- a/definitions/infra-container/golden_metrics.yml
+++ b/definitions/infra-container/golden_metrics.yml
@@ -2,19 +2,15 @@ cpuUsage:
   title: CPU usage (cores)
   query:
     select: max(docker.container.cpuUsedCores) or max(k8s.container.cpuUsedCores)
-      as 'CPU used cores'
 cpuUtilization:
   title: CPU Utilization (%)
   query:
     select: max(docker.container.cpuPercent) or max(k8s.container.cpuCoresUtilization)
-      AS 'CPU Utilization (%)'
 memoryUsage:
   title: Memory usage (bytes)
   query:
     select: max(docker.container.memoryUsageBytes) or max(k8s.container.memoryUtilization)
-      AS 'Memory used (bytes)'
 storageUsage:
   title: Storage usage (bytes)
   query:
     select: max(docker.container.ioTotalBytes) or max(k8s.container.fsUsedPercent)
-      AS 'Storage used (bytes)'

--- a/definitions/infra-postgresqlinstance/golden_metrics.yml
+++ b/definitions/infra-postgresqlinstance/golden_metrics.yml
@@ -1,21 +1,21 @@
 scheduledCheckpoints:
   title: Scheduled checkpoints
   query:
-    select: average(bgwriter.checkpointsScheduledPerSecond) as 'Scheduled checkpoints'
+    select: average(bgwriter.checkpointsScheduledPerSecond)
     from: PostgresqlInstanceSample
     facet: entityName
     eventId: entityGuid
 requestedCheckpoints:
   title: Requested checkpoints
   query:
-    select: average(bgwriter.checkpointsRequestedPerSecond) as 'Requested checkpoints'
+    select: average(bgwriter.checkpointsRequestedPerSecond)
     from: PostgresqlInstanceSample
     facet: entityName
     eventId: entityGuid
 buffersAllocated:
   title: Buffers allocated
   query:
-    select: average(bgwriter.buffersAllocatedPerSecond) as 'Buffers allocated'
+    select: average(bgwriter.buffersAllocatedPerSecond)
     from: PostgresqlInstanceSample
     facet: entityName
     eventId: entityGuid

--- a/docs/golden_metrics.md
+++ b/docs/golden_metrics.md
@@ -7,7 +7,7 @@ We allow a maximum of 10 metrics per entityType.
 ## Defining golden metrics
 
 Golden metrics are defined in a map where each key should be unique. The allowed characters are `[a-zA-Z0-9_]` with a maximum of 100 characters.
-This key defines the intention of the metric:
+This key defines the intention of the metric and will be used as the alias of the query:
 
 ```yaml
 memoryUsage:

--- a/validator/schemas/golden-metrics-schema-v1.json
+++ b/validator/schemas/golden-metrics-schema-v1.json
@@ -68,6 +68,7 @@
         "properties": {
           "select": {
             "$id": "#/properties/query/properties/select",
+            "pattern": "^((?!((\\s+)as(\\s+))).)*$",
             "type": "string",
             "examples": [
               "average(host.memoryUsagePercent)"

--- a/validator/schemas/golden-metrics-schema-v1.json
+++ b/validator/schemas/golden-metrics-schema-v1.json
@@ -68,7 +68,7 @@
         "properties": {
           "select": {
             "$id": "#/properties/query/properties/select",
-            "pattern": "^((?!((\\s+)as(\\s+))).)*$",
+            "pattern": "^((?!((\\s+)[Aa][Ss](\\s+))).)*$",
             "type": "string",
             "examples": [
               "average(host.memoryUsagePercent)"

--- a/validator/schemas/summary-metrics-schema-v1.json
+++ b/validator/schemas/summary-metrics-schema-v1.json
@@ -52,7 +52,7 @@
         ]
       },
       "unit": {
-        "$id": "#/properties/title",
+        "$id": "#/properties/unit",
         "type": "string",
         "title": "The unit of the metric",
         "enum": ["REQUESTS_PER_SECOND","PAGES_PER_SECOND","MESSAGES_PER_SECOND","OPERATIONS_PER_SECOND","COUNT","SECONDS","PERCENTAGE","BITS","BYTES","BITS_PER_SECOND","BYTES_PER_SECOND","HERTZ","APDEX","TIMESTAMP","STRING"],


### PR DESCRIPTION
### Relevant information

Follow up to [PR-77](https://github.com/newrelic-experimental/entity-synthesis-definitions/pull/77), validating that we don't add more GM with the alias on select. 