### PR TITLE
Turn private locations and secure credentials alertable

### DIFF
--- a/definitions/synth-private_location/definition.yml
+++ b/definitions/synth-private_location/definition.yml
@@ -2,4 +2,4 @@ domain: SYNTH
 type: PRIVATE_LOCATION
 configuration:
   entityExpirationTime: EIGHT_DAYS
-  alertable: false
+  alertable: true

--- a/definitions/synth-secure_cred/definition.yml
+++ b/definitions/synth-secure_cred/definition.yml
@@ -2,4 +2,4 @@ domain: SYNTH
 type: SECURE_CRED
 configuration:
   entityExpirationTime: EIGHT_DAYS
-  alertable: false
+  alertable: true


### PR DESCRIPTION
### Relevant information

Turning synthetics related private locations and secure credentials entities alertable, so they appear in Explorer.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
