### PR TITLE
Add entity definition file for new entity type ext-sap_qrfc.

### DIFF
--- a/definitions/ext-sap_qrfc/dashboard.json
+++ b/definitions/ext-sap_qrfc/dashboard.json
@@ -1,0 +1,125 @@
+{
+  "name": "E-QRFC",
+  "description": null,
+  "pages": [
+    {
+      "name": "RFC",
+      "description": null,
+      "widgets": [
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "height": 3,
+            "width": 6
+          },
+          "title": "Queue Entries Count",
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT average(NR.SAP.RFC.QRFC) as `Entry Count` WHERE KEY_FIGURE = 'ENTRYCOUNT' SINCE 1 day ago TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 7,
+            "row": 1,
+            "height": 3,
+            "width": 6
+          },
+          "title": "No. of Queues in Error",
+          "rawConfiguration": {
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT average(NR.SAP.RFC.QRFC) WHERE KEY_FIGURE = 'QUEUECOUNT' AND STATUS = 'TOTAL' SINCE 1 day ago TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "height": 3,
+            "width": 6
+          },
+          "title": "Oldest Age in Errored Queues  (days)",
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT average(NR.SAP.RFC.QRFC) /8640000 WHERE KEY_FIGURE = 'AGE' SINCE 1 day ago FACET cases(WHERE STATUS = 'TOTAL' AS 'Queues in Error', WHERE STATUS IS NULL AS 'ALL') TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 7,
+            "row": 4,
+            "height": 3,
+            "width": 6
+          },
+          "title": "Oldest Age of All Selected Queues (days)",
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT average(NR.SAP.RFC.QRFC) / 8640000 as `Entries Age` WHERE KEY_FIGURE = 'AGE' SINCE 1 day ago TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/definitions/ext-sap_qrfc/definition.yml
+++ b/definitions/ext-sap_qrfc/definition.yml
@@ -1,0 +1,29 @@
+domain: EXT
+type: SAP_QRFC
+goldenTags:
+  - instrumentation.provider
+  - sap.functional_area
+  - sap.system
+
+synthesis:
+  rules:
+    # Telemetry from New Relic SAP integration
+    # SAP_EID in SYS_ID/QNAME format
+  - identifier: SAP_EID
+    name: QUEUES
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: SAP_ETYPE
+      value: QRFC
+    tags:
+      sap.functional_area:
+      SYS_ID:
+        entityTagName: sap.system
+
+dashboardTemplates:
+  SAP:
+    template: dashboard.json
+
+configuration:
+  entityExpirationTime: EIGHT_DAYS
+  alertable: true

--- a/definitions/ext-sap_qrfc/golden_metrics.yml
+++ b/definitions/ext-sap_qrfc/golden_metrics.yml
@@ -1,0 +1,17 @@
+totalEntries:
+  title: Total Entries
+  unit: COUNT
+  query:
+    select: average(NR.SAP.RFC.QRFC)
+    from: Metric
+    where: KEY_FIGURE = 'ENTRYCOUNT' and STATUS is null
+    eventId: entity.guid
+
+errorQueueCount:
+  title: Errored Queue Count
+  unit: COUNT
+  query:
+    select: average(NR.SAP.RFC.QRFC)
+    from: Metric
+    where: KEY_FIGURE = 'QUEUECOUNT' and STATUS = 'TOTAL'
+    eventId: entity.guid

--- a/definitions/ext-sap_qrfc/summary_metrics.yml
+++ b/definitions/ext-sap_qrfc/summary_metrics.yml
@@ -1,0 +1,17 @@
+totalEntries:
+  title: Total Entries
+  unit: COUNT
+  query:
+    select: average(NR.SAP.RFC.QRFC)
+    from: Metric
+    where: KEY_FIGURE = 'ENTRYCOUNT' and STATUS is null
+    eventId: entity.guid
+
+errorQueueCount:
+  title: Errored Queue Count
+  unit: COUNT
+  query:
+    select: average(NR.SAP.RFC.QRFC)
+    from: Metric
+    where: KEY_FIGURE = 'QUEUECOUNT' and STATUS = 'TOTAL'
+    eventId: entity.guid


### PR DESCRIPTION
### Relevant information

Add definition files for new entity type ext-sap_qrfc. This entity type is used to monitor the RFC Queue status.

### Checklist

* [x ] I've read the guidelines and understand the acceptance criteria.
* [x ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
