### PR TITLE
Add Infra IBMMQ_MANAGER entity

### DIFF
--- a/definitions/infra-ibmmq_manager/definition.yml
+++ b/definitions/infra-ibmmq_manager/definition.yml
@@ -1,0 +1,16 @@
+domain: INFRA
+type: IBMMQ_MANAGER
+
+synthesis:
+  rules:
+    - identifier: targetName
+      name: targetName
+      conditions:
+        - attribute: metricName
+          prefix: ibmmq_
+      tags:
+        clusterName:
+
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-ibmmq_manager/golden_metrics.yml
+++ b/definitions/infra-ibmmq_manager/golden_metrics.yml
@@ -1,0 +1,26 @@
+connections_count:
+  title: Connections.
+  unit: COUNT
+  query:
+    select: latest(ibmmq_qmgr_connection_count) AS 'Connections'
+
+queue_uncommitted_messages:
+  title: Uncommitted messages.
+  unit: COUNT
+  query:
+    select: latest(ibmmq_queue_uncommitted_messages) AS 'Uncommitted messages'
+    facet: queue
+
+queue_input_handles:
+  title: Queue input.
+  unit: COUNT
+  query:
+    select: latest(ibmmq_queue_input_handles) AS 'Queue input'
+    facet: queue
+
+queue_output_handles:
+  title: Queue output.
+  unit: COUNT
+  query:
+    select: latest(ibmmq_queue_output_handles) AS 'Queue output'
+    facet: queue

--- a/definitions/infra-ibmmq_manager/summary_metrics.yml
+++ b/definitions/infra-ibmmq_manager/summary_metrics.yml
@@ -1,0 +1,31 @@
+connections_count:
+  title: Connections
+  unit: COUNT
+  query:
+    select: latest(ibmmq_qmgr_connection_count) AS 'Connections'
+    from: Metric
+    eventId: entity.guid
+
+queue_uncommitted_messages:
+  title: Uncommitted messages average.
+  unit: COUNT
+  query:
+    select: average(ibmmq_queue_uncommitted_messages) AS 'Uncommitted messages'
+    from: Metric
+    eventId: entity.guid
+
+queue_input_handles:
+  title: Queue input average.
+  unit: COUNT
+  query:
+    select: average(ibmmq_queue_input_handles) AS 'Queue input'
+    from: Metric
+    eventId: entity.guid
+
+queue_output_handles:
+  title: Queue output average.
+  unit: COUNT
+  query:
+    select: average(ibmmq_queue_output_handles) AS 'Queue output'
+    from: Metric
+    eventId: entity.guid

--- a/definitions/infra-powerdns_authoritative/definition.yml
+++ b/definitions/infra-powerdns_authoritative/definition.yml
@@ -9,7 +9,6 @@ synthesis:
       prefix: powerdns_authoritative_
   tags:
     clusterName:
-    targetName:
 
 dashboardTemplates:
   newRelic:

--- a/definitions/infra-powerdns_recursor/definition.yml
+++ b/definitions/infra-powerdns_recursor/definition.yml
@@ -9,7 +9,6 @@ synthesis:
       prefix: powerdns_recursor_
   tags:
     clusterName:
-    targetName:
 
 dashboardTemplates:
   newRelic:

--- a/docs/synthesis.md
+++ b/docs/synthesis.md
@@ -29,7 +29,7 @@ synthesis:
   rules:
   - identifier: hostname
     name: hostname
-  	conditions:
+    conditions:
     - attribute: aws.az
 ```
 
@@ -39,7 +39,7 @@ synthesis:
   rules:
   - identifier: hostname
     name: hostname
-  	conditions:
+    conditions:
     - attribute: aws.az
       value: "us-west-1"
 ```
@@ -50,7 +50,7 @@ synthesis:
   rules:
   - identifier: hostname
     name: hostname
-  	conditions:
+    conditions:
     - prefix: us-
 ```
 


### PR DESCRIPTION
### Relevant information
The Core Integrations team is working on the IBMMQ integration based on prometheus exporters, and this PR adds the IBMMQ_MANAGER entity.

[This](https://onenr.io/0nVjYkXgKw0) is a metric example that we are currently ingesting. 

This entities can be either synthesized with the Prometheus Open Metrics integration using the rules specified in the `definitions.yaml` file, or by the Infra Agent (register endpoint of infra pipeline) when the integration is running as an on-host integration. 

**Duplication entity note**:
There are already 2 entities `ext-ibmmqmanager` and `ext-ibmmqqueue` that are used to create entities from an existing integration which will be deprecated with the new supported one. 
I try to combine both entities but `instrumentation.provider` is `newRelic` for both of them because so there is no possibility to separate dashboards and queries (which are based on different metrics)

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
