### PR TITLE
EXT-ROUTER: Update Mikrotik to read memory.load metric

### DIFF
--- a/definitions/ext-router/golden_metrics.yml
+++ b/definitions/ext-router/golden_metrics.yml
@@ -33,7 +33,7 @@ memoryUtilization:
       where: "provider = 'kentik-router'"
     # Mikrotik Router from mikrotik-newrelic script
     mikrotik-router:
-      select: average(mikrotik.system.memory.used)
+      select: average(mikrotik.system.memory.load)
       from: Metric
 
 receiveErrors:

--- a/definitions/ext-router/mikrotik-dashboard.json
+++ b/definitions/ext-router/mikrotik-dashboard.json
@@ -28,7 +28,7 @@
               },
               {
                 "accountId": 0,
-                "query": "SELECT (1 - (average(mikrotik.system.memory.free) / average(mikrotik.system.memory.total))) * 100 as '% RAM used' FROM Metric TIMESERIES"
+                "query": "SELECT average(mikrotik.system.memory.load) as '% RAM used' FROM Metric TIMESERIES"
               },
               {
                 "accountId": 0,

--- a/definitions/ext-router/summary_metrics.yml
+++ b/definitions/ext-router/summary_metrics.yml
@@ -44,7 +44,7 @@ memoryUtilization:
       eventId: entity.guid
     # Mikrotik Router from mikrotik-newrelic script
     mikrotik-router:
-      select: (1 - (average(mikrotik.system.memory.free) / average(mikrotik.system.memory.total))) * 100
+      select: average(mikrotik.system.memory.load)
       from: Metric
       eventId: entity.guid
 


### PR DESCRIPTION
### Relevant information

- The agent was updated time ago to report the memory utilization: https://github.com/OscarDCorbalan/mikrotik-newrelic/pull/6/files
- So it's no longer needed to calculate it derive it, in golden metrics and dashboard, from the reported used and total memory values.

👉  This PR updates those to directly read the memory load value


### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
