### PR TITLE
Add where clause for sap entity golden metrics.

### DIFF
--- a/definitions/ext-sap_httpdest/golden_metrics.yml
+++ b/definitions/ext-sap_httpdest/golden_metrics.yml
@@ -1,0 +1,17 @@
+avgCallTime:
+  title: Avg Call Time
+  unit: SECONDS
+  query:
+    select: average(duration.ms)/1000
+    from: Span
+    where: instrumentation.provider = 'SAP' and SAP_ETYPE = 'HTTPDEST'
+    eventId: entity.guid
+
+callCount:
+  title: No. of Http Calls
+  unit: COUNT
+  query:
+    select: count(*)
+    from: Span
+    where: instrumentation.provider = 'SAP' and SAP_ETYPE = 'HTTPDEST'
+    eventId: entity.guid

--- a/definitions/ext-sap_rfcdest/golden_metrics.yml
+++ b/definitions/ext-sap_rfcdest/golden_metrics.yml
@@ -1,0 +1,17 @@
+avgCallTime:
+  title: Avg Call Time
+  unit: SECONDS
+  query:
+    select: average(duration.ms)/1000
+    from: Span
+    where: instrumentation.provider = 'SAP' and SAP_ETYPE = 'RFCDEST'
+    eventId: entity.guid
+
+callCount:
+  title: No. of RFC Calls
+  unit: COUNT
+  query:
+    select: count(*)
+    from: Span
+    where: instrumentation.provider = 'SAP' and SAP_ETYPE = 'RFCDEST'
+    eventId: entity.guid

--- a/definitions/ext-sap_transaction/golden_metrics.yml
+++ b/definitions/ext-sap_transaction/golden_metrics.yml
@@ -1,0 +1,17 @@
+avgResponseTime:
+  title: Avg Response Time
+  unit: SECONDS
+  query:
+    select: average(duration.ms) / 1000
+    from: Span
+    where: instrumentation.provider = 'SAP' and SAP_ETYPE = 'TRANSACTION'
+    eventId: entity.guid
+
+numOfCalls:
+  title: No. of Calls 
+  unit: COUNT
+  query:
+    select: count(*)
+    from: Span
+    where: instrumentation.provider = 'SAP' and SAP_ETYPE = 'TRANSACTION'
+    eventId: entity.guid


### PR DESCRIPTION
It was reported that entities in Span table cause system load up as the system to scan through too many records.

Solution: Limit the number of records the system will look at.
Modify golden metrics for ext-sap_httpdest, ext-sap_rfcdest, ext-sap_transaction, add where clause for contion instrumentation.provider = 'SAP' and SAP_ETYPE = intended SAP ETYPE.

### Relevant information

Describe what you have done and any details that you think are relevant or that you might want to discuss with us. 

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
