### PR TITLE
Add ext-oracle definition to entity definitions

### DIFF
--- a/definitions/ext-oracle/dashboard.json
+++ b/definitions/ext-oracle/dashboard.json
@@ -1,0 +1,128 @@
+{
+  "name": "Ext-Oracle",
+  "description": null,
+  "pages": [
+    {
+      "name": "Ext-Oracle",
+      "description": null,
+      "widgets": [
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "height": 3,
+            "width": 6
+          },
+          "title": "DB Availability (%)",
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT average(NR.SAP.DB.KPI.AVAILABLE) FACET entity.name TIMESERIES 5 minutes SINCE 1 day ago"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 7,
+            "row": 1,
+            "height": 3,
+            "width": 6
+          },
+          "title": "DB Response Time (ms)",
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT average(NR.SAP.SYSTEM.PROCESS) WHERE metricName= 'NR.SAP.SYSTEM.PROCESS' and KEY_FIGURE = 'DB Time' SINCE 1 day ago FACET SYS_ID TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "height": 3,
+            "width": 6
+          },
+          "title": "DB Space Usage (%)",
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT average(NR.SAP.DB.KPI.USED) / average(NR.SAP.DB.KPI.SIZE) * 100 as `DB Space Usage %` FACET entity.name TIMESERIES 5 minutes SINCE 1 day ago"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 7,
+            "row": 4,
+            "height": 3,
+            "width": 6
+          },
+          "title": "DB Size (GB)",
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT average(NR.SAP.DB.KPI.SIZE)/1000000 as `DB Size(GB)` FACET entity.name TIMESERIES 5 minutes SINCE 1 day ago"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/definitions/ext-oracle/definition.yml
+++ b/definitions/ext-oracle/definition.yml
@@ -1,0 +1,29 @@
+domain: EXT
+type: ORACLE
+
+goldenTags:
+  - instrumentation.provider
+  - sap.system
+
+synthesis:
+  rules:
+    # Telemetry from New Relic SAP integration
+    # DB_ID in SYS_ID/DB format
+  - identifier: SAP_EID
+    name: SAP_EID
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: SAP_ETYPE
+      value: ORACLE
+    tags:
+      sap.functional_area:
+      SYS_ID:
+        entityTagName: sap.system
+
+dashboardTemplates:
+  SAP:
+    template: dashboard.json
+
+configuration:
+  entityExpirationTime: EIGHT_DAYS
+  alertable: true

--- a/definitions/ext-oracle/golden_metrics.yml
+++ b/definitions/ext-oracle/golden_metrics.yml
@@ -6,11 +6,21 @@ dbAvailability:
     from: Metric 
     eventId: entity.guid
 
-dbSpaceUsage:
-  title: DB Space Usage %
-  unit: PERCENTAGE
+dbSpaceUsed:
+  title: DB Space Used
+  unit: BYTES
   query:
-    select: average(NR.SAP.DB.KPI.USED) / average(NR.SAP.DB.KPI.SIZE) * 100 
+    select: average(NR.SAP.DB.KPI.USED)
+    from: Metric 
+    eventId: entity.guid
+
+dbSize:
+  title: DB Size
+  unit: BYTES
+  query:
+    select: average(NR.SAP.DB.KPI.SIZE)
+    from: Metric 
+    eventId: entity.guid
 
 responseTime:
   title: Response Time

--- a/definitions/ext-oracle/golden_metrics.yml
+++ b/definitions/ext-oracle/golden_metrics.yml
@@ -11,8 +11,6 @@ dbSpaceUsage:
   unit: PERCENTAGE
   query:
     select: average(NR.SAP.DB.KPI.USED) / average(NR.SAP.DB.KPI.SIZE) * 100 
-    from: Metric 
-    eventId: entity.guid
 
 responseTime:
   title: Response Time

--- a/definitions/ext-oracle/golden_metrics.yml
+++ b/definitions/ext-oracle/golden_metrics.yml
@@ -1,0 +1,24 @@
+dbAvailability:
+  title: DB Availability
+  unit: PERCENTAGE
+  query:
+    select: average(NR.SAP.DB.KPI.AVAILABLE) 
+    from: Metric 
+    eventId: entity.guid
+
+dbSpaceUsage:
+  title: DB Space Usage %
+  unit: PERCENTAGE
+  query:
+    select: average(NR.SAP.DB.KPI.USED) / average(NR.SAP.DB.KPI.SIZE) * 100 
+    from: Metric 
+    eventId: entity.guid
+
+responseTime:
+  title: Response Time
+  unit: SECONDS
+  query:
+    select: average(NR.SAP.SYSTEM.PROCESS)
+    from: Metric
+    where: KEY_FIGURE = 'DB Time'
+    eventId: entity.guid

--- a/definitions/ext-oracle/summary_metrics.yml
+++ b/definitions/ext-oracle/summary_metrics.yml
@@ -8,17 +8,17 @@ dbAvailability:
 
 dbSpaceUsed:
   title: DB Space Used
-  unit: GB 
+  unit: BYTES
   query:
-    select: average(NR.SAP.DB.KPI.USED) /1000000
+    select: average(NR.SAP.DB.KPI.USED)
     from: Metric 
     eventId: entity.guid
 
 dbSize:
   title: DB Size
-  unit: GB 
+  unit: BYTES
   query:
-    select: average(NR.SAP.DB.KPI.SIZE) /1000000
+    select: average(NR.SAP.DB.KPI.SIZE)
     from: Metric 
     eventId: entity.guid
 

--- a/definitions/ext-oracle/summary_metrics.yml
+++ b/definitions/ext-oracle/summary_metrics.yml
@@ -6,11 +6,19 @@ dbAvailability:
     from: Metric 
     eventId: entity.guid
 
-dbSpaceUsage:
-  title: DB Space Usage %
-  unit: PERCENTAGE
+dbSpaceUsed:
+  title: DB Space Used
+  unit: GB 
   query:
-    select: average(NR.SAP.DB.KPI.USED) / average(NR.SAP.DB.KPI.SIZE) * 100 
+    select: average(NR.SAP.DB.KPI.USED) /1000000
+    from: Metric 
+    eventId: entity.guid
+
+dbSize:
+  title: DB Size
+  unit: GB 
+  query:
+    select: average(NR.SAP.DB.KPI.SIZE) /1000000
     from: Metric 
     eventId: entity.guid
 

--- a/definitions/ext-oracle/summary_metrics.yml
+++ b/definitions/ext-oracle/summary_metrics.yml
@@ -1,0 +1,24 @@
+dbAvailability:
+  title: DB Availability
+  unit: PERCENTAGE
+  query:
+    select: average(NR.SAP.DB.KPI.AVAILABLE) 
+    from: Metric 
+    eventId: entity.guid
+
+dbSpaceUsage:
+  title: DB Space Usage %
+  unit: PERCENTAGE
+  query:
+    select: average(NR.SAP.DB.KPI.USED) / average(NR.SAP.DB.KPI.SIZE) * 100 
+    from: Metric 
+    eventId: entity.guid
+
+responseTime:
+  title: Response Time
+  unit: SECONDS
+  query:
+    select: average(NR.SAP.SYSTEM.PROCESS)
+    from: Metric
+    where: KEY_FIGURE = 'DB Time'
+    eventId: entity.guid

--- a/definitions/ext-oracle/tests/MetricRaw.json
+++ b/definitions/ext-oracle/tests/MetricRaw.json
@@ -2,16 +2,16 @@
     {
         "SAP_ETYPE": "ORACLE",
         "SAP_EID": "SD2/DB",
-        "metricName": "NR.SAP.DB.KPI.AVAILABLE",
+        "metricName": "NR.SAP.DB.KPI.AVAILABLE"
     },
     {
         "SAP_ETYPE": "ORACLE",
         "SAP_EID": "SD2/DB",
-        "metricName": "NR.SAP.DB.KPI.SIZE",
+        "metricName": "NR.SAP.DB.KPI.SIZE"
     },
     {
         "SAP_ETYPE": "ORACLE",
         "SAP_EID": "SD2/DB",
-        "metricName": "NR.SAP.SYSTEM.PROCESS",
+        "metricName": "NR.SAP.SYSTEM.PROCESS"
     }
 ]

--- a/definitions/ext-oracle/tests/MetricRaw.json
+++ b/definitions/ext-oracle/tests/MetricRaw.json
@@ -1,0 +1,17 @@
+[
+    {
+        "SAP_ETYPE": "ORACLE",
+        "SAP_EID": "SD2/DB",
+        "metricName": "NR.SAP.DB.KPI.AVAILABLE",
+    },
+    {
+        "SAP_ETYPE": "ORACLE",
+        "SAP_EID": "SD2/DB",
+        "metricName": "NR.SAP.DB.KPI.SIZE",
+    },
+    {
+        "SAP_ETYPE": "ORACLE",
+        "SAP_EID": "SD2/DB",
+        "metricName": "NR.SAP.SYSTEM.PROCESS",
+    }
+]


### PR DESCRIPTION
### Relevant information

Add ext-oracle entity type as part of the SAP entities definitions. This was proposed with the first batch of SAP entities, but not put in as we didn't have Oracle data collected then. Now we have worked out to collect metrics for ORACLE based on  customer request, it's time to add it.

### Checklist

* [x ] I've read the guidelines and understand the acceptance criteria.
* [ x] The value of the attribute marked as `identifier` will be unique and valid. 
* [ x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
