### PR TITLE
fix WHERE clauses in golden and summary metrics queries

### DIFF
--- a/definitions/ext-istio_service/golden_metrics.yml
+++ b/definitions/ext-istio_service/golden_metrics.yml
@@ -6,11 +6,13 @@ throughput:
 errorRate:
   title: Error rate
   query:
-    select: (filter(sum(istio_requests_total), WHERE response_code LIKE '5%') * 100 ) / sum(istio_requests_total) WHERE reporter = 'destination'
+    select: (filter(sum(istio_requests_total), WHERE response_code LIKE '5%') * 100 ) / sum(istio_requests_total)
+    where: reporter = 'destination'
     from: Metric
 responseTimeMs:
   title: Response time (ms)
   query:
-    select: sum(istio_request_duration_milliseconds_sum / istio_request_duration_milliseconds_count) WHERE reporter = 'destination' 
+    select: sum(istio_request_duration_milliseconds_sum / istio_request_duration_milliseconds_count)
+    where: reporter = 'destination' 
     from: Metric
 

--- a/definitions/ext-istio_service/summary_metrics.yml
+++ b/definitions/ext-istio_service/summary_metrics.yml
@@ -12,27 +12,31 @@ throughputInbound:
   title: Throughput (Inbound)
   unit: REQUESTS_PER_SECOND
   query:
-    select: rate(sum(istio_requests_total), 1 SECOND) WHERE reporter = 'destination'
+    select: rate(sum(istio_requests_total), 1 SECOND)
+    where: reporter = 'destination'
     from: Metric
     eventId: entity.guid
 throughputOutbound:
   title: Throughput (Outbound)
   unit: REQUESTS_PER_SECOND
   query:
-    select: rate(sum(istio_requests_total), 1 SECOND) WHERE reporter = 'source'
+    select: rate(sum(istio_requests_total), 1 SECOND)
+    where: reporter = 'source'
     from: Metric
     eventId: entity.guid
 errorRate:
   title: Error rate
   unit: PERCENTAGE
   query:
-    select: (filter(sum(istio_requests_total), WHERE response_code LIKE '5%') / sum(istio_requests_total)) * 100 WHERE reporter = 'destination'
+    select: (filter(sum(istio_requests_total), WHERE response_code LIKE '5%') / sum(istio_requests_total)) * 100
+    where: reporter = 'destination'
     from: Metric
     eventId: entity.guid
 responseTimeMs:
   title: Response time
   unit: SECONDS
   query:
-    select: (sum(istio_request_duration_milliseconds_sum) / sum(istio_request_duration_milliseconds_count)) / 1000 WHERE reporter = 'destination' 
+    select: (sum(istio_request_duration_milliseconds_sum) / sum(istio_request_duration_milliseconds_count)) / 1000
+    where: reporter = 'destination' 
     from: Metric
     eventId: entity.guid


### PR DESCRIPTION
### Relevant information

Original queries had `WHERE` clauses embedded in the `select:` key.
Fixed by moving them to the proper `where:` key

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
