### PR TITLE
Add TTL for k8s tags in ext service

### DIFF
--- a/definitions/ext-service/definition.yml
+++ b/definitions/ext-service/definition.yml
@@ -43,8 +43,11 @@ synthesis:
       present: false
     tags:
       k8s.cluster.name:
+        ttl: P1DT
       k8s.deployment.name:
+        ttl: P1DT
       k8s.namespace.name:
+        ttl: P1DT
       telemetry.sdk.name:
         entityTagName: instrumentation.provider
       telemetry.sdk.language:
@@ -60,8 +63,11 @@ synthesis:
       value: opentelemetry
     tags:
       k8s.cluster.name:
+        ttl: P1DT
       k8s.deployment.name:
+        ttl: P1DT
       k8s.namespace.name:
+        ttl: P1DT
       telemetry.sdk.language:
         entityTagName: language
       telemetry.sdk.version:


### PR DESCRIPTION
### Relevant information

Configure 1 day of TTL for k8s. tags in ext-service.
This will help lower the number of tags from K8s

Format is in ISO-8601, I will do a follow up PR to document and add validations on this new field

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
