### PR TITLE
Fix Cloudflare Host error metric

### DIFF
--- a/definitions/ext-cloudflare_host/golden_metrics.yml
+++ b/definitions/ext-cloudflare_host/golden_metrics.yml
@@ -8,7 +8,7 @@ throughput:
 errorRate:
   title: Error rate (%)
   query:
-    select: (filter(sum(cloudflare_request_total), where http_status >= 500) / sum(cloudflare_request_total)) * 100
+    select: (filter(sum(cloudflare_request_total), where http_status >= 500) * 100) / sum(cloudflare_request_total)
     from: Metric
     where: cloudflare_request_total IS NOT NULL
 


### PR DESCRIPTION

### Relevant information

The definition for `errorRate` is not currently supported internally. Fixing it here while we work on a long-term solution

### Checklist

* [x ] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
