### PR TITLE
Update ext-sap_instance definition file to fix a typo. Change conditi…

### DIFF
--- a/definitions/ext-sap_instance/definition.yml
+++ b/definitions/ext-sap_instance/definition.yml
@@ -12,7 +12,7 @@ synthesis:
     name: INSTANCE
     encodeIdentifierInGUID: true
     conditions:
-    - attribute: SAP.ETYPE
+    - attribute: SAP_ETYPE
       value: INSTANCE
     tags:
       sap.functional_area:


### PR DESCRIPTION
Change condition from SAP.ETYPE to SAP_ETYPE.

### Relevant information

There was a type in the ext-sap_instance definition file. The synthesize condition should be SAP_ETYPE attribute present and equals to INSTANCE, not SAP.ETYPE.

### Checklist

* [ x] I've read the guidelines and understand the acceptance criteria.
* [x ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
