### PR TITLE
Fix network golden and summary metrics for OTEL hosts

### DIFF
--- a/definitions/infra-host/golden_metrics.yml
+++ b/definitions/infra-host/golden_metrics.yml
@@ -55,7 +55,7 @@ networkTraffic:
       eventId: entityGuid
       eventName: entityName
     opentelemetry:
-      select: derivative(system.network.io, 1 second)
+      select: average(system.network.io)
       from: Metric
       eventId: entity.guid
       eventName: entity.name

--- a/definitions/infra-host/summary_metrics.yml
+++ b/definitions/infra-host/summary_metrics.yml
@@ -137,7 +137,14 @@ networkTrafficGcp:
   unit: BYTES_PER_SECOND
   derive: (@networkInGcp + @networkOutGcp) / 60
   hidden: true
+networkTrafficOtel:
+  title: Network Traffic OTEL
+  unit: BYTES_PER_SECOND
+  query:
+    from: Metric
+    select: average(system.network.io)
+    eventId: entity.guid
 networkTraffic:
   title: Network Traffic
   unit: BYTES_PER_SECOND
-  derive: '@networkTrafficEc2 || @networkTrafficAzure || @networkTrafficGcp || @networkTrafficHost'
+  derive: '@networkTrafficEc2 || @networkTrafficAzure || @networkTrafficGcp || @networkTrafficHost || @networkTrafficOtel'


### PR DESCRIPTION
### Relevant information

The previous GM definition for OTEL hosts contained the derivative function, which is not supported. In this PR, this is changed to `average`. What's more, the summary metric definition is also provided.

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
