### PR TITLE
Make containerId single value.

### DIFF
--- a/definitions/infra-container/definition.yml
+++ b/definitions/infra-container/definition.yml
@@ -13,6 +13,7 @@ synthesis:
       docker.state:
         entityTagName: container.state
       docker.containerId:
+        multiValue: false
       docker.shortContainerId:
       docker.imageName:
       docker.ecsClusterArn:
@@ -34,8 +35,10 @@ synthesis:
       k8s.namespaceName:
       k8s.podName:
       k8s.containerImage:
+        multiValue: false
       k8s.nodeName:
       k8s.containerId:
+        multiValue: false
       label.topology.kubernetes.io/region:
       label.topology.kubernetes.io/zone:
       label.eks.amazonaws.com/compute-type:


### PR DESCRIPTION
There are some containers that use the same name (which determines the identifier) but get restarted often.   As the tag is set to multi value, we'll keep accumulating the containerId tag.

### Relevant information

Describe what you have done and any details that you think are relevant or that you might want to discuss with us. 

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
