### PR TITLE
Remove the as in the summary metrics

### DIFF
--- a/definitions/ext-dell_compellent/summary_metrics.yml
+++ b/definitions/ext-dell_compellent/summary_metrics.yml
@@ -10,7 +10,7 @@ failedDriveCount:
   title: Failed Drive Occurences
   unit: COUNT
   query:
-    select: count(status_code) as 'Drive Failures'
+    select: count(status_code)
     from: compellent_disks
     where: status = 'Down'
     eventId: entity.guid
@@ -19,7 +19,7 @@ usedCapacityPercent:
   title: Used Capacity %
   unit: PERCENTAGE
   query:
-    select: (sum(usedSpace)/sum(availableSpace))*100 as 'Avg Used %'
+    select: (sum(usedSpace)/sum(availableSpace))*100
     from: compellent_capacity_all
     where: objectType = 'StorageCenterStorageUsage'
     eventId: entity.guid

--- a/definitions/ext-dell_recoverpoint/summary_metrics.yml
+++ b/definitions/ext-dell_recoverpoint/summary_metrics.yml
@@ -11,6 +11,6 @@ usedCapacityPercent:
   title: Used Capacity %
   unit: PERCENTAGE
   query:
-    select: latest(usedCapacity/totalCapacity)*100 as 'Used %'
+    select: latest(usedCapacity/totalCapacity)*100
     from: rpa_capacity
     eventId: entity.guid

--- a/definitions/ext-dell_vmax/summary_metrics.yml
+++ b/definitions/ext-dell_vmax/summary_metrics.yml
@@ -19,6 +19,6 @@ usedCapacityPercent:
   title: Used Capacity %
   unit: PERCENTAGE
   query:
-    select: latest(effective_used_capacity_percent) as 'Used %'
+    select: latest(effective_used_capacity_percent)
     from: vmax_capacity
     eventId: entity.guid

--- a/definitions/ext-dell_vnx/summary_metrics.yml
+++ b/definitions/ext-dell_vnx/summary_metrics.yml
@@ -2,7 +2,7 @@ clusterUsedPercent:
   title: Cluster Used %
   unit: PERCENTAGE
   query:
-    select: latest((sizeUsed / sizeTotal))*100 as 'Used %'
+    select: latest((sizeUsed / sizeTotal))*100
     from: vnx_capacity
     where: key = 'cluster_capacity'
     eventId: entity.guid
@@ -20,6 +20,6 @@ hardwareUnhealthy:
   title: Hardware Status
   unit: COUNT
   query:
-    select: latest(healthID) as 'Status'
+    select: latest(healthID)
     from: vnx_hardware
     eventId: entity.guid

--- a/definitions/ext-dell_vplex/summary_metrics.yml
+++ b/definitions/ext-dell_vplex/summary_metrics.yml
@@ -2,34 +2,35 @@ portUnhealthy:
   title: Unhealthy Port/Link Count
   unit: COUNT
   query:
-    select: count(`operational-status-id`) as 'Unhealthy Occurrences'
+    select: count(`operational-status-id`)
     from: vplex_ports
-    where: "enabled != 'false' and (name NOT LIKE '%FC02%' and name NOT LIKE '%FC03%') and `operational-status-id` != 0"
+    where: enabled != 'false' and (name NOT LIKE '%FC02%' and name NOT LIKE '%FC03%') and `operational-status-id`
+      != 0
     eventId: entity.guid
 
 upsUnhealthy:
   title: Unhealthy UPS Count
   unit: COUNT
   query:
-    select: count(`operational-status-id`) as 'Unhealthy Occurrences'
+    select: count(`operational-status-id`)
     from: vplex_ups
-    where: "`operational-status-id` != 0"
+    where: '`operational-status-id` != 0'
     eventId: entity.guid
 
 engineUnhealthy:
   title: Unhealthy Engine Count
   unit: COUNT
   query:
-    select: count(`operational-status-id`) as 'Unhealthy Occurrences'
+    select: count(`operational-status-id`)
     from: vplex_engines
-    where: "`operational-status-id` != 0"
+    where: '`operational-status-id` != 0'
     eventId: entity.guid
 
 psuUnhealthy:
   title: Unhealthy PSU Count
   unit: COUNT
   query:
-    select: count(`operational-status-id`) as 'Unhealthy Occurrences'
+    select: count(`operational-status-id`)
     from: vplex_psu
-    where: "`operational-status-id` != 0"
+    where: '`operational-status-id` != 0'
     eventId: entity.guid

--- a/definitions/ext-dell_xtremio/summary_metrics.yml
+++ b/definitions/ext-dell_xtremio/summary_metrics.yml
@@ -2,7 +2,7 @@ usedCapacityPercent:
   title: Used Capacity %
   unit: PERCENTAGE
   query:
-    select: average(100 - `free-ud-ssd-space-in-percent`) as 'Used SSD %'
+    select: average(100 - `free-ud-ssd-space-in-percent`)
     from: XIO_capacity
     where: key = 'capacity'
     eventId: entity.guid
@@ -11,7 +11,7 @@ writeLatency:
   title: Write Latency
   unit: SECONDS
   query:
-    select: average(avg__wr_latency)/1000 as 'Latency (sec)'
+    select: average(avg__wr_latency)/1000
     from: XIOPerformance
     where: dataType = 'cluster'
     eventId: entity.guid
@@ -20,7 +20,7 @@ readLatency:
   title: Read Latency
   unit: SECONDS
   query:
-    select: average(avg__rd_latency)/1000 as 'Latency (sec)'
+    select: average(avg__rd_latency)/1000
     from: XIOPerformance
     where: dataType = 'cluster'
     eventId: entity.guid
@@ -29,7 +29,7 @@ packetDrops:
   title: Packet Drops
   unit: SECONDS
   query:
-    select: latest(avg__packet_drop_ratio) as 'Packet Drop Ratio'
+    select: latest(avg__packet_drop_ratio)
     from: XIOPerformance
     where: dataType = 'cluster'
     eventId: entity.guid

--- a/definitions/ext-pure/summary_metrics.yml
+++ b/definitions/ext-pure/summary_metrics.yml
@@ -2,7 +2,7 @@ failedDriveCount:
   title: Failed Drive Count
   unit: COUNT
   query:
-    select: count(status) as 'Drive Failures'
+    select: count(status)
     from: puredisks
     where: status = 'failed'
     eventId: entity.guid
@@ -11,7 +11,7 @@ usedCapacityPercent:
   title: Used Capacity %
   unit: PERCENTAGE
   query:
-    select: latest(total/capacity)*100 as 'Used %'
+    select: latest(total/capacity)*100
     from: pureCapacity
     eventId: entity.guid
 
@@ -19,7 +19,7 @@ readLatency:
   title: Read Latency
   unit: OPERATIONS_PER_SECOND
   query:
-    select: latest(usec_per_read_op)/1024 as 'I/O Read Latency'
+    select: latest(usec_per_read_op)/1024
     from: purePerf
     eventId: entity.guid
 
@@ -27,6 +27,6 @@ writeLatency:
   title: Write Latency
   unit: OPERATIONS_PER_SECOND
   query:
-    select: latest(usec_per_write_op)/1024 as 'I/O Write Latency'
+    select: latest(usec_per_write_op)/1024
     from: purePerf
     eventId: entity.guid

--- a/definitions/ext-synology/summary_metrics.yml
+++ b/definitions/ext-synology/summary_metrics.yml
@@ -2,7 +2,7 @@ volumeUsedPercent:
   title: Volume Used %
   unit: PERCENTAGE
   query:
-    select: latest(used_perc) as 'Used %'
+    select: latest(used_perc)
     from: synology
     where: key = 'capacity'
     eventId: entity.guid
@@ -11,7 +11,7 @@ failedDriveCount:
   title: Failed Drives
   unit: COUNT
   query:
-    select: count(longName) as 'Drive Failures'
+    select: count(longName)
     from: synology
     where: key = 'drives' and overview_status_id != 0
     eventId: entity.guid
@@ -20,7 +20,7 @@ cpuPercent:
   title: CPU %
   unit: PERCENTAGE
   query:
-    select: average(user_load)+average(system_load)+average(other_load) AS 'CPU %'
+    select: average(user_load)+average(system_load)+average(other_load)
     from: synology
     where: key = 'performance'
     eventId: entity.guid
@@ -29,7 +29,7 @@ usedRAM:
   title: RAM Used %
   unit: PERCENTAGE
   query:
-    select: latest(real_usage) as 'Memory usage'
+    select: latest(real_usage)
     from: synology
     where: key = 'performance'
     eventId: entity.guid

--- a/definitions/infra-ibmmq_manager/summary_metrics.yml
+++ b/definitions/infra-ibmmq_manager/summary_metrics.yml
@@ -2,7 +2,7 @@ connections_count:
   title: Connections
   unit: COUNT
   query:
-    select: latest(ibmmq_qmgr_connection_count) AS 'Connections'
+    select: latest(ibmmq_qmgr_connection_count)
     from: Metric
     eventId: entity.guid
 
@@ -10,7 +10,7 @@ queue_uncommitted_messages:
   title: Uncommitted messages average.
   unit: COUNT
   query:
-    select: average(ibmmq_queue_uncommitted_messages) AS 'Uncommitted messages'
+    select: average(ibmmq_queue_uncommitted_messages)
     from: Metric
     eventId: entity.guid
 
@@ -18,7 +18,7 @@ queue_input_handles:
   title: Queue input average.
   unit: COUNT
   query:
-    select: average(ibmmq_queue_input_handles) AS 'Queue input'
+    select: average(ibmmq_queue_input_handles)
     from: Metric
     eventId: entity.guid
 
@@ -26,6 +26,6 @@ queue_output_handles:
   title: Queue output average.
   unit: COUNT
   query:
-    select: average(ibmmq_queue_output_handles) AS 'Queue output'
+    select: average(ibmmq_queue_output_handles)
     from: Metric
     eventId: entity.guid


### PR DESCRIPTION
### Relevant information

Remove the `as` fields in the summary metric since this is not allowed in summary metrics queries. 
 
### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
