### PR TITLE
fix: syntax typos on round() function

### DIFF
--- a/definitions/ext-kentik_default/dashboard.json
+++ b/definitions/ext-kentik_default/dashboard.json
@@ -260,7 +260,7 @@
 			  "nrqlQueries": [
 				{
 				  "accountId": 0,
-				  "query": "FROM Metric SELECT round(latest(kentik.snmp.hrStorageUsed)*100/latest(kentik.snmp.hrStorageSize}.01) AS 'Used %', round(latest(kentik.snmp.hrStorageSize)*1e-6,.01) AS 'Total MBytes', round(latest(kentik.snmp.hrStorageUsed)*1e-6,.01) AS 'Used MBytes' WHERE `mib-table` = 'hrStorage' FACET storage_description LIMIT MAX"
+				  "query": "FROM Metric SELECT round(latest(kentik.snmp.hrStorageUsed)*100/latest(kentik.snmp.hrStorageSize),.01) AS 'Used %', round(latest(kentik.snmp.hrStorageSize)*1e-6,.01) AS 'Total MBytes', round(latest(kentik.snmp.hrStorageUsed)*1e-6,.01) AS 'Used MBytes' WHERE `mib-table` = 'hrStorage' FACET storage_description LIMIT MAX"
 				}
 			  ]
 			}
@@ -287,7 +287,7 @@
 			  "nrqlQueries": [
 				{
 				  "accountId": 0,
-				  "query": "FROM Metric SELECT round(latest(kentik.snmp.hrStorageUsed)*100/latest(kentik.snmp.hrStorageSize}.01) AS 'Used %' WHERE `mib-table` = 'hrStorage' FACET storage_description LIMIT MAX TIMESERIES 5 MINUTES"
+				  "query": "FROM Metric SELECT round(latest(kentik.snmp.hrStorageUsed)*100/latest(kentik.snmp.hrStorageSize),.01) AS 'Used %' WHERE `mib-table` = 'hrStorage' FACET storage_description LIMIT MAX TIMESERIES 5 MINUTES"
 				}
 			  ],
 			  "yAxisLeft": {
@@ -314,7 +314,7 @@
 			  "nrqlQueries": [
 				{
 				  "accountId": 0,
-				  "query": "SELECT round(max(`Used %`}.01) FROM (FROM Metric SELECT (latest(kentik.snmp.hrStorageUsed)*100/latest(kentik.snmp.hrStorageSize)) AS 'Used %' WHERE `mib-table` = 'hrStorage' FACET storage_description LIMIT MAX) WHERE `Used %` > 80 FACET storage_description"
+				  "query": "SELECT round(max(`Used %`),.01) FROM (FROM Metric SELECT (latest(kentik.snmp.hrStorageUsed)*100/latest(kentik.snmp.hrStorageSize)) AS 'Used %' WHERE `mib-table` = 'hrStorage' FACET storage_description LIMIT MAX) WHERE `Used %` > 80 FACET storage_description"
 				}
 			  ],
 			  "thresholds": [
@@ -348,7 +348,7 @@
 			  "nrqlQueries": [
 				{
 				  "accountId": 0,
-				  "query": "FROM Metric SELECT round(latest(kentik.snmp.dskTotal)*1e-6,.01) AS 'Total MBytes', round(latest(kentik.snmp.dskUsed)*1e-6,.01) AS 'Used MBytes', round(latest(kentik.snmp.dskPercent}.01) AS 'Used %', round(latest(kentik.snmp.dskPercentNode}.01) AS 'Inodes %' WHERE `mib-table` = 'dsk' FACET dsk_device, dsk_path, dsk_error_msg LIMIT MAX"
+				  "query": "FROM Metric SELECT round(latest(kentik.snmp.dskTotal)*1e-6,.01) AS 'Total MBytes', round(latest(kentik.snmp.dskUsed)*1e-6,.01) AS 'Used MBytes', round(latest(kentik.snmp.dskPercent),.01) AS 'Used %', round(latest(kentik.snmp.dskPercentNode),.01) AS 'Inodes %' WHERE `mib-table` = 'dsk' FACET dsk_device, dsk_path, dsk_error_msg LIMIT MAX"
 				}
 			  ]
 			}


### PR DESCRIPTION
### Relevant information

fixes a syntax error found in the dashboard definition for the `round()` function

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
