### PR TITLE
Fix event type for otel host definition

### DIFF
--- a/definitions/infra-host/definition.yml
+++ b/definitions/infra-host/definition.yml
@@ -29,7 +29,7 @@ synthesis:
         - attribute: newrelic.source
           value: 'api.metrics.otlp'
         - attribute: eventType
-          value: MetricRaw
+          value: Metric
         - attribute: metricName
           prefix: 'system.'
         # if service.name is present, it's a service, not a host


### PR DESCRIPTION
### Relevant information

In a previous PR, I tried adding an event_type condition for otel host entities, but it looks like it didn't work. I'm hoping to fix it in this PR.
### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
