### PR TITLE
chore: adding new vendor to env sensor entity type

### DIFF
--- a/definitions/ext-environment_sensor/definition.yml
+++ b/definitions/ext-environment_sensor/definition.yml
@@ -1,21 +1,37 @@
 domain: EXT
 type: ENVIRONMENT_SENSOR
 synthesis:
+  rules:
   # APC Netbotz devices
-  name: device_name
-  identifier: device_name
-  encodeIdentifierInGUID: true
-  conditions:
-  - attribute: provider
-    value: kentik-netbotz
-  tags:
-    src_addr:
-      entityTagName: device_ip
-      multiValue: false
+  - identifier: device_name
+    name: device_name
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: provider
+      value: kentik-netbotz
+    tags:
+      src_addr:
+        entityTagName: device_ip
+        multiValue: false
+  # Vertiv Watchdog devices
+  - identifier: device_name
+    name: device_name
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: provider
+      value: kentik-watchdog
+    tags:
+      src_addr:
+        entityTagName: device_ip
+        multiValue: false
     
 goldenTags:
 - device_ip
 
 dashboardTemplates:
+  # APC Netbotz devices (default)
   kentik/apc-netbotz:
     template: kentik-apc-netbotz-dashboard.json
+  # Vertiv Watchdog devices
+  kentik/watchdog:
+    template: vertiv-watchdog-dashboard.json

--- a/definitions/ext-environment_sensor/summary_metrics.yml
+++ b/definitions/ext-environment_sensor/summary_metrics.yml
@@ -7,8 +7,16 @@ ipAddress:
 uptime:
   title: Uptime
   unit: SECONDS
-  query:
-    select: latest(kentik.snmp.Uptime)/100
-    from: Metric
-    where: "provider = 'kentik-netbotz'"
-    eventId: entity.guid
+  queries:
+    # APC Netbotz devices (default)
+    kentik/apc-netbotz:
+      select: latest(kentik.snmp.Uptime)/100
+      from: Metric
+      where: "provider = 'kentik-netbotz'"
+      eventId: entity.guid
+    # Vertiv Watchdog devices
+    kentik/watchdog:
+      select: latest(kentik.snmp.Uptime)/100
+      from: Metric
+      where: "provider = 'kentik-watchdog'"
+      eventId: entity.guid

--- a/definitions/ext-environment_sensor/vertiv-watchdog-dashboard.json
+++ b/definitions/ext-environment_sensor/vertiv-watchdog-dashboard.json
@@ -1,0 +1,258 @@
+{
+    "name": "Vertiv Watchdog",
+    "description": null,
+    "pages": [
+      {
+        "name": "Vertiv Watchdog",
+        "description": null,
+        "widgets": [
+          {
+            "visualization": {
+              "id": "viz.billboard"
+            },
+            "layout": {
+              "column": 1,
+              "row": 1,
+              "height": 5,
+              "width": 3
+            },
+            "title": "",
+            "rawConfiguration": {
+              "dataFormatters": [
+                {
+                  "name": "Uptime (Days)",
+                  "precision": 1,
+                  "type": "decimal"
+                }
+              ],
+              "nrqlQueries": [
+                {
+                  "accountId": 0,
+                  "query": "FROM Metric SELECT latest(device_name) AS 'Device Name', latest(src_addr) AS 'Device IP', latest(SysObjectID) AS 'SysObjectID', latest(entity.type) AS 'NR Entity Type', latest(instrumentation.name) AS 'Ktranslate Profile', latest(timestamp) AS 'Last Update', latest(kentik.snmp.Uptime)/8640000 AS 'Uptime (Days)' WHERE provider = 'kentik-watchdog'"
+                }
+              ],
+              "thresholds": []
+            }
+          },
+          {
+            "visualization": {
+              "id": "viz.billboard"
+            },
+            "layout": {
+              "column": 4,
+              "row": 1,
+              "height": 1,
+              "width": 4
+            },
+            "title": "Internal Temperature (F)",
+            "rawConfiguration": {
+              "dataFormatters": [
+                {
+                  "name": "Internal Temperature (F)",
+                  "precision": 1,
+                  "type": "decimal"
+                }
+              ],
+              "facet": {
+                "showOtherSeries": false
+              },
+              "nrqlQueries": [
+                {
+                  "accountId": 0,
+                  "query": "FROM Metric SELECT latest(kentik.snmp.internalTemp)/10 AS 'Internal Temperature (F)' WHERE provider = 'kentik-watchdog'"
+                }
+              ],
+              "thresholds": [
+                {
+                  "alertSeverity": "WARNING",
+                  "value": 80
+                },
+                {
+                  "alertSeverity": "CRITICAL",
+                  "value": 85
+                }
+              ]
+            }
+          },
+          {
+            "visualization": {
+              "id": "viz.billboard"
+            },
+            "layout": {
+              "column": 8,
+              "row": 1,
+              "height": 1,
+              "width": 4
+            },
+            "title": "Temp Sensor Temperature (F)",
+            "rawConfiguration": {
+              "dataFormatters": [
+                {
+                  "name": "Temp Sensor Temperature (F)",
+                  "precision": 1,
+                  "type": "decimal"
+                }
+              ],
+              "facet": {
+                "showOtherSeries": false
+              },
+              "nrqlQueries": [
+                {
+                  "accountId": 0,
+                  "query": "FROM Metric SELECT latest(kentik.snmp.tempSensorTemp)/10 AS 'Temp Sensor Temperature (F)' WHERE provider = 'kentik-watchdog'"
+                }
+              ],
+              "thresholds": [
+                {
+                  "alertSeverity": "WARNING",
+                  "value": 80
+                },
+                {
+                  "alertSeverity": "CRITICAL",
+                  "value": 85
+                }
+              ]
+            }
+          },
+          {
+            "visualization": {
+              "id": "viz.line"
+            },
+            "layout": {
+              "column": 4,
+              "row": 2,
+              "height": 4,
+              "width": 4
+            },
+            "title": "Internal Temperature (F)",
+            "rawConfiguration": {
+              "facet": {
+                "showOtherSeries": false
+              },
+              "legend": {
+                "enabled": true
+              },
+              "nrqlQueries": [
+                {
+                  "accountId": 0,
+                  "query": "FROM Metric SELECT max(kentik.snmp.internalTemp)/10 FACET device_name WHERE provider = 'kentik-watchdog' TIMESERIES "
+                }
+              ],
+              "yAxisLeft": {
+                "zero": true
+              }
+            }
+          },
+          {
+            "visualization": {
+              "id": "viz.line"
+            },
+            "layout": {
+              "column": 8,
+              "row": 2,
+              "height": 4,
+              "width": 4
+            },
+            "title": "Temp Sensor Temperature (F)",
+            "rawConfiguration": {
+              "facet": {
+                "showOtherSeries": false
+              },
+              "legend": {
+                "enabled": true
+              },
+              "nrqlQueries": [
+                {
+                  "accountId": 0,
+                  "query": "FROM Metric SELECT max(kentik.snmp.tempSensorTemp)/10 FACET device_name, tempSensorName WHERE provider = 'kentik-watchdog' TIMESERIES "
+                }
+              ],
+              "yAxisLeft": {
+                "zero": true
+              }
+            }
+          },
+          {
+            "visualization": {
+              "id": "viz.billboard"
+            },
+            "layout": {
+              "column": 1,
+              "row": 6,
+              "height": 3,
+              "width": 3
+            },
+            "title": "",
+            "rawConfiguration": {
+              "dataFormatters": [],
+              "nrqlQueries": [
+                {
+                  "accountId": 0,
+                  "query": "FROM Metric SELECT latest(productFriendlyName), latest(internalSerial), latest(productVersion), latest(productMacAddress) WHERE provider = 'kentik-watchdog'"
+                }
+              ],
+              "thresholds": []
+            }
+          },
+          {
+            "visualization": {
+              "id": "viz.line"
+            },
+            "layout": {
+              "column": 4,
+              "row": 6,
+              "height": 3,
+              "width": 4
+            },
+            "title": "Internal Humidity",
+            "rawConfiguration": {
+              "facet": {
+                "showOtherSeries": false
+              },
+              "legend": {
+                "enabled": true
+              },
+              "nrqlQueries": [
+                {
+                  "accountId": 0,
+                  "query": "FROM Metric SELECT max(kentik.snmp.internalHumidity) FACET device_name WHERE provider = 'kentik-watchdog' TIMESERIES "
+                }
+              ],
+              "yAxisLeft": {
+                "zero": true
+              }
+            }
+          },
+          {
+            "visualization": {
+              "id": "viz.line"
+            },
+            "layout": {
+              "column": 8,
+              "row": 6,
+              "height": 3,
+              "width": 4
+            },
+            "title": "Internal Dew Point",
+            "rawConfiguration": {
+              "facet": {
+                "showOtherSeries": false
+              },
+              "legend": {
+                "enabled": true
+              },
+              "nrqlQueries": [
+                {
+                  "accountId": 0,
+                  "query": "FROM Metric SELECT max(kentik.snmp.internalDewPoint) FACET device_name WHERE provider = 'kentik-watchdog' TIMESERIES "
+                }
+              ],
+              "yAxisLeft": {
+                "zero": true
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }


### PR DESCRIPTION
### Relevant information

Adding `Vertiv Watchdog` as a vendor for the environment sensor entity type.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
