### PR TITLE
feat: host opentelemetry memory utilization

### DIFF
--- a/definitions/infra-host/golden_metrics.yml
+++ b/definitions/infra-host/golden_metrics.yml
@@ -32,6 +32,12 @@ memoryUsage:
       from: SystemSample
       eventId: entityGuid
       eventName: entityName
+    opentelemetry:
+      select: average(system.memory.utilization) * 100
+      where: state = 'used'
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
 storageUsage:
   title: Storage usage (%)
   unit: PERCENTAGE


### PR DESCRIPTION
### Relevant information

This is adding the memory golden metric definition for hosts monitored by the opentelemetry collector.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.

### Comments

In Linux systems, the resulting value will be different than the one provided by the infra-agent host. The agent uses the `MemAvailable` and `MemTotal` fields from `/proc/meminfo` to compute the memory usage, while the Open Telemetry Collector relies on a sum of some already provided fields. We consider `MemAvailable` more fine-grained as it is computed in the kernel and it takes into account memory low watermarks. 
Issue proposing `MemAvailable` as a new state for the Open Telemetry Collector: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/7417 
