### PR TITLE
chore: updating to new celsius metric unit in SM

### DIFF
--- a/definitions/ext-ups/summary_metrics.yml
+++ b/definitions/ext-ups/summary_metrics.yml
@@ -15,7 +15,7 @@ outputLoadCapacity:
 
 batteryTemperature:
   title: Battery Temp (C)
-  unit: STRING
+  unit: CELSIUS
   query:
     select: latest(kentik.snmp.upsAdvBatteryTemperature)
     from: Metric


### PR DESCRIPTION
### Relevant information

Update Summary Metric definition for `ext-ups` entity to use new metric unit introduced in PR #257 

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
