### PR TITLE
Hide otel host summary metric

### DIFF
--- a/definitions/infra-host/summary_metrics.yml
+++ b/definitions/infra-host/summary_metrics.yml
@@ -140,6 +140,7 @@ networkTrafficGcp:
 networkTrafficOtel:
   title: Network Traffic OTEL
   unit: BYTES_PER_SECOND
+  hidden: true
   query:
     from: Metric
     select: average(system.network.io)


### PR DESCRIPTION
### Relevant information

In the previous PR, I mistakenly made the OTEL network summary metric visible. This is the fix.

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
