### PR TITLE
Add cloudflare host entity

### DIFF
--- a/definitions/ext-cloudflare_host/dashboard.json
+++ b/definitions/ext-cloudflare_host/dashboard.json
@@ -1,0 +1,130 @@
+{
+    "name": "Cloudflare Hosts Summary",
+    "description": null,
+    "pages": [
+      {
+        "name": "Cloudflare Hosts Summary",
+        "description": null,
+        "widgets": [
+          {
+            "visualization": {
+              "id": "viz.billboard"
+            },
+            "layout": {
+              "column": 1,
+              "row": 1,
+              "height": 2,
+              "width": 4
+            },
+            "title": "Request rate per minute",
+            "rawConfiguration": {
+              "dataFormatters": [],
+              "nrqlQueries": [
+                {
+                  "accountId": 0,
+                  "query": "FROM Metric SELECT rate(sum(cloudflare_request_total), 1 minute) AS 'Req/min' WHERE cloudflare_request_total IS NOT NULL"
+                }
+              ],
+              "thresholds": []
+            }
+          },
+          {
+            "visualization": {
+              "id": "viz.billboard"
+            },
+            "layout": {
+              "column": 5,
+              "row": 1,
+              "height": 2,
+              "width": 4
+            },
+            "title": "Error rate (%)",
+            "rawConfiguration": {
+              "dataFormatters": [],
+              "nrqlQueries": [
+                {
+                  "accountId": 0,
+                  "query": "FROM Metric SELECT filter(sum(cloudflare_request_total), where http_status >= 500) / sum(cloudflare_request_total) * 100 AS '% of Errors' WHERE cloudflare_request_total IS NOT NULL"
+                }
+              ],
+              "thresholds": []
+            }
+          },
+          {
+            "visualization": {
+              "id": "viz.billboard"
+            },
+            "layout": {
+              "column": 9,
+              "row": 1,
+              "height": 2,
+              "width": 4
+            },
+            "title": "Avg Response Time (ms)",
+            "rawConfiguration": {
+              "dataFormatters": [],
+              "nrqlQueries": [
+                {
+                  "accountId": 0,
+                  "query": "FROM Metric SELECT average(cloudflare_response_time_ms) AS 'Avg Response time in MS'"
+                }
+              ],
+              "thresholds": []
+            }
+          },
+          {
+            "visualization": {
+              "id": "viz.stacked-bar"
+            },
+            "layout": {
+              "column": 1,
+              "row": 3,
+              "height": 4,
+              "width": 12
+            },
+            "title": "Requests by status over time",
+            "rawConfiguration": {
+              "facet": {
+                "showOtherSeries": false
+              },
+              "legend": {
+                "enabled": true
+              },
+              "nrqlQueries": [
+                {
+                  "accountId": 0,
+                  "query": "FROM Metric SELECT rate(sum(cloudflare_request_total), 1 minute) WHERE cloudflare_request_total IS NOT NULL FACET http_status TIMESERIES "
+                }
+              ]
+            }
+          },
+          {
+            "visualization": {
+              "id": "viz.line"
+            },
+            "layout": {
+              "column": 1,
+              "row": 7,
+              "height": 3,
+              "width": 12
+            },
+            "title": "Response time range over time",
+            "rawConfiguration": {
+              "legend": {
+                "enabled": true
+              },
+              "nrqlQueries": [
+                {
+                  "accountId": 0,
+                  "query": "FROM Metric SELECT average(cloudflare_response_time_ms), min(cloudflare_response_time_ms), max(cloudflare_response_time_ms) TIMESERIES"
+                }
+              ],
+              "yAxisLeft": {
+                "zero": true
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }

--- a/definitions/ext-cloudflare_host/definition.yml
+++ b/definitions/ext-cloudflare_host/definition.yml
@@ -1,0 +1,21 @@
+domain: EXT
+type: CLOUDFLARE_HOST
+goldenTags:
+- zone
+synthesis:
+  rules:
+    - identifier: host
+      name: host
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: metricName
+          prefix: cloudflare_
+      tags:
+        zone:
+
+dashboardTemplates:
+  newRelic:
+    template: dashboard.json
+configuration:
+  entityExpirationTime: EIGHT_DAYS
+  alertable: true

--- a/definitions/ext-cloudflare_host/golden_metrics.yml
+++ b/definitions/ext-cloudflare_host/golden_metrics.yml
@@ -1,0 +1,20 @@
+throughput:
+  title: Throughput (rpm)
+  query:
+    select: rate(sum(cloudflare_request_total), 1 minute)
+    from: Metric
+    where: cloudflare_request_total IS NOT NULL
+
+errorRate:
+  title: Error rate (%)
+  query:
+    select: filter(sum(cloudflare_request_total), where http_status >= 500) / sum(cloudflare_request_total) * 100
+    from: Metric
+    where: cloudflare_request_total IS NOT NULL
+
+responseTimeMs:
+  title: Response time (ms)
+  query:
+    select: average(cloudflare_response_time_ms)
+    from: Metric
+    eventId: entity.guid

--- a/definitions/ext-cloudflare_host/summary_metrics.yml
+++ b/definitions/ext-cloudflare_host/summary_metrics.yml
@@ -1,0 +1,31 @@
+zone:
+  title: Zone
+  unit: STRING
+  tag:
+    key: zone
+
+responseTimeMs:
+  title: Response time
+  unit: SECONDS
+  query:
+    select: average(cloudflare_response_time_ms) / 1000
+    from: Metric
+    eventId: entity.guid
+
+throughput:
+  title: Throughput
+  unit: REQUESTS_PER_SECOND
+  query:
+    select: rate(sum(cloudflare_request_total), 1 second)
+    from: Metric
+    where: cloudflare_request_total IS NOT NULL
+    eventId: entity.guid
+
+errorRate:
+  title: Error rate
+  unit: PERCENTAGE
+  query:
+    select: (filter(sum(cloudflare_request_total), where http_status >= 500) / sum(cloudflare_request_total)) * 100
+    from: Metric
+    where: cloudflare_request_total IS NOT NULL
+    eventId: entity.guid


### PR DESCRIPTION
### Relevant information

Customer is emitting metrics from Cloudflare logs that they process themselves. They would like Cloudflare host entities to be generated from these metrics.

### Checklist

* [ x ] I've read the guidelines and understand the acceptance criteria.
* [ x ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ x ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
