### PR TITLE
fix: update netapp instrumentation.name and cleanup SM and GM

### DIFF
--- a/definitions/ext-nas/definition.yml
+++ b/definitions/ext-nas/definition.yml
@@ -20,5 +20,5 @@ goldenTags:
 dashboardTemplates:
   kentik/readynas:
     template: readynas-dashboard.json
-  kentik/netapp:
+  kentik/netapp-cluster:
     template: netapp-dashboard.json

--- a/definitions/ext-nas/golden_metrics.yml
+++ b/definitions/ext-nas/golden_metrics.yml
@@ -1,16 +1,12 @@
-# Tested on Netgear ReadyNAS
 cpuUtilization:
-  title: CPU Utilization (%)
+  title: CPU
   unit: PERCENTAGE
-  query:
-    select: average(kentik.snmp.CPU)
-    from: Metric
-    where: "provider = 'kentik-nas'"
-
-memoryUtilization:
-  title: Memory Utilization (%)
-  unit: PERCENTAGE
-  query:
-    select: average(kentik.snmp.MemoryUtilization)
-    from: Metric
-    where: "provider = 'kentik-nas'"
+  queries:
+    kentik/readynas:
+      select: 100 - latest(kentik.snmp.ssCpuIdle)
+      from: Metric
+      where: "provider = 'kentik-nas' AND SysObjectID = '.1.3.6.1.4.1.4526.100.16'"
+    kentik/netapp-cluster:
+      select: average(kentik.snmp.CPU)
+      from: Metric
+      where: "provider = 'kentik-nas'"

--- a/definitions/ext-nas/summary_metrics.yml
+++ b/definitions/ext-nas/summary_metrics.yml
@@ -1,30 +1,20 @@
-# Tested on Netgear ReadyNAS
 ipAddress:
   title: IP Address
   unit: STRING
   tag:
     key: device_ip
 
-model:
-  title: Model
-  unit: STRING
-  tag:
-    key: device_model
-
 cpuUtilization:
   title: CPU
   unit: PERCENTAGE
-  query:
-    select: 100 - latest(kentik.snmp.ssCpuIdle)
-    from: Metric
-    where: "provider = 'kentik-nas' AND SysObjectID = '.1.3.6.1.4.1.4526.100.16'"
-    eventId: entity.guid
-
-memoryUtilization:
-  title: Memory
-  unit: PERCENTAGE
-  query:
-    select: ((latest(kentik.snmp.memTotalReal) - latest(kentik.snmp.memAvailReal)) / latest(kentik.snmp.memTotalReal)) * 100
-    from: Metric
-    where: "provider = 'kentik-nas' AND SysObjectID = '.1.3.6.1.4.1.4526.100.16'"
-    eventId: entity.guid
+  queries:
+    kentik/readynas:
+      select: 100 - latest(kentik.snmp.ssCpuIdle)
+      from: Metric
+      where: "provider = 'kentik-nas' AND SysObjectID = '.1.3.6.1.4.1.4526.100.16'"
+      eventId: entity.guid
+    kentik/netapp-cluster:
+      select: average(kentik.snmp.CPU)
+      from: Metric
+      where: "provider = 'kentik-nas'"
+      eventId: entity.guid


### PR DESCRIPTION
### Relevant information

* Corrected a typo on the `instrumenation.name` for NetApp clusters
* Removed deprecated tab from SM
* Removed memory util from SM and GM as it's not a standard metric across NAS devices
* Updated CPU util in SM and GM to add the NetApp clusters

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
