### PR TITLE
Revert "fix network golden metrics for otel hosts"

### DIFF
--- a/definitions/infra-host/golden_metrics.yml
+++ b/definitions/infra-host/golden_metrics.yml
@@ -55,7 +55,7 @@ networkTraffic:
       eventId: entityGuid
       eventName: entityName
     opentelemetry:
-      select: rate(sum(system.network.io), 1 second)
+      select: rate(average(system.network.io), 1 second)
       where: device != 'lo'
       from: Metric
       eventId: entity.guid


### PR DESCRIPTION
Reverts newrelic/entity-definitions#367 - the golden metric harvester is refusing this definition 😭 