### PR TITLE
Add K8s tags to all OpenTelemetry synthesis rules

### DIFF
--- a/definitions/ext-service/definition.yml
+++ b/definitions/ext-service/definition.yml
@@ -40,6 +40,9 @@ synthesis:
     - attribute: telemetry.sdk.name
       value: opentelemetry
     tags:
+      k8s.cluster.name:
+      k8s.deployment.name:
+      k8s.namespace.name:
       telemetry.sdk.name:
         entityTagName: instrumentation.provider
       telemetry.sdk.language:


### PR DESCRIPTION
### Relevant information

This repeats the tag additions from #429 but for the other OpenTelemetry synthesis rule. I failed to notice that this rule will add the `instrumentation.provider=opentelemetry` value when `telemetry.sdk.name=opentelemetry` which makes it equivalent to the first rule.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
