### PR TITLE
chore: adding new metric name style to NRQL

### DIFF
--- a/definitions/ext-router/cisco-asr-dashboard.json
+++ b/definitions/ext-router/cisco-asr-dashboard.json
@@ -172,7 +172,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "FROM Metric SELECT latest(kentik.snmp.IfInUtilization) AS 'RX %', latest(kentik.snmp.IfOutUtilization) AS 'TX %', latest(ifOperStatus) AS 'Operational Status', sum(kentik.snmp.ifInErrors) AS 'RX Errors', sum(kentik.snmp.ifOutErrors) AS 'TX Errors' FACET if_name or if_interface_name AS 'Interface', if_Alias AS 'Interface Alias', if_Speed WHERE provider = 'kentik-router' LIMIT MAX"
+                "query": "FROM Metric SELECT latest(kentik.snmp.IfInUtilization) AS 'RX %', latest(kentik.snmp.IfOutUtilization) AS 'TX %', latest(ifOperStatus)  OR latest(if_OperStatus) AS 'Operational Status', sum(kentik.snmp.ifInErrors) AS 'RX Errors', sum(kentik.snmp.ifOutErrors) AS 'TX Errors' FACET if_name or if_interface_name AS 'Interface', if_Alias AS 'Interface Alias', if_Speed WHERE provider = 'kentik-router' LIMIT MAX"
               }
             ]
           }

--- a/definitions/ext-switch/arista-dashboard.json
+++ b/definitions/ext-switch/arista-dashboard.json
@@ -184,7 +184,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "FROM Metric SELECT latest(kentik.snmp.IfInUtilization) AS 'RX %', latest(kentik.snmp.IfOutUtilization) AS 'TX %', latest(ifOperStatus) AS 'Operational Status', sum(kentik.snmp.ifInErrors) AS 'RX Errors', sum(kentik.snmp.ifOutErrors) AS 'TX Errors' FACET if_name or if_interface_name AS 'Interface', if_Alias AS 'Interface Alias', if_Speed WHERE provider = 'kentik-switch' LIMIT MAX"
+                "query": "FROM Metric SELECT latest(kentik.snmp.IfInUtilization) AS 'RX %', latest(kentik.snmp.IfOutUtilization) AS 'TX %', latest(ifOperStatus) OR latest(if_OperStatus) AS 'Operational Status', sum(kentik.snmp.ifInErrors) AS 'RX Errors', sum(kentik.snmp.ifOutErrors) AS 'TX Errors' FACET if_name or if_interface_name AS 'Interface', if_Alias AS 'Interface Alias', if_Speed WHERE provider = 'kentik-switch' LIMIT MAX"
               }
             ]
           }

--- a/definitions/ext-switch/cisco-catalyst-dashboard.json
+++ b/definitions/ext-switch/cisco-catalyst-dashboard.json
@@ -166,7 +166,7 @@
               "nrqlQueries": [
                 {
                   "accountId": 0,
-                  "query": "FROM Metric SELECT latest(kentik.snmp.IfInUtilization) AS 'RX %', latest(kentik.snmp.IfOutUtilization) AS 'TX %', latest(ifOperStatus) AS 'Operational Status', sum(kentik.snmp.ifInErrors) AS 'RX Errors', sum(kentik.snmp.ifOutErrors) AS 'TX Errors' FACET if_name or if_interface_name AS 'Interface', if_Alias AS 'Interface Alias', if_Speed WHERE provider = 'kentik-switch' LIMIT MAX"
+                  "query": "FROM Metric SELECT latest(kentik.snmp.IfInUtilization) AS 'RX %', latest(kentik.snmp.IfOutUtilization) AS 'TX %', latest(ifOperStatus) OR latest(if_OperStatus) AS 'Operational Status', sum(kentik.snmp.ifInErrors) AS 'RX Errors', sum(kentik.snmp.ifOutErrors) AS 'TX Errors' FACET if_name or if_interface_name AS 'Interface', if_Alias AS 'Interface Alias', if_Speed WHERE provider = 'kentik-switch' LIMIT MAX"
                 }
               ]
             }

--- a/definitions/ext-switch/cisco-nexus-dashboard.json
+++ b/definitions/ext-switch/cisco-nexus-dashboard.json
@@ -166,7 +166,7 @@
               "nrqlQueries": [
                 {
                   "accountId": 0,
-                  "query": "FROM Metric SELECT latest(kentik.snmp.IfInUtilization) AS 'RX %', latest(kentik.snmp.IfOutUtilization) AS 'TX %', latest(ifOperStatus) AS 'Operational Status', sum(kentik.snmp.ifInErrors) AS 'RX Errors', sum(kentik.snmp.ifOutErrors) AS 'TX Errors' FACET if_name or if_interface_name AS 'Interface', if_Alias AS 'Interface Alias', if_Speed WHERE provider = 'kentik-switch' LIMIT MAX"
+                  "query": "FROM Metric SELECT latest(kentik.snmp.IfInUtilization) AS 'RX %', latest(kentik.snmp.IfOutUtilization) AS 'TX %', latest(ifOperStatus) OR latest(if_OperStatus) AS 'Operational Status', sum(kentik.snmp.ifInErrors) AS 'RX Errors', sum(kentik.snmp.ifOutErrors) AS 'TX Errors' FACET if_name or if_interface_name AS 'Interface', if_Alias AS 'Interface Alias', if_Speed WHERE provider = 'kentik-switch' LIMIT MAX"
                 }
               ]
             }

--- a/definitions/ext-switch/dell-force10-dashboard.json
+++ b/definitions/ext-switch/dell-force10-dashboard.json
@@ -166,7 +166,7 @@
               "nrqlQueries": [
                 {
                   "accountId": 0,
-                  "query": "FROM Metric SELECT latest(kentik.snmp.IfInUtilization) AS 'RX %', latest(kentik.snmp.IfOutUtilization) AS 'TX %', latest(ifOperStatus) AS 'Operational Status', sum(kentik.snmp.ifInErrors) AS 'RX Errors', sum(kentik.snmp.ifOutErrors) AS 'TX Errors' FACET if_name or if_interface_name AS 'Interface', if_Alias AS 'Interface Alias', if_Speed WHERE provider = 'kentik-switch' LIMIT MAX"
+                  "query": "FROM Metric SELECT latest(kentik.snmp.IfInUtilization) AS 'RX %', latest(kentik.snmp.IfOutUtilization) AS 'TX %', latest(ifOperStatus) OR latest(if_OperStatus) AS 'Operational Status', sum(kentik.snmp.ifInErrors) AS 'RX Errors', sum(kentik.snmp.ifOutErrors) AS 'TX Errors' FACET if_name or if_interface_name AS 'Interface', if_Alias AS 'Interface Alias', if_Speed WHERE provider = 'kentik-switch' LIMIT MAX"
                 }
               ]
             }


### PR DESCRIPTION
### Relevant information

Updating `ROUTER` and `SWITCH` entity dashboards to add a new metric name style to the NRQL as an `OR` option to support newer versions of NPM agent. 

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
