### PR TITLE
Reintroduce db2 and oracle definitions

### DIFF
--- a/definitions/mlops-machine_learning_model/definition.yml
+++ b/definitions/mlops-machine_learning_model/definition.yml
@@ -1,0 +1,5 @@
+domain: MLOPS
+type: MACHINE_LEARNING_MODEL
+configuration:
+  entityExpirationTime: QUARTERLY
+  alertable: true


### PR DESCRIPTION
We removed DB2 and Oracle definitions waiting for feedback from core-integrations.

I'm keeping this branch around since these where the changes we merged. We can update from here
