### PR TITLE
Add CELSIUS unit into the validator

### DIFF
--- a/validator/schemas/summary-metrics-schema-v1.json
+++ b/validator/schemas/summary-metrics-schema-v1.json
@@ -57,7 +57,7 @@
         "$id": "#/properties/title/unit",
         "type": "string",
         "title": "The unit of the metric",
-        "enum": ["REQUESTS_PER_SECOND", "PAGES_PER_SECOND", "MESSAGES_PER_SECOND", "OPERATIONS_PER_SECOND", "COUNT", "SECONDS", "PERCENTAGE", "BITS", "BYTES", "BITS_PER_SECOND", "BYTES_PER_SECOND", "HERTZ", "APDEX", "TIMESTAMP", "STRING"],
+        "enum": ["REQUESTS_PER_SECOND", "PAGES_PER_SECOND", "MESSAGES_PER_SECOND", "OPERATIONS_PER_SECOND", "COUNT", "SECONDS", "PERCENTAGE", "BITS", "BYTES", "BITS_PER_SECOND", "BYTES_PER_SECOND", "HERTZ", "APDEX", "TIMESTAMP", "STRING", "CELSIUS"],
         "examples": [
           "COUNT"
         ]


### PR DESCRIPTION
### Relevant information

This ones goes in had with: https://github.com/newrelic/entity-definitions/pull/257
Add the CELSIUS unit into the validator. All the internal work is already done.

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
