### PR TITLE
Remove GM definitions for OTEL hosts

### DIFF
--- a/definitions/infra-host/golden_metrics.yml
+++ b/definitions/infra-host/golden_metrics.yml
@@ -54,8 +54,3 @@ networkTraffic:
       from: NetworkSample
       eventId: entityGuid
       eventName: entityName
-    opentelemetry:
-      select: average(system.network.io)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name


### PR DESCRIPTION

### Relevant information

Looks like the GM definition for OTEL break the Lookout for hosts. This PR is to remove it.

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
