### PR TITLE
fix network golden metrics for otel hosts

### DIFF
--- a/definitions/infra-host/golden_metrics.yml
+++ b/definitions/infra-host/golden_metrics.yml
@@ -55,7 +55,7 @@ networkTraffic:
       eventId: entityGuid
       eventName: entityName
     opentelemetry:
-      select: rate(average(system.network.io), 1 second)
+      select: rate(sum(system.network.io), 1 second)
       where: device != 'lo'
       from: Metric
       eventId: entity.guid


### PR DESCRIPTION
### Relevant information

The current golden metric definition for OTEL host network uses the wrong function. This PR fixes it.

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
