### PR TITLE
Add ext sap rfcdest

### DIFF
--- a/definitions/ext-sap_rfcdest/dashboard.json
+++ b/definitions/ext-sap_rfcdest/dashboard.json
@@ -1,0 +1,116 @@
+{
+  "name": "E-RFCDEST",
+  "description": null,
+  "pages": [
+    {
+      "name": "RFC",
+      "description": null,
+      "widgets": [
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "height": 3,
+            "width": 6
+          },
+          "title": "Trend - Avg Call Time (seconds)",
+          "rawConfiguration": {
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(duration.ms)/1000 as 'Call Time' FROM Span SINCE 1 day ago TIMESERIES Auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 7,
+            "row": 1,
+            "height": 3,
+            "width": 6
+          },
+          "title": "No. of RFC Calls",
+          "rawConfiguration": {
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT count(*) FROM Span SINCE 1 day ago TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "height": 3,
+            "width": 6
+          },
+          "title": "Trend - Data Sent (KB)",
+          "rawConfiguration": {
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`DATA_SEND(b)`) /1000 as 'Data Sent' FROM Span SINCE 1 day ago TIMESERIES Auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 7,
+            "row": 4,
+            "height": 3,
+            "width": 6
+          },
+          "title": "Trend - Data Received (KB)",
+          "rawConfiguration": {
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`DATA_RECEIVE(b)`)/1000 as 'Data Received' FROM Span SINCE 1 day ago TIMESERIES Auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/definitions/ext-sap_rfcdest/definition.yml
+++ b/definitions/ext-sap_rfcdest/definition.yml
@@ -1,0 +1,31 @@
+domain: EXT
+type: SAP_RFCDEST
+goldenTags:
+  - instrumentation.provider
+  - sap.functional_area
+  - sap.system
+  
+synthesis:
+  rules:
+    # Telemetry from New Relic SAP integration
+    # DESTINATION_ID in SYS_ID/DESTINATION format
+  - identifier: SAP_EID
+    name: DESTINATION
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: SAP_ETYPE
+      value: RFCDEST
+    tags:
+      sap.functional_area:
+      SYS_ID:
+        entityTagName: sap.system
+      HOST_NAME:
+        entityTagName: host
+      
+dashboardTemplates:
+  SAP:
+    template: dashboard.json
+
+configuration:
+  entityExpirationTime: EIGHT_DAYS
+  alertable: true

--- a/definitions/ext-sap_rfcdest/definition.yml
+++ b/definitions/ext-sap_rfcdest/definition.yml
@@ -4,7 +4,7 @@ goldenTags:
   - instrumentation.provider
   - sap.functional_area
   - sap.system
-  
+
 synthesis:
   rules:
     # Telemetry from New Relic SAP integration
@@ -19,9 +19,7 @@ synthesis:
       sap.functional_area:
       SYS_ID:
         entityTagName: sap.system
-      HOST_NAME:
-        entityTagName: host
-      
+
 dashboardTemplates:
   SAP:
     template: dashboard.json

--- a/definitions/ext-sap_rfcdest/golden_metrics.yml
+++ b/definitions/ext-sap_rfcdest/golden_metrics.yml
@@ -1,0 +1,15 @@
+avgCallTime:
+  title: Avg Call Time
+  unit: SECONDS
+  query:
+    select: average(duration.ms)/1000
+    from: Span
+    eventId: entity.guid
+
+callCount:
+  title: No. of RFC Calls
+  unit: COUNT
+  query:
+    select: count(*)
+    from: Span
+    eventId: entity.guid

--- a/definitions/ext-sap_rfcdest/summary_metrics.yml
+++ b/definitions/ext-sap_rfcdest/summary_metrics.yml
@@ -1,0 +1,15 @@
+avgCallTime:
+  title: Avg Call Time
+  unit: SECONDS
+  query:
+    select: average(duration.ms)/1000
+    from: Span
+    eventId: entity.guid
+
+callCount:
+  title: No. of RFC Calls
+  unit: COUNT
+  query:
+    select: count(*)
+    from: Span
+    eventId: entity.guid


### PR DESCRIPTION
### Relevant information

Add definition files for new entity type ext-sap_rfcdest. This entity type is used to monitor RFC destinations in SAP system.
RFC destination are used by SAP to connect to remote systems. Note: It has a few more tags defined than the document shared during discussion last week.

### Checklist

* [x ] I've read the guidelines and understand the acceptance criteria.
* [x ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
