### PR TITLE
otel: remove dummy condition for hosts

### DIFF
--- a/definitions/ext-service/tests/Log.json
+++ b/definitions/ext-service/tests/Log.json
@@ -3,7 +3,6 @@
         "host.id": "i-0600db543f30a26f7",
         "host.name": "ip-172-31-15-60.eu-central-1.compute.internal",
         "newrelic.source": "api.logs.otlp",
-        "nr.entity_type": "host",
         "service.name": "julien-otel-app"
     }
 ]

--- a/definitions/infra-host/definition.yml
+++ b/definitions/infra-host/definition.yml
@@ -28,15 +28,16 @@ synthesis:
       conditions:
         - attribute: eventType
           value: MetricRaw
+        - attribute: metricName
+          prefix: system.
+        - attribute: newrelic.source
+          value: 'api.metrics.otlp'
         # if service.name is present, it's a service, not a host
         - attribute: service.name
           present: false
         # if container.id is present, it's a container, not a host
         - attribute: container.id
           present: false
-        # This is a temporary condition to restrict synthesis for a particular set of telemetry data.
-        - attribute: nr.entity_type
-          value: host
       tags:
         cloud.provider:
         cloud.account.id:
@@ -55,19 +56,16 @@ synthesis:
       name: host.id
       encodeIdentifierInGUID: true
       conditions:
-        - attribute: newrelic.source
-          value: 'api.logs.otlp'
         - attribute: eventType
           value: Log
+        - attribute: newrelic.source
+          value: 'api.logs.otlp'
         # if service.name is present, it's a service, not a host
         - attribute: service.name
           present: false
         # if container.id is present, it's a container, not a host
         - attribute: container.id
           present: false
-        # This is a temporary condition to restrict synthesis for a particular set of telemetry data.
-        - attribute: nr.entity_type
-          value: host
       tags:
         cloud.provider:
         cloud.account.id:

--- a/definitions/infra-host/tests/MetricRaw.json
+++ b/definitions/infra-host/tests/MetricRaw.json
@@ -4,6 +4,5 @@
         "host.name": "ip-172-31-15-60.eu-central-1.compute.internal",
         "metricName": "system.cpu.utilization",
         "newrelic.source": "api.metrics.otlp",
-        "nr.entity_type": "host"
     }
 ]

--- a/definitions/infra-host/tests/MetricRaw.json
+++ b/definitions/infra-host/tests/MetricRaw.json
@@ -3,6 +3,6 @@
         "host.id": "i-0600db543f30a26f7",
         "host.name": "ip-172-31-15-60.eu-central-1.compute.internal",
         "metricName": "system.cpu.utilization",
-        "newrelic.source": "api.metrics.otlp",
+        "newrelic.source": "api.metrics.otlp"
     }
 ]


### PR DESCRIPTION
The OTEL entity synthesis for hosts is currently being restricted by a condition (`nr.entity_type: host`). This was done while we tested the rule, and also because we didn't have the option to have multiple rules to restrict synthesis as we wanted to. Now that we can have multiple rules, I'd like to remove this condition.

I'd like to test this in staging before merging if that's possible!

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
