### PR TITLE
Remove opentelemetry host network gm

### DIFF
--- a/definitions/infra-host/golden_metrics.yml
+++ b/definitions/infra-host/golden_metrics.yml
@@ -46,7 +46,7 @@ storageUsage:
       from: StorageSample
       eventId: entityGuid
       eventName: entityName
-networkTransmitTraffic:
+networkTrafficTx:
   title: Network Transmit Traffic (B/s)
   unit: BYTES_PER_SECOND
   queries:
@@ -60,14 +60,7 @@ networkTransmitTraffic:
       from: NetworkSample
       eventId: entityGuid
       eventName: entityName
-    opentelemetry:
-      # emulate a rate of 1 second in order to get bytes/second
-      select: sum(system.network.io / ((endTimestamp - timestamp) / 1000))
-      where: device != 'lo' AND direction='transmit'
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-networkReceiveTraffic:
+networkTrafficRx:
   title: Network Receive Traffic (B/s)
   unit: BYTES_PER_SECOND
   queries:
@@ -81,10 +74,3 @@ networkReceiveTraffic:
       from: NetworkSample
       eventId: entityGuid
       eventName: entityName
-    opentelemetry:
-      # emulate a rate of 1 second in order to get bytes/second
-      select: sum(system.network.io / ((endTimestamp - timestamp) / 1000))
-      where: device != 'lo' AND direction='receive'
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name


### PR DESCRIPTION
### Relevant information

The OTEL definition broke the golden metric harvester - removing it

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
