### PR TITLE
Add more conditions into otel Metric

### DIFF
--- a/definitions/infra-host/definition.yml
+++ b/definitions/infra-host/definition.yml
@@ -26,6 +26,14 @@ synthesis:
       name: host.id
       encodeIdentifierInGUID: true
       conditions:
+        - attribute: eventType
+          value: MetricRaw
+        # if service.name is present, it's a service, not a host
+        - attribute: service.name
+          present: false
+        # if container.id is present, it's a container, not a host
+        - attribute: container.id
+          present: false
         # This is a temporary condition to restrict synthesis for a particular set of telemetry data.
         - attribute: nr.entity_type
           value: host


### PR DESCRIPTION
### Relevant information

Add more conditions into the otel rule for Metrics so we ensure only the important events are being processed.

There are 2 more conditions missing that we will add in the future.

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
