### PR TITLE
feat: Rename 'env' golden tag for Service Levels

### DIFF
--- a/definitions/ext-service_level/definition.yml
+++ b/definitions/ext-service_level/definition.yml
@@ -1,13 +1,13 @@
 domain: EXT
 type: SERVICE_LEVEL
 goldenTags:
-- owner
-- category
-- env
-- maturity
-- user_journey
-- application
-- product
+  - owner
+  - category
+  - environment
+  - maturity
+  - user_journey
+  - application
+  - product
 configuration:
   entityExpirationTime: MANUAL
   alertable: false


### PR DESCRIPTION
### Relevant information

Rename `env` golden tag to `environment` for Service level entities

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
