### PR TITLE
fix: add entity.guid to widget

### DIFF
--- a/definitions/ext-kentik_default/dashboard.json
+++ b/definitions/ext-kentik_default/dashboard.json
@@ -314,7 +314,7 @@
 			  "nrqlQueries": [
 				{
 				  "accountId": 0,
-				  "query": "SELECT round(max(`Used %`),.01) FROM (FROM Metric SELECT (latest(kentik.snmp.hrStorageUsed)*100/latest(kentik.snmp.hrStorageSize)) AS 'Used %' WHERE `mib-table` = 'hrStorage' FACET storage_description LIMIT MAX) WHERE `Used %` > 80 FACET storage_description"
+				  "query": "SELECT round(max(`Used %`),.01) FROM (FROM Metric SELECT (latest(kentik.snmp.hrStorageUsed)*100/latest(kentik.snmp.hrStorageSize)) AS 'Used %' WHERE `mib-table` = 'hrStorage' FACET storage_description, `entity.guid` LIMIT MAX) WHERE `Used %` > 80 FACET storage_description"
 				}
 			  ],
 			  "thresholds": [


### PR DESCRIPTION
### Relevant information

Added required for the entity.guid filtering that gets applied when viewing a specific entity

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
