### PR TITLE
Db2 and Oracle instances

### DIFF
--- a/definitions/ext-db2/definition.yml
+++ b/definitions/ext-db2/definition.yml
@@ -1,0 +1,17 @@
+domain: EXT
+type: DB2
+
+synthesis:
+  identifier: instance
+  name: instance
+  encodeIdentifierInGUID: true
+  conditions:
+  - attribute: event_type
+    value: db2
+  tags:
+    database:
+    hostname:
+
+configuration:
+  entityExpirationTime: EIGHT_DAYS
+  alertable: true

--- a/definitions/ext-oracle/definition.yml
+++ b/definitions/ext-oracle/definition.yml
@@ -1,0 +1,17 @@
+domain: EXT
+type: ORACLE
+
+synthesis:
+  identifier: instance_name
+  name: instance_name
+  encodeIdentifierInGUID: true
+  conditions:
+  - attribute: event_type
+    value: Oracle
+  tags:
+    database:
+    hostname:
+
+configuration:
+  entityExpirationTime: EIGHT_DAYS
+  alertable: true


### PR DESCRIPTION
### Relevant information

Add synth definitions for DB2 and Oracle instances.

I went with plain DB2 & Oracle for the types. I notice EXT-REDIS is just redis while infra is REDIS_INSTANCE. So let me know if you prefer one or the other.

Notice these are not "databases" but "instances". One instance can contain multiple databases.

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
