### PR TITLE
fix: change network synthetic metric calculation

### DIFF
--- a/definitions/ext-network_synth/network-synth-dashboard.json
+++ b/definitions/ext-network_synth/network-synth-dashboard.json
@@ -47,7 +47,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "FROM Metric SELECT round(average(kentik.synth.lost_pct)/1000,2) as 'Average Loss %' since 10 minutes ago compare with 1 day ago"
+                "query": "FROM Metric SELECT round(average(kentik.synth.lost_pct),2) as 'Average Loss %' since 10 minutes ago compare with 1 day ago"
               }
             ],
             "thresholds": []


### PR DESCRIPTION
### Relevant information
Fixed a mistake with the math of a particular dashboard metric

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
