### PR TITLE
Update docs to reflect default behavior of roll-up composite metrics

### DIFF
--- a/docs/golden_metrics.md
+++ b/docs/golden_metrics.md
@@ -73,4 +73,4 @@ The first tag value that matches with the entity will be the one used to build t
 
 Is also important to note that the semantics of the queries should match between each implementation. This includes things like average vs counts, units and other details.
 
-If no rule matches the `newRelic` one will be used.
+If no rule matches, the first one on the list will be used. In the example above that would be `prometheus`.

--- a/docs/summary_metrics.md
+++ b/docs/summary_metrics.md
@@ -118,4 +118,4 @@ The first tag value that matches with the entity will be the one used to build t
 
 Is also important to note that the semantics of the queries should match between each implementation. This includes things like average vs counts, units and other details.
 
-If no rule matches the `newRelic` one will be used.
+If no rule matches, the first one on the list will be used. In the example above that would be `prometheus`.


### PR DESCRIPTION
### Relevant information

Update docs to reflect default behavior of roll-up composite metrics: The first query is selected, not the one with the `newRelic` discriminator. 

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
