### PR TITLE
fix: change otel golden error rate, use in summary metric

### DIFF
--- a/definitions/ext-service/golden_metrics.yml
+++ b/definitions/ext-service/golden_metrics.yml
@@ -18,8 +18,9 @@ errorRate:
   title: Error rate (%)
   queries:
     opentelemetry:
-      select: (filter(count(*), where error.message IS NOT NULL) * 100) / count(*)
+      select: (filter(count(*), WHERE otel.status_code = 'ERROR') * 100) / count(*)
       from: Span
+      where: span.kind IN ('server', 'consumer') OR kind IN ('server', 'consumer')
     kamon-agent:
       select: (filter(sum(http.server.requests), where http.status_code = '5xx') * 100) / sum(http.server.requests)
       from: Metric

--- a/definitions/ext-service/summary_metrics.yml
+++ b/definitions/ext-service/summary_metrics.yml
@@ -50,8 +50,8 @@ errorRate:
   unit: PERCENTAGE
   queries:
     opentelemetry:
-      select: filter(count(*), where error.message IS NOT NULL) / count(*) * 100
-      from: Span
+      select: average(newrelic.goldenmetrics.ext.service.errorRate)
+      from: Metric
       eventId: entity.guid
     kamon-agent:
       select: filter(sum(http.server.requests), where http.status_code = '5xx') / sum(http.server.requests) * 100


### PR DESCRIPTION
### Relevant information

This PR fixes error rates for Otel services. Currently, all Otel services have a summary metric value of 0% for error rate, because Otel services don't have an error metric. This PR updates the golden metric to use span data for error rates, and then uses the golden metric as the summary metric for error rates.

### Checklist

* [X] I've read the guidelines and understand the acceptance criteria.
* [X] The value of the attribute marked as `identifier` will be unique and valid. 
* [X] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
