### PR TITLE
Use *.utilization metrics to define OTEL host GMs

### DIFF
--- a/definitions/infra-host/golden_metrics.yml
+++ b/definitions/infra-host/golden_metrics.yml
@@ -13,8 +13,8 @@ cpuUsage:
       eventId: entityGuid
       eventName: entityName
     opentelemetry:
-      select: sum(system.cpu.time) / sum((endTimestamp - timestamp) / 1000) * 100
-      where: state != 'idle'
+      select: average(1 - system.cpu.utilization) * 100
+      where: state = 'idle'
       from: Metric
       eventId: entity.guid
       eventName: entity.name
@@ -53,7 +53,9 @@ storageUsage:
       eventId: entityGuid
       eventName: entityName
     opentelemetry:
-      select: filter(sum(system.filesystem.usage), where state != 'free') / sum(system.filesystem.usage) * 100
+      select: average(system.filesystem.utilization) * 100
+      # squashfs will always have a utilization of 100%
+      where: type != 'squashfs'
       from: Metric
       eventId: entity.guid
       eventName: entity.name


### PR DESCRIPTION
:sigh: The previous definitions didn't work as expected. Trying out new definitions using gauges, which should work better. This can be done because a couple of PRs were merged in the otel collector, adding these new metrics.

### Relevant information

Describe what you have done and any details that you think are relevant or that you might want to discuss with us. 

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
