### PR TITLE
Add tests for OTEL hosts and services

### DIFF
--- a/definitions/ext-service/tests/Log.json
+++ b/definitions/ext-service/tests/Log.json
@@ -4,6 +4,6 @@
         "host.name": "ip-172-31-15-60.eu-central-1.compute.internal",
         "newrelic.source": "api.logs.otlp",
         "nr.entity_type": "host",
-        "service.name": "julien-otel-app",
+        "service.name": "julien-otel-app"
     }
 ]

--- a/definitions/ext-service/tests/Log.json
+++ b/definitions/ext-service/tests/Log.json
@@ -1,0 +1,9 @@
+[
+    {
+        "host.id": "i-0600db543f30a26f7",
+        "host.name": "ip-172-31-15-60.eu-central-1.compute.internal",
+        "newrelic.source": "api.logs.otlp",
+        "nr.entity_type": "host",
+        "service.name": "julien-otel-app",
+    }
+]

--- a/definitions/infra-host/tests/Log.json
+++ b/definitions/infra-host/tests/Log.json
@@ -1,0 +1,8 @@
+[
+    {
+        "host.id": "i-0600db543f30a26f7",
+        "host.name": "ip-172-31-15-60.eu-central-1.compute.internal",
+        "newrelic.source": "api.logs.otlp",
+        "nr.entity_type": "host",
+    }
+]

--- a/definitions/infra-host/tests/Log.json
+++ b/definitions/infra-host/tests/Log.json
@@ -3,7 +3,6 @@
         "host.id": "i-0600db543f30a26f7",
         "host.name": "ip-172-31-15-60.eu-central-1.compute.internal",
         "newrelic.source": "api.logs.otlp",
-        "nr.entity_type": "host",
-        "service.name": "service"
+        "nr.entity_type": "host"
     }
 ]

--- a/definitions/infra-host/tests/Log.json
+++ b/definitions/infra-host/tests/Log.json
@@ -3,6 +3,6 @@
         "host.id": "i-0600db543f30a26f7",
         "host.name": "ip-172-31-15-60.eu-central-1.compute.internal",
         "newrelic.source": "api.logs.otlp",
-        "nr.entity_type": "host",
+        "nr.entity_type": "host"
     }
 ]

--- a/definitions/infra-host/tests/Log.json
+++ b/definitions/infra-host/tests/Log.json
@@ -3,6 +3,7 @@
         "host.id": "i-0600db543f30a26f7",
         "host.name": "ip-172-31-15-60.eu-central-1.compute.internal",
         "newrelic.source": "api.logs.otlp",
-        "nr.entity_type": "host"
+        "nr.entity_type": "host",
+        "service.name": "service"
     }
 ]

--- a/definitions/infra-host/tests/MetricRaw.json
+++ b/definitions/infra-host/tests/MetricRaw.json
@@ -3,6 +3,7 @@
         "host.id": "i-0600db543f30a26f7",
         "host.name": "ip-172-31-15-60.eu-central-1.compute.internal",
         "metricName": "system.cpu.utilization",
-        "newrelic.source": "api.metrics.otlp"
+        "newrelic.source": "api.metrics.otlp",
+        "nr.entity_type": "host"
     }
 ]

--- a/definitions/infra-host/tests/MetricRaw.json
+++ b/definitions/infra-host/tests/MetricRaw.json
@@ -1,0 +1,8 @@
+[
+    {
+        "host.id": "i-0600db543f30a26f7",
+        "host.name": "ip-172-31-15-60.eu-central-1.compute.internal",
+        "metricName": "system.cpu.utilization"
+        "newrelic.source": "api.metrics.otlp",
+    }
+]

--- a/definitions/infra-host/tests/MetricRaw.json
+++ b/definitions/infra-host/tests/MetricRaw.json
@@ -2,7 +2,7 @@
     {
         "host.id": "i-0600db543f30a26f7",
         "host.name": "ip-172-31-15-60.eu-central-1.compute.internal",
-        "metricName": "system.cpu.utilization"
-        "newrelic.source": "api.metrics.otlp",
+        "metricName": "system.cpu.utilization",
+        "newrelic.source": "api.metrics.otlp"
     }
 ]


### PR DESCRIPTION
### Relevant information

Since the entity definitions for OTEL hosts and services are getting a bit complex, I wanted to add a couple of tests:

1. A metric containing host.id will create to a Host
2. A log containing host.id but not service.name will create a Host
3. A log containing host.id and service.name will create a service

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
