### PR TITLE
fix: Correct awsvpcnetworkinterface summary metric eventId

### DIFF
--- a/definitions/infra-awsvpcnetworkinterface/summary_metrics.yml
+++ b/definitions/infra-awsvpcnetworkinterface/summary_metrics.yml
@@ -5,14 +5,14 @@ providerAccountName:
   unit: STRING
 byteRate:
   query:
-    eventId: entity.guid
+    eventId: entityGuid
     select: rate(sum(provider.bytes),1 minute)
     from: PrivateNetworkSample
   unit: BYTES
   title: Bytes per minute
 packetRate:
   query:
-    eventId: entity.guid
+    eventId: entityGuid
     select: rate(sum(provider.packets),1 minute)
     from: PrivateNetworkSample
   unit: COUNT


### PR DESCRIPTION
### Relevant information

Corrected the values of eventId for the summary_metric.yml in the infra-awsvpcnetworkinterface entity.
'entity.guid' was not the correct way to reference the guid.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
