### PR TITLE
feat: adding kentik-default entity type

### DIFF
--- a/definitions/ext-kentik_default/dashboard.json
+++ b/definitions/ext-kentik_default/dashboard.json
@@ -1,0 +1,51 @@
+{
+	"name": "Kentik-Default",
+	"description": null,
+	"pages": [
+		{
+			"name": "Kentik-Default",
+			"description": null,
+			"widgets": [
+				{
+					"visualization": {
+						"id": "viz.markdown"
+					},
+					"layout": {
+						"column": 1,
+						"row": 1,
+						"height": 4,
+						"width": 10
+					},
+					"title": "",
+					"rawConfiguration": {
+						"text": "# This device needs attention!!!\n\n*The creation of entities from ktranslate data in New Relic has dependencies in the open source repositories of both [ktranslate](https://github.com/kentik/ktranslate) and our [Entity Definitions](https://github.com/newrelic/entity-definitions) library. More additions are being added all the time and we always welcome PRs!*\n\nThe process to create an entity is as follows:\n \n 1. Data is processed by ktranslate and SysOIDs are matched to a pre-defined '[profile](https://github.com/kentik/ktranslate/tree/main/config/profiles/kentik_snmp)', which then transposes to the `provider` attribute in the data sent to New Relic. Devices with no match are set to `provider: kentik-default`.\n  2. On ingest, New Relic matches data from ktranslate based on the value of the `provider` attribute into a pre-defined entity definition. Devices where `provider: kentik-default` are synthesized in `Kentik Default` entities. *(which is what you are looking at right now)*\n\nTo remediate this, you will need to update your YAML config file for ktranslate to ensure the `mib_profile` value for this device matches a known profile. If none exist to match, you can [submit a pull request](https://github.com/kentik/ktranslate/compare) to ktranslate, or [open an issue](https://github.com/kentik/ktranslate/issues) if you need assistance. \n\nIf you also need a new entity type defined in New Relic, you can [submit a pull request](https://github.com/newrelic/entity-definitions/compare) to the entity definition repo, or contact your New Relic account team or [ask for help in the Explorer's Hub](https://discuss.newrelic.com/c/full-stack-observability/465) and we'll be happy to assist!"
+					}
+				},
+				{
+					"visualization": {
+						"id": "viz.table"
+					},
+					"layout": {
+						"column": 1,
+						"row": 5,
+						"height": 2,
+						"width": 10
+					},
+					"title": "Device Summary",
+					"rawConfiguration": {
+						"dataFormatters": [],
+						"facet": {
+							"showOtherSeries": false
+						},
+						"nrqlQueries": [
+							{
+								"accountId": 0,
+								"query": "FROM Metric SELECT latest(timestamp) AS 'Last Poll' FACET device_name AS 'Name', src_addr AS 'IP Address', SysObjectID, sysoid_profile AS 'ktranslate profile' WHERE provider = 'kentik-default'"
+							}
+						]
+					}
+				}
+			]
+		}
+	]
+}

--- a/definitions/ext-kentik_default/definition.yml
+++ b/definitions/ext-kentik_default/definition.yml
@@ -1,0 +1,21 @@
+domain: EXT
+# Devices from Kentik's ktranslate agent that do not match a known entity type
+# Current list is defined in the 'Provider' type definition in ktranslate, found here:
+# https://github.com/kentik/ktranslate/blob/main/pkg/kt/types.go
+type: KENTIK_DEFAULT
+synthesis:
+  name: device_name
+  identifier: device_name
+  encodeIdentifierInGUID: true
+
+  conditions:
+  - attribute: provider
+    value: kentik-default
+
+  tags:
+    src_addr:
+    profile_message:
+
+dashboardTemplates:
+  kentik:
+    template: dashboard.json

--- a/definitions/ext-kentik_default/definition.yml
+++ b/definitions/ext-kentik_default/definition.yml
@@ -19,3 +19,6 @@ synthesis:
 dashboardTemplates:
   kentik:
     template: dashboard.json
+
+configuration:
+  entityExpirationTime: FOUR_HOURS

--- a/definitions/ext-kentik_default/summary_metrics.yml
+++ b/definitions/ext-kentik_default/summary_metrics.yml
@@ -1,0 +1,11 @@
+ipAddress:
+  title: IP Address
+  unit: STRING
+  tag:
+    key: src_addr
+
+profileMessage:
+  title: Profile Message
+  unit: STRING
+  tag:
+    key: profile_message


### PR DESCRIPTION
### Relevant information

adding a default entity type for telemetry received from Kentik's ktranslate agent

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
