### PR TITLE
Change EXT-IBMMQQUEUE tags to multiValue

### DIFF
--- a/definitions/ext-ibmmqqueue/definition.yml
+++ b/definitions/ext-ibmmqqueue/definition.yml
@@ -10,11 +10,11 @@ synthesis:
 
   tags:
     qManagerName:
-      multiValue: false
+      multiValue: true
     qManagerHost:
-      multiValue: false
+      multiValue: true
     agentName:
-      multiValue: false
+      multiValue: true
     object:
       multiValue: false
 


### PR DESCRIPTION
### Relevant information

Change some `EXT-IBMMQQUEUE` tags to `multiValue:true` since their values flip from one telemetry datapoint to another. This was discussed on slack with @khpeet. 

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
