### PR TITLE
Document new functionality

### DIFF
--- a/definitions/infra-container/definition.yml
+++ b/definitions/infra-container/definition.yml
@@ -11,7 +11,7 @@ synthesis:
     tags:
       container.state:
       docker.state:
-        entityTagName: container.state
+        entityTagNames: [container.state, docker.state]
       docker.containerId:
         multiValue: false
       docker.shortContainerId:
@@ -33,7 +33,7 @@ synthesis:
     - attribute: k8s.containerName
     tags:
       k8s.status:
-        entityTagName: container.state
+        entityTagNames: [container.state, k8s.status]
       k8s.clusterName:
       k8s.namespaceName:
       k8s.podName:

--- a/docs/synthesis.md
+++ b/docs/synthesis.md
@@ -161,7 +161,7 @@ synthesis:
 
 You can also change the name of the tag to another value, rather than using the name in the attribute. In general, we suggest not to use this configuration unless you are trying to use more standard namings, since sometimes it's difficult for the user to see the difference between entity tags and telemetry attributes, and changing the names could cause even more confusion.
 
-A good use case for this feature is `CONTAINER`: A container has different sources (docker, kubernetes, etc.), and we rename the tags to use a standard naming instead of a "per source" name.
+A good use case for this feature is `CONTAINER`: A container has different sources (docker, kubernetes, etc.), and we rename the tags to use a standard naming and a "per source" name.
 
 ```yaml
 synthesis:
@@ -170,18 +170,18 @@ synthesis:
     name: docker.name
     tags:
       docker.state:
-        entityTagName: container.state
+        entityTagNames: [container.state, docker.state]
   - identifier: entity.id
     name: k8s.containerName
     tags:
       k8s.status:
-        entityTagName: container.state
+        entityTagNames: [container.state, k8s.status]
 ```
 
 | **Name** | **Type** | **Required** | **Description**  |
 | -------- | -------- | ------------ | ---------------- |
 | multiValue | Boolean  | No | If set to `false`, any update will replace all existing values in the tag, making it a tag with only one value. Defaults to `true`. |
-| entityTagName | String | No | If provided, the attribute value will be copied into a tag with this name. Defaults to the attribute name. |
+| entityTagNames | List<String> | No | If provided, the attribute value will be copied into a tag using each value of the list as the key. Defaults to list with the attribute name. |
 
 #### Default tags
 

--- a/validator/schemas/entity-schema-v1.json
+++ b/validator/schemas/entity-schema-v1.json
@@ -263,6 +263,19 @@
                       "$id": "#/properties/tags/items/anyOf/0/properties/entityTagName",
                       "type": "string",
                       "title": "The key of the tag to be created with the value of the provided attribute"
+                    },
+                    "entityTagNames": {
+                      "$id": "#/properties/tags/items/anyOf/0/properties/entityTagNames",
+                      "type": "array",
+                      "title": "A list of tag names to create from this attribute",
+                      "items": {
+                        "$id": "#/properties/tags/items/anyOf/0/properties/entityTagNames/items",
+                        "anyOf": [{
+                          "$id": "#/properties/tags/items/anyOf/0/properties/entityTagNames/items/0",
+                          "type": "string",
+                          "title": "The key of the tag to be created with the value of the provided attribute"
+                        }]
+                      }
                     }
                   }
                 }]


### PR DESCRIPTION
### Relevant information

Document the new `entityTagNames` property for renaming attributes into tags.

Removed the old `entityTagName` this is mostly to avoid confussing users on deciding which one to use, since one is a subset of the other.

We may want to run a script to change all existing `entityTagName` into `entityTagNames` for simplicity.

Finally do the change in containers since this was required for them.

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
