### PR TITLE
Add entity synthesis for otel containers

### DIFF
--- a/definitions/infra-container/definition.yml
+++ b/definitions/infra-container/definition.yml
@@ -52,7 +52,7 @@ synthesis:
         entityTagName: k8s.namespaceName
   - identifier: container.id
     name: container.name
-    encodeIdentifierInGUID: false
+    encodeIdentifierInGUID: true
     # This is a temporary condition to restrict synthesis for a particular set of telemetry data.
     conditions:
       - attribute: nr.entity_type

--- a/definitions/infra-container/definition.yml
+++ b/definitions/infra-container/definition.yml
@@ -50,6 +50,21 @@ synthesis:
         entityTagName: k8s.clusterName
       k8s.namespace.name:
         entityTagName: k8s.namespaceName
+    - identifier: container.id
+      name: container.name
+      encodeIdentifierInGUID: false
+      # This is a temporary condition to restrict synthesis for a particular set of telemetry data.
+      conditions:
+        - attribute: nr.entity_type
+          value: container
+      tags:
+        container.runtime:
+        container.image.name:
+        container.image.tag:
+        host.type:
+        cloud.provider:
+        cloud.account.id:
+        cloud.region:
   tags:
     newrelic.integrationName:
     newrelic.integrationVersion:

--- a/definitions/infra-container/definition.yml
+++ b/definitions/infra-container/definition.yml
@@ -50,21 +50,21 @@ synthesis:
         entityTagName: k8s.clusterName
       k8s.namespace.name:
         entityTagName: k8s.namespaceName
-    - identifier: container.id
-      name: container.name
-      encodeIdentifierInGUID: false
-      # This is a temporary condition to restrict synthesis for a particular set of telemetry data.
-      conditions:
-        - attribute: nr.entity_type
-          value: container
-      tags:
-        container.runtime:
-        container.image.name:
-        container.image.tag:
-        host.type:
-        cloud.provider:
-        cloud.account.id:
-        cloud.region:
+  - identifier: container.id
+    name: container.name
+    encodeIdentifierInGUID: false
+    # This is a temporary condition to restrict synthesis for a particular set of telemetry data.
+    conditions:
+      - attribute: nr.entity_type
+        value: container
+    tags:
+      container.runtime:
+      container.image.name:
+      container.image.tag:
+      host.type:
+      cloud.provider:
+      cloud.account.id:
+      cloud.region:
   tags:
     newrelic.integrationName:
     newrelic.integrationVersion:


### PR DESCRIPTION
### Relevant information

This an attempt to synthesize containers monitored by the opentelemetry collector. The semantic conventions are described [here](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/container.md).

Note that this rule will only be applied when a specific attribute is sent (nr.entity_type). This is because I'm still testing it and I don't want to release it just yes.

Also note that I haven't defined golden metrics yet. This will come as a follow-up PR.

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
