### PR TITLE
chore: update links to new repo location

### DIFF
--- a/definitions/ext-kentik_default/dashboard.json
+++ b/definitions/ext-kentik_default/dashboard.json
@@ -13,12 +13,12 @@
 					"layout": {
 						"column": 1,
 						"row": 1,
-						"height": 7,
+						"height": 6,
 						"width": 12
 					},
 					"title": "",
 					"rawConfiguration": {
-						"text": "# This device needs attention!!!\n\n*The creation of entities from ktranslate data in New Relic has dependencies in the open source repositories of both [ktranslate](https://github.com/kentik/ktranslate) and our [Entity Definitions](https://github.com/newrelic/entity-definitions) library. More additions are being added all the time and we always welcome PRs!*\n\nThe process to create an entity is as follows:\n \n 1. Data is processed by ktranslate and SysOIDs are matched to a pre-defined '[profile](https://github.com/kentik/ktranslate/tree/main/config/profiles/kentik_snmp)', which then transposes to the `provider` attribute in the data sent to New Relic. Devices with no match are set to `provider: kentik-default`.\n  2. On ingest, New Relic matches data from ktranslate based on the value of the `provider` attribute into a pre-defined entity definition. Devices where `provider: kentik-default` are synthesized in `Kentik Default` entities. *(which is what you are looking at right now)*\n\nTo remediate this, you will need to update your YAML config file for ktranslate to ensure the `mib_profile` value for this device matches a known profile. If none exist to match, you can [submit a pull request](https://github.com/kentik/ktranslate/compare) to ktranslate, or [open an issue](https://github.com/kentik/ktranslate/issues) if you need assistance. \n\nIf you also need a new entity type defined in New Relic, you can [submit a pull request](https://github.com/newrelic/entity-definitions/compare) to the entity definition repo, or contact your New Relic account team or [ask for help in the Explorer's Hub](https://discuss.newrelic.com/c/full-stack-observability/465) and we'll be happy to assist!"
+						"text": "# This device needs attention!!!\n\n*The creation of entities from ktranslate data in New Relic has dependencies in the open source repositories of both [Kentik's snmp-profiles](https://github.com/kentik/snmp-profiles) and our [Entity Definitions](https://github.com/newrelic/entity-definitions) library. More additions are being added all the time and we always welcome PRs!*\n\nThe process to create an entity is as follows:\n \n 1. Data is processed by ktranslate and SysOIDs are matched to a pre-defined '[profile](https://github.com/kentik/snmp-profiles/tree/main/profiles/kentik_snmp)', which then transposes to the `provider` attribute in the data sent to New Relic. Devices with no match are set to `provider: kentik-default`.\n  2. On ingest, New Relic matches data from ktranslate based on the value of the `provider` attribute into a pre-defined entity definition. Devices where `provider: kentik-default` are synthesized in `Kentik Default` entities. *(which is what you are looking at right now)*\n\nTo remediate this, you will need to update your YAML config file for ktranslate to ensure the `mib_profile` value for this device matches a known profile. If none exist to match, you can [submit a pull request](https://github.com/kentik/snmp-profiles/compare) to ktranslate, or [open an issue](https://github.com/kentik/snmp-profiles/issues/new) if you need assistance. \n\nIf you also need a new entity type defined in New Relic, you can [submit a pull request](https://github.com/newrelic/entity-definitions/compare) to the entity definition repo, contact your New Relic account team or [ask for help in the Explorer's Hub](https://discuss.newrelic.com/c/full-stack-observability/465) and we'll be happy to assist!"
 					}
 				},
 				{
@@ -27,7 +27,7 @@
 					},
 					"layout": {
 						"column": 1,
-						"row": 8,
+						"row": 7,
 						"height": 2,
 						"width": 12
 					},


### PR DESCRIPTION
### Relevant information

Updating dashboard for `EXT-Kentik_Default` entity with links to new [snmp-profiles](https://github.com/kentik/snmp-profiles) repository

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
