### PR TITLE
Don't use k8s.containerId as a synthesis condition

### DIFF
--- a/definitions/infra-container/definition.yml
+++ b/definitions/infra-container/definition.yml
@@ -27,7 +27,7 @@ synthesis:
     name: k8s.containerName
     encodeIdentifierInGUID: false
     conditions:
-    - attribute: k8s.containerId
+    - attribute: k8s.containerName
     tags:
       k8s.status:
         entityTagName: container.state


### PR DESCRIPTION
### Relevant information

This attribute is not present in all the K8s containers (there are some circumstances where a container doesn't have an id yet), so we're missing some of them.
`k8s.containerName` is enough to identify a K8s container since this attribute is only present in container metrics, so there is no need to add any other extra attribute to the synthesis condition.
### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
