### PR TITLE
Update SM docs to explain that STRING unit is not supported for NRDB queries

### DIFF
--- a/docs/summary_metrics.md
+++ b/docs/summary_metrics.md
@@ -52,7 +52,7 @@ The unit of the metric must be a string with one of the following values:
 - HERTZ
 - APDEX
 - TIMESTAMP
-- STRING
+- STRING (Not supported for NRDB queries, please use tags instead)
 
 
 ### NRDB Query


### PR DESCRIPTION
### Relevant information

Update SM docs to explain that STRING unit is not supported for NRDB queries
