### PR TITLE
chore: add Sinetica Eagle-i to existing entity definition

### DIFF
--- a/definitions/ext-environment_sensor/definition.yml
+++ b/definitions/ext-environment_sensor/definition.yml
@@ -46,6 +46,17 @@ synthesis:
       src_addr:
         entityTagName: device_ip
         multiValue: false
+  # Sinetica Eagle-i devices
+  - identifier: device_name
+    name: device_name
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: provider
+      value: kentik-eagle-i
+    tags:
+      src_addr:
+        entityTagName: device_ip
+        multiValue: false
     
 goldenTags:
 - device_ip
@@ -63,3 +74,6 @@ dashboardTemplates:
   # Sunbird DcTrack devices
   kentik/dctrack:
     template: sunbird-dctrack-dashboard.json
+  # Sinetica Eagle-i devices
+  kentik/eagle-i:
+    template: sinetica-eagle-i-dashboard.json

--- a/definitions/ext-environment_sensor/sinetica-eagle-i-dashboard.json
+++ b/definitions/ext-environment_sensor/sinetica-eagle-i-dashboard.json
@@ -1,9 +1,9 @@
 {
-    "name": "[NR Testing] Eagle-i",
+    "name": "Eagle-i",
     "description": null,
     "pages": [
       {
-        "name": "[NR Testing] Eagle-i",
+        "name": "Eagle-i",
         "description": null,
         "widgets": [
           {

--- a/definitions/ext-environment_sensor/sinetica-eagle-i-dashboard.json
+++ b/definitions/ext-environment_sensor/sinetica-eagle-i-dashboard.json
@@ -1,0 +1,106 @@
+{
+    "name": "[NR Testing] Eagle-i",
+    "description": null,
+    "pages": [
+      {
+        "name": "[NR Testing] Eagle-i",
+        "description": null,
+        "widgets": [
+          {
+            "visualization": {
+              "id": "viz.billboard"
+            },
+            "layout": {
+              "column": 1,
+              "row": 1,
+              "height": 7,
+              "width": 3
+            },
+            "title": "Summary",
+            "rawConfiguration": {
+              "dataFormatters": [
+                {
+                  "name": "Uptime (Days)",
+                  "precision": 1,
+                  "type": "decimal"
+                },
+                {
+                  "name": "Last Update",
+                  "type": "date"
+                }
+              ],
+              "nrqlQueries": [
+                {
+                  "accountId": 0,
+                  "query": "FROM Metric SELECT latest(device_name) AS 'Device Name', latest(src_addr) AS 'Device IP', latest(invSerialNum) AS 'Serial Number', latest(invHwRevision) AS 'HW Revision', latest(invFwRevision) AS 'Firmware Revision', latest(kentik.snmp.Uptime)/8640000 AS 'Uptime (Days)', latest(SysObjectID) AS 'SysObjectID', latest(entity.type) AS 'NR Entity Type', latest(instrumentation.name) AS 'Ktranslate Profile', latest(timestamp) AS 'Last Update' WHERE provider = 'kentik-eagle-i'"
+                }
+              ],
+              "thresholds": []
+            }
+          },
+          {
+            "visualization": {
+              "id": "viz.billboard"
+            },
+            "layout": {
+              "column": 4,
+              "row": 1,
+              "height": 3,
+              "width": 5
+            },
+            "title": "Latest Sensor Readings",
+            "rawConfiguration": {
+              "dataFormatters": [],
+              "nrqlQueries": [
+                {
+                  "accountId": 0,
+                  "query": "FROM Metric SELECT latest(kentik.snmp.ipTHAValue)/10 AS 'Value' FACET ipTHAName AS 'Name', ipTHALocn AS 'Location' WHERE provider = 'kentik-eagle-i' LIMIT MAX"
+                }
+              ],
+              "thresholds": []
+            }
+          },
+          {
+            "visualization": {
+              "id": "viz.table"
+            },
+            "layout": {
+              "column": 4,
+              "row": 4,
+              "height": 4,
+              "width": 5
+            },
+            "title": "PDU Metrics",
+            "rawConfiguration": {
+              "dataFormatters": [
+                {
+                  "name": "Total Energy",
+                  "precision": null,
+                  "type": "decimal"
+                },
+                {
+                  "name": "Volts",
+                  "precision": null,
+                  "type": "decimal"
+                },
+                {
+                  "name": "Amps",
+                  "precision": null,
+                  "type": "decimal"
+                }
+              ],
+              "facet": {
+                "showOtherSeries": false
+              },
+              "nrqlQueries": [
+                {
+                  "accountId": 0,
+                  "query": "FROM Metric SELECT latest(kentik.snmp.pduRMSAmpsValue) AS 'Amps', latest(kentik.snmp.pduRMSVoltsValue) AS 'Volts', latest(kentik.snmp.pduTotalEnergyValue) AS 'Total Energy' FACET pduName WHERE provider = 'kentik-eagle-i' LIMIT MAX"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ]
+  }

--- a/definitions/ext-environment_sensor/summary_metrics.yml
+++ b/definitions/ext-environment_sensor/summary_metrics.yml
@@ -32,3 +32,9 @@ uptime:
       from: Metric
       where: "provider = 'kentik-dctrack'"
       eventId: entity.guid
+    # Sinetica Eagle-i devices
+    kentik/eagle-i:
+      select: latest(kentik.snmp.Uptime)/100
+      from: Metric
+      where: "provider = 'kentik-eagle-i'"
+      eventId: entity.guid


### PR DESCRIPTION
### Relevant information

Adding another vendor to the existing `EXT-ENVIRONMENT_SENSOR` entity type 

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
