### PR TITLE
Split the host network traffic into rx and tx

### DIFF
--- a/definitions/infra-host/golden_metrics.yml
+++ b/definitions/infra-host/golden_metrics.yml
@@ -46,23 +46,45 @@ storageUsage:
       from: StorageSample
       eventId: entityGuid
       eventName: entityName
-networkTraffic:
-  title: Network Traffic (B/s)
+networkTransmitTraffic:
+  title: Network Transmit Traffic (B/s)
   unit: BYTES_PER_SECOND
   queries:
     newRelic:
-      select: average(host.net.transmitBytesPerSecond) + average(host.net.receiveBytesPerSecond)
+      select: average(host.net.transmitBytesPerSecond)
       from: Metric
       eventId: entity.guid
       eventName: entity.name
     newRelicSample:
-      select: average(transmitBytesPerSecond) + average(receiveBytesPerSecond)
+      select: average(transmitBytesPerSecond)
       from: NetworkSample
       eventId: entityGuid
       eventName: entityName
     opentelemetry:
-      select: rate(average(system.network.io), 1 second)
-      where: device != 'lo'
+      # emulate a rate of 1 second in order to get bytes/second
+      select: sum(system.network.io / ((endTimestamp - timestamp) / 1000))
+      where: device != 'lo' AND direction='transmit'
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+networkReceiveTraffic:
+  title: Network Receive Traffic (B/s)
+  unit: BYTES_PER_SECOND
+  queries:
+    newRelic:
+      select: average(host.net.receiveBytesPerSecond)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    newRelicSample:
+      select: average(receiveBytesPerSecond)
+      from: NetworkSample
+      eventId: entityGuid
+      eventName: entityName
+    opentelemetry:
+      # emulate a rate of 1 second in order to get bytes/second
+      select: sum(system.network.io / ((endTimestamp - timestamp) / 1000))
+      where: device != 'lo' AND direction='receive'
       from: Metric
       eventId: entity.guid
       eventName: entity.name


### PR DESCRIPTION
Since summing two different dimensional metrics is not supported,
the network traffic metric is split into the tx and rx components.

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
