### PR TITLE
Update summary and golden metric NRQL query

### DIFF
--- a/definitions/ext-isilon/golden_metrics.yml
+++ b/definitions/ext-isilon/golden_metrics.yml
@@ -1,18 +1,18 @@
 usedHDD:
-  title: Used HDD %
+  title: Avg Used HDD %
   unit: PERCENTAGE
   query:
-    select: latest(usage.pctUsedHdd)
+    select: average(usage.pctUsedHdd)
     from: IsilonPools
-    where: "dataType = 'pool' and name not like 'Archive_Tier' and name not like 'Active_Tier' and name not like 'SSD_SED_tier'"
+    where: "dataType = 'pool'"
     eventId: entity.guid
 usedSSD:
-  title: Used SSD %
+  title: Avg Used SSD %
   unit: PERCENTAGE
   query:
-    select: latest(usage.pctUsedSsd)
+    select: average(usage.pctUsedSsd)
     from: IsilonPools
-    where: "dataType = 'pool' and name not like 'Archive_Tier' and name not like 'Active_Tier' and name not like 'SSD_SED_tier'"
+    where: "dataType = 'pool'"
     eventId: entity.guid
 syncFailedJobs:
   title: SyncIQ Failures

--- a/definitions/ext-isilon/summary_metrics.yml
+++ b/definitions/ext-isilon/summary_metrics.yml
@@ -1,5 +1,5 @@
 usedHDD:
-  title: Used HDD %
+  title: Avg Used HDD %
   unit: PERCENTAGE
   query:
     select: average(usage.pctUsedHdd)
@@ -7,7 +7,7 @@ usedHDD:
     where: "dataType = 'pool'"
     eventId: entity.guid
 usedSSD:
-  title: Used SSD %
+  title: Avg Used SSD %
   unit: PERCENTAGE
   query:
     select: average(usage.pctUsedSsd)

--- a/definitions/ext-kentik_default/definition.yml
+++ b/definitions/ext-kentik_default/definition.yml
@@ -30,6 +30,18 @@ synthesis:
       src_addr:
         entityTagName: device_ip
         multiValue: false
+        
+    # net-snmp device
+  - identifier: device_name
+    name: device_name
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: provider
+      value: kentik-net-snmp
+    tags:
+      src_addr:
+        entityTagName: device_ip
+        multiValue: false
 
 dashboardTemplates:
   kentik/base:


### PR DESCRIPTION
### Relevant information

This is an update after initial entity creation to correct what metrics to show.
Summary metric and golden metric can be a single metric/value. In this entity case, there can be many disk pools but only single metric (latest) for one of the pools is shown. This is the update to show average used capacity of all pools. Bugfix.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
