### PR TITLE
Improve Service otel rule when provider is not given

### DIFF
--- a/definitions/ext-service/definition.yml
+++ b/definitions/ext-service/definition.yml
@@ -32,13 +32,15 @@ synthesis:
         entityTagName: language
       telemetry.sdk.version:
 
-    # telemetry from opentelemetry provider
+    # telemetry from opentelemetry provider without instrumentation.provider
   - identifier: service.name
     name: service.name
     encodeIdentifierInGUID: true
     conditions:
     - attribute: telemetry.sdk.name
       value: opentelemetry
+    - attribute: instrumentation.provider
+      present: false
     tags:
       k8s.cluster.name:
       k8s.deployment.name:

--- a/docs/synthesis.md
+++ b/docs/synthesis.md
@@ -11,13 +11,13 @@ synthesis:
     name: hostname
 ```
 
-| **Name** | **Type** | **Description**  |
-| -------- | -------- | ---------------- |
-| name    | String | Required. The attribute to use for the entity name. |
-| identifier| String| Required. Telemetry attribute to use as the entity identifier.|
-| encodeIdentifierInGUID | Boolean | Defaults to `false`. If true, the identifier value will be encoded to respect the [GUID limits][guid_spec]. |
-| conditions | List | Defaults to an empty list. The list of conditions to apply in the data point to match the rule. |
-| tags     | List   | Defaults to an empty list. The list of attributes to copy as entity tags if the rule matches. |
+| **Name** | **Type** | **Required** | **Description**  |
+| -------- | -------- | ------------ | ---------------- |
+| name    | String | Yes | The attribute to use for the entity name. |
+| identifier| String| Yes | Telemetry attribute to use as the entity identifier.|
+| encodeIdentifierInGUID | Boolean | No | If true, the identifier value will be encoded to respect the [GUID limits][guid_spec]. Defaults to `false`. |
+| conditions | List | No | The list of conditions to apply in the data point to match the rule. Defaults to an empty list. |
+| tags     | List   | No | The list of attributes to copy as entity tags if the rule matches. Defaults to an empty list. |
 
 ### Conditions
 
@@ -67,12 +67,12 @@ synthesis:
     - prefix: us-
 ```
 
-| **Name** | **Type** | **Description**  |
-| -------- | -------- | ---------------- |
-| attribute | String  | Required. The name of the attribute to match in the data point. |
-| value    | String   | Optional. Can't be mixed with `prefix` or `present`. The exact value the attribute must contain in order to match the data point. |
-| prefix | String | Optional. Can't be mixed with `value` or `present`. The attribute must start with this value. |
-| present | Boolean | Optional. Defaults to true when no other condition is given. Can't be mixed with `value` or `prefix`. The attribute must be present or absent. |
+| **Name** | **Type** | **Required** | **Description**  |
+| -------- | -------- | ------------ | ---------------- |
+| attribute | String  | Yes | The name of the attribute to match in the data point. |
+| value    | String   | No | The exact value the attribute must contain in order to match the data point. Can't be mixed with `prefix` or `present`.  |
+| prefix | String | No | The attribute must start with this value. Can't be mixed with `value` or `present`. |
+| present | Boolean | No | When `true` the attribute must be present, when `false` attribute must not exist in the data point. Defaults to true when no other condition is given. Can't be mixed with `value` or `prefix`.  |
 
 ### Tags
 
@@ -126,10 +126,10 @@ synthesis:
         entityTagName: container.state
 ```
 
-| **Name** | **Type** | **Description**  |
-| -------- | -------- | ---------------- |
-| multiValue | Boolean  | Defaults to `true`. If set to `false`, any update will replace all existing values in the tag, making it a tag with only one value. |
-| entityTagName | String | Defaults to the attribute name. If provided, the attribute value will be copied into a tag with this name. |
+| **Name** | **Type** | **Required** | **Description**  |
+| -------- | -------- | ------------ | ---------------- |
+| multiValue | Boolean  | No | If set to `false`, any update will replace all existing values in the tag, making it a tag with only one value. Defaults to `true`. |
+| entityTagName | String | No | If provided, the attribute value will be copied into a tag with this name. Defaults to the attribute name. |
 
 #### Default tags
 
@@ -158,6 +158,6 @@ These features are defined under the rule using the `legacyFeatures` key.
       overrideGuidType: true
 ```
 
-| **Name** | **Type** | **Description**  |
-| -------- | -------- | ---------------- |
-| overrideGuidType | Boolean  | Defaults to `false`. If set to `true`, it will replace the entityType in the guid for the `NA` value. |
+| **Name** | **Type** | **Required** | **Description**  |
+| -------- | -------- | ------------ | ---------------- |
+| overrideGuidType | Boolean  | No | If set to `true`, it will replace the entityType in the guid for the `NA` value. Defaults to `false`. |


### PR DESCRIPTION
### Relevant information

We have two rules for otel services that are the same on the main definition.
The main difference is that for one of them the instrumentation.provider tag of the entity is taken from another attribute rather than the original one.

This must only happen when the instrumentation.provider attribute is not in the telemetry (i think?) hence overriding it.

Before it was not possible to define this behavior but now we can make the rule not match when instrumentation.provider is present.

@erabug could you double check this makes sense to you?


### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
