### PR TITLE
Update EXT-SERVICE summary metrics order and title case

### DIFF
--- a/definitions/ext-service/summary_metrics.yml
+++ b/definitions/ext-service/summary_metrics.yml
@@ -3,6 +3,27 @@ providerName:
     key: instrumentation.provider
   title: Provider
   unit: STRING
+responseTimeMs:
+  title: Response Time
+  unit: SECONDS
+  queries:
+    opentelemetry:
+      select: average(duration.ms) / 1000
+      from: Span
+      where: span.kind LIKE 'server' OR span.kind LIKE 'consumer' OR kind LIKE 'server' OR kind LIKE 'consumer'
+      eventId: entity.guid
+    kamon-agent:
+      select: average(http.server.requests) / 1000
+      from: Metric
+      eventId: entity.guid
+    micrometer:
+      select: average(http.server.requests) / 1000
+      from: Metric
+      eventId: entity.guid
+    pixie:
+      select: average(http.server.duration) / 1000
+      from: Metric
+      eventId: entity.guid
 throughput:
   title: Throughput
   unit: REQUESTS_PER_SECOND
@@ -25,7 +46,7 @@ throughput:
       from: Metric
       eventId: entity.guid
 errorRate:
-  title: Error rate
+  title: Error Rate
   unit: PERCENTAGE
   queries:
     opentelemetry:
@@ -42,26 +63,5 @@ errorRate:
       eventId: entity.guid
     pixie:
       select: filter(count(http.server.duration), where numeric(http.status_code) >= 400 AND numeric(http.status_code) != 404) / count(http.server.duration) * 100
-      from: Metric
-      eventId: entity.guid
-responseTimeMs:
-  title: Response time
-  unit: SECONDS
-  queries:
-    opentelemetry:
-      select: average(duration.ms) / 1000
-      from: Span
-      where: span.kind LIKE 'server' OR span.kind LIKE 'consumer' OR kind LIKE 'server' OR kind LIKE 'consumer'
-      eventId: entity.guid
-    kamon-agent:
-      select: average(http.server.requests) / 1000
-      from: Metric
-      eventId: entity.guid
-    micrometer:
-      select: average(http.server.requests) / 1000
-      from: Metric
-      eventId: entity.guid
-    pixie:
-      select: average(http.server.duration) / 1000
       from: Metric
       eventId: entity.guid


### PR DESCRIPTION
### Relevant information

Update all ext-service summary metric titles to title case and move response time to the first position.
![image](https://user-images.githubusercontent.com/200663/145448480-033cc9b3-a91a-4961-b871-83008e853b4a.png)


### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
