### PR TITLE
change alertable to false

### DIFF
--- a/definitions/ext-endpoint/definition.yml
+++ b/definitions/ext-endpoint/definition.yml
@@ -4,4 +4,4 @@ type: ENDPOINT
 
 configuration:
   entityExpirationTime: FOUR_HOURS
-  alertable: true
+  alertable: false

--- a/definitions/infra-awsalblistener/definition.yml
+++ b/definitions/infra-awsalblistener/definition.yml
@@ -2,4 +2,4 @@ domain: INFRA
 type: AWSALBLISTENER
 configuration:
   entityExpirationTime: DAILY
-  alertable: true
+  alertable: false

--- a/definitions/infra-awsalblistenerrule/definition.yml
+++ b/definitions/infra-awsalblistenerrule/definition.yml
@@ -2,4 +2,4 @@ domain: INFRA
 type: AWSALBLISTENERRULE
 configuration:
   entityExpirationTime: DAILY
-  alertable: true
+  alertable: false

--- a/definitions/infra-azureappservicehostname/definition.yml
+++ b/definitions/infra-azureappservicehostname/definition.yml
@@ -2,4 +2,4 @@ domain: INFRA
 type: AZUREAPPSERVICEHOSTNAME
 configuration:
   entityExpirationTime: DAILY
-  alertable: true
+  alertable: false

--- a/definitions/infra-azureloadbalancerbackend/definition.yml
+++ b/definitions/infra-azureloadbalancerbackend/definition.yml
@@ -2,4 +2,4 @@ domain: INFRA
 type: AZURELOADBALANCERBACKEND
 configuration:
   entityExpirationTime: DAILY
-  alertable: true
+  alertable: false

--- a/definitions/infra-azureloadbalancerfrontendip/definition.yml
+++ b/definitions/infra-azureloadbalancerfrontendip/definition.yml
@@ -2,4 +2,4 @@ domain: INFRA
 type: AZURELOADBALANCERFRONTENDIP
 configuration:
   entityExpirationTime: DAILY
-  alertable: true
+  alertable: false

--- a/definitions/infra-azureloadbalancerinboundnatpool/definition.yml
+++ b/definitions/infra-azureloadbalancerinboundnatpool/definition.yml
@@ -2,4 +2,4 @@ domain: INFRA
 type: AZURELOADBALANCERINBOUNDNATPOOL
 configuration:
   entityExpirationTime: DAILY
-  alertable: true
+  alertable: false

--- a/definitions/infra-azureloadbalancerinboundnatrule/definition.yml
+++ b/definitions/infra-azureloadbalancerinboundnatrule/definition.yml
@@ -2,4 +2,4 @@ domain: INFRA
 type: AZURELOADBALANCERINBOUNDNATRULE
 configuration:
   entityExpirationTime: DAILY
-  alertable: true
+  alertable: false

--- a/definitions/infra-azureloadbalancerprobe/definition.yml
+++ b/definitions/infra-azureloadbalancerprobe/definition.yml
@@ -2,4 +2,4 @@ domain: INFRA
 type: AZURELOADBALANCERPROBE
 configuration:
   entityExpirationTime: DAILY
-  alertable: true
+  alertable: false

--- a/definitions/infra-azureloadbalancerrule/definition.yml
+++ b/definitions/infra-azureloadbalancerrule/definition.yml
@@ -2,4 +2,4 @@ domain: INFRA
 type: AZURELOADBALANCERRULE
 configuration:
   entityExpirationTime: DAILY
-  alertable: true
+  alertable: false

--- a/definitions/infra-azuresqlfirewall/definition.yml
+++ b/definitions/infra-azuresqlfirewall/definition.yml
@@ -2,4 +2,4 @@ domain: INFRA
 type: AZURESQLFIREWALL
 configuration:
   entityExpirationTime: DAILY
-  alertable: true
+  alertable: false

--- a/definitions/infra-azuresqlreplicationlink/definition.yml
+++ b/definitions/infra-azuresqlreplicationlink/definition.yml
@@ -2,4 +2,4 @@ domain: INFRA
 type: AZURESQLREPLICATIONLINK
 configuration:
   entityExpirationTime: DAILY
-  alertable: true
+  alertable: false

--- a/definitions/infra-azuresqlrestorepoint/definition.yml
+++ b/definitions/infra-azuresqlrestorepoint/definition.yml
@@ -2,4 +2,4 @@ domain: INFRA
 type: AZURESQLRESTOREPOINT
 configuration:
   entityExpirationTime: DAILY
-  alertable: true
+  alertable: false

--- a/definitions/infra-azurevirtualnetworksipconfiguration/definition.yml
+++ b/definitions/infra-azurevirtualnetworksipconfiguration/definition.yml
@@ -2,4 +2,4 @@ domain: INFRA
 type: AZUREVIRTUALNETWORKSIPCONFIGURATION
 configuration:
   entityExpirationTime: DAILY
-  alertable: true
+  alertable: false

--- a/definitions/infra-azurevirtualnetworksnetworkinterface/definition.yml
+++ b/definitions/infra-azurevirtualnetworksnetworkinterface/definition.yml
@@ -2,4 +2,4 @@ domain: INFRA
 type: AZUREVIRTUALNETWORKSNETWORKINTERFACE
 configuration:
   entityExpirationTime: DAILY
-  alertable: true
+  alertable: false

--- a/definitions/infra-azurevirtualnetworkspeering/definition.yml
+++ b/definitions/infra-azurevirtualnetworkspeering/definition.yml
@@ -2,4 +2,4 @@ domain: INFRA
 type: AZUREVIRTUALNETWORKSPEERING
 configuration:
   entityExpirationTime: DAILY
-  alertable: true
+  alertable: false

--- a/definitions/infra-azurevirtualnetworksroute/definition.yml
+++ b/definitions/infra-azurevirtualnetworksroute/definition.yml
@@ -2,4 +2,4 @@ domain: INFRA
 type: AZUREVIRTUALNETWORKSROUTE
 configuration:
   entityExpirationTime: DAILY
-  alertable: true
+  alertable: false

--- a/definitions/infra-azurevirtualnetworksroutetable/definition.yml
+++ b/definitions/infra-azurevirtualnetworksroutetable/definition.yml
@@ -2,4 +2,4 @@ domain: INFRA
 type: AZUREVIRTUALNETWORKSROUTETABLE
 configuration:
   entityExpirationTime: DAILY
-  alertable: true
+  alertable: false

--- a/definitions/infra-azurevirtualnetworkssecuritygroup/definition.yml
+++ b/definitions/infra-azurevirtualnetworkssecuritygroup/definition.yml
@@ -2,4 +2,4 @@ domain: INFRA
 type: AZUREVIRTUALNETWORKSSECURITYGROUP
 configuration:
   entityExpirationTime: DAILY
-  alertable: true
+  alertable: false

--- a/definitions/infra-azurevirtualnetworkssecurityrule/definition.yml
+++ b/definitions/infra-azurevirtualnetworkssecurityrule/definition.yml
@@ -1,2 +1,4 @@
 domain: INFRA
 type: AZUREVIRTUALNETWORKSSECURITYRULE
+configuration:
+  alertable: false


### PR DESCRIPTION
### Relevant information

Changing `alertable` from `true` to `false` in EXT-ENDPOINT, which represents a network endpoint.
Changing `alertable` from `true` to `false` on Infra entities which should not have `health`.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
