### PR TITLE
INFRA-HOST: add cpu gm for otel

### DIFF
--- a/definitions/infra-host/golden_metrics.yml
+++ b/definitions/infra-host/golden_metrics.yml
@@ -12,6 +12,12 @@ cpuUsage:
       from: SystemSample
       eventId: entityGuid
       eventName: entityName
+    opentelemetry:
+      select: average(1 - system.cpu.utilization)
+      where: state = 'idle'
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
 memoryUsage:
   title: Memory usage (%)
   unit: PERCENTAGE

--- a/definitions/infra-host/golden_metrics.yml
+++ b/definitions/infra-host/golden_metrics.yml
@@ -13,7 +13,7 @@ cpuUsage:
       eventId: entityGuid
       eventName: entityName
     opentelemetry:
-      select: average(1 - system.cpu.utilization)
+      select: average(1 - system.cpu.utilization) * 100
       where: state = 'idle'
       from: Metric
       eventId: entity.guid


### PR DESCRIPTION
### Relevant information

This is adding the cpu golden metric definition for hosts monitored by the opentelemetry collector.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
