### PR TITLE
Add K8s tags to ext service opentelemetry entities

### DIFF
--- a/definitions/ext-service/definition.yml
+++ b/definitions/ext-service/definition.yml
@@ -54,6 +54,9 @@ synthesis:
     - attribute: instrumentation.provider
       value: opentelemetry
     tags:
+      k8s.cluster.name:
+      k8s.deployment.name:
+      k8s.namespace.name:
       telemetry.sdk.language:
         entityTagName: language
       telemetry.sdk.version:


### PR DESCRIPTION
### Relevant information

This PR pulls Kubernetes metadata on telemetry from "OpenTelemetry-flavored" service entities and maps it as tags. These tags are useful for filtering in NR1 as well as powering future curated experiences.

While this function could be useful for all types of providers, I chose to scope it for now only to those with a provider value of `opentelemetry` so we can validate its value before applying it widely. Also note that the `pixie` entities already have something similar except their tags map the OTel semantic casing to the New Relic casing -- this aligns with the existing NR Infra instrumentation but is something we're looking to eventually change.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
