### PR TITLE
Add networking GMs for otel hosts

### DIFF
--- a/definitions/infra-host/golden_metrics.yml
+++ b/definitions/infra-host/golden_metrics.yml
@@ -60,6 +60,13 @@ networkTrafficTx:
       from: NetworkSample
       eventId: entityGuid
       eventName: entityName
+    opentelemetry:
+      # emulate a rate of 1 second in order to get bytes/second
+      select: sum(system.network.io) / sum((endTimestamp - timestamp) / 1000)
+      where: device != 'lo' AND direction='transmit'
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
 networkTrafficRx:
   title: Network Receive Traffic (B/s)
   unit: BYTES_PER_SECOND
@@ -74,3 +81,10 @@ networkTrafficRx:
       from: NetworkSample
       eventId: entityGuid
       eventName: entityName
+    opentelemetry:
+      # emulate a rate of 1 second in order to get bytes/second
+      select: sum(system.network.io) / sum((endTimestamp - timestamp) / 1000)
+      where: device != 'lo' AND direction='receive'
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name


### PR DESCRIPTION
### Relevant information

Yet another attempt to fix the network golden metric for otel hosts

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
