### PR TITLE
fix: summary and golden metric eventId's for EXT-DEEPER_CONNECT

### DIFF
--- a/definitions/ext-deeper_connect/golden_metrics.yml
+++ b/definitions/ext-deeper_connect/golden_metrics.yml
@@ -4,67 +4,67 @@ cpuPercent:
   query:
     select: latest(device.cpuPercent)
     from: DeeperConnectSample
-    eventId: device.sn
+    eventId: entity.guid
 memoryPercent:
   title: Memory Percent
   unit: PERCENTAGE
   query:
     select: latest(device.memoryPercent)
     from: DeeperConnectSample
-    eventId: device.sn
+    eventId: entity.guid
 temperatureCelsius:
   title: Temp Celsius
   unit: CELSIUS
   query:
     select: latest(device.tempCelsius)
     from: DeeperConnectSample
-    eventId: device.sn
+    eventId: entity.guid
 creditScore:
   title: Credit Score
   unit: COUNT
   query:
     select: latest(balance.credit)
     from: DeeperConnectSample
-    eventId: device.sn
+    eventId: entity.guid
 inboundConnections:
   title: Inbound Connections
   unit: COUNT
   query:
     select: latest(map.connections.inboundCount)
     from: DeeperConnectSample
-    eventId: device.sn
+    eventId: entity.guid
 outboundConnections:
   title: Outbound Connections
   unit: COUNT
   query:
     select: latest(map.connections.outboundCount)
     from: DeeperConnectSample
-    eventId: device.sn
+    eventId: entity.guid
 sharedUpload:
   title: Shared Upload
   unit: BYTES
   query:
     select: latest(traffic.server.uploadBytes)
     from: DeeperConnectSample
-    eventId: device.sn
+    eventId: entity.guid
 sharedDownload:
   title: Shared Download
   unit: BYTES
   query:
     select: latest(traffic.server.downloadBytes)
     from: DeeperConnectSample
-    eventId: device.sn
+    eventId: entity.guid
 clientUpload:
   title: Client Upload
   unit: BYTES
   query:
     select: latest(traffic.client.uploadBytes)
     from: DeeperConnectSample
-    eventId: device.sn
+    eventId: entity.guid
 clientDownload:
   title: Client Download
   unit: BYTES
   query:
     select: latest(traffic.client.downloadBytes)
     from: DeeperConnectSample
-    eventId: device.sn
+    eventId: entity.guid

--- a/definitions/ext-deeper_connect/summary_metrics.yml
+++ b/definitions/ext-deeper_connect/summary_metrics.yml
@@ -19,46 +19,46 @@ cpuPercent:
   query:
     select: latest(device.cpuPercent)
     from: DeeperConnectSample
-    eventId: device.sn
+    eventId: entity.guid
 memoryPercent:
   title: Memory Percent
   unit: PERCENTAGE
   query:
     select: latest(device.memoryPercent)
     from: DeeperConnectSample
-    eventId: device.sn
+    eventId: entity.guid
 temperatureCelsius:
   title: Temp Celsius
   unit: CELSIUS
   query:
     select: latest(device.tempCelsius)
     from: DeeperConnectSample
-    eventId: device.sn
+    eventId: entity.guid
 creditScore:
   title: Credit Score
   unit: COUNT
   query:
     select: latest(balance.credit)
     from: DeeperConnectSample
-    eventId: device.sn
+    eventId: entity.guid
 sharedUpload:
   title: Shared Upload
   unit: BYTES
   query:
     select: latest(traffic.server.uploadBytes)
     from: DeeperConnectSample
-    eventId: device.sn
+    eventId: entity.guid
 sharedDownload:
   title: Shared Download
   unit: BYTES
   query:
     select: latest(traffic.server.downloadBytes)
     from: DeeperConnectSample
-    eventId: device.sn
+    eventId: entity.guid
 inboundConnections:
   title: Inbound Connections
   unit: COUNT
   query:
     select: latest(map.connections.inboundCount)
     from: DeeperConnectSample
-    eventId: device.sn
+    eventId: entity.guid


### PR DESCRIPTION
### Relevant information

Fixes summary and golden metrics, was previously using `device.sn` when should be `entity.guid`.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
