### PR TITLE
fix(vpc_network): use correct data partition

### DIFF
--- a/definitions/ext-vpc_network/summary_metrics.yml
+++ b/definitions/ext-vpc_network/summary_metrics.yml
@@ -39,7 +39,7 @@ egressBytes:
       eventId: entity.guid
     aws-kinesis-firehose/vpc-flow-logs:
       select: sum(bytes*sample_rate)
-      from: Log
+      from: Log_VPC_Flows
       where: "provider = 'firehose-vpc' and flow_direction = 'egress'"
       eventId: entity.guid
 
@@ -54,7 +54,7 @@ ingressBytes:
       eventId: entity.guid
     aws-kinesis-firehose/vpc-flow-logs:
       select: sum(bytes*sample_rate)
-      from: Log
+      from: Log_VPC_Flows
       where: "provider = 'firehose-vpc' and flow_direction = 'egress'"
       eventId: entity.guid
 


### PR DESCRIPTION
### Relevant information

Quick fix to make remaining summary metrics select from the `Log_VPC_Flows` data partition.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
