### PR TITLE
Removes GITHUB-* entityType definitions from INFRA domain

### DIFF
--- a/definitions/infra-github_actions/definition.yml
+++ b/definitions/infra-github_actions/definition.yml
@@ -1,5 +1,0 @@
-domain: INFRA
-type: GITHUB_ACTIONS
-configuration:
-  entityExpirationTime: DAILY
-  alertable: true

--- a/definitions/infra-github_api/definition.yml
+++ b/definitions/infra-github_api/definition.yml
@@ -1,5 +1,0 @@
-domain: INFRA
-type: GITHUB_API
-configuration:
-  entityExpirationTime: DAILY
-  alertable: true

--- a/definitions/infra-github_repo/definition.yml
+++ b/definitions/infra-github_repo/definition.yml
@@ -1,5 +1,0 @@
-domain: INFRA
-type: GITHUB_REPO
-configuration:
-  entityExpirationTime: DAILY
-  alertable: true


### PR DESCRIPTION
### Relevant information

Removing GITHUB-*  entityType definitions which are unused to avoid conflicts with new entities.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
