### PR TITLE
Add legacy features & apply to infra-containers

### DIFF
--- a/definitions/infra-container/definition.yml
+++ b/definitions/infra-container/definition.yml
@@ -23,6 +23,9 @@ synthesis:
       docker.ecsTaskArn:
       docker.ecsTaskDefinitionFamily:
       docker.ecsTaskDefinitionVersion:
+    legacyFeatures:
+      overrideGuidType: true
+
   - identifier: entity.id
     name: k8s.containerName
     encodeIdentifierInGUID: false
@@ -50,6 +53,9 @@ synthesis:
         entityTagName: k8s.clusterName
       k8s.namespace.name:
         entityTagName: k8s.namespaceName
+    legacyFeatures:
+      overrideGuidType: true
+
   - identifier: container.id
     name: container.name
     encodeIdentifierInGUID: true

--- a/validator/schemas/entity-schema-v1.json
+++ b/validator/schemas/entity-schema-v1.json
@@ -18,7 +18,10 @@
           "attribute": "attributeName",
           "prefix": "value"
         }
-      ]
+      ],
+      "legacyFeatures": {
+        "overrideGuidType": true
+      }
     }
   }],
   "required": [
@@ -195,6 +198,21 @@
                     }
                   }
                 }]
+              },
+              "legacyFeatures": {
+                "$id": "#/synthesis/rules/items/legacyFeatures",
+                "type": "object",
+                "title": "Legacy features",
+                "description": "Configure legacy features for the current rule",
+                "properties": {
+                  "overrideGuidType": {
+                    "$id": "#/synthesis/rules/items/legacyFeatures/overrideGuidType",
+                    "type": "boolean",
+                    "default": false,
+                    "title": "Override GUID type",
+                    "description": "Enables the override of the type in the GUID"
+                  }
+                }
               }
             },
             "additionalProperties": false


### PR DESCRIPTION
### Relevant information

Allow to configure the use of the entityType override as a legacy feature.
This will allow existing types to still use the NA type in the guid while allowing new rules to use the actual type.

Add the configuration into the INFRA-CONTAINER entity type rules that come from the old system.

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
