### PR TITLE
EXT-SERVICE: Fix ttl times for k8s tags

### DIFF
--- a/definitions/ext-service/definition.yml
+++ b/definitions/ext-service/definition.yml
@@ -43,11 +43,11 @@ synthesis:
       present: false
     tags:
       k8s.cluster.name:
-        ttl: P1DT
+        ttl: P1D
       k8s.deployment.name:
-        ttl: P1DT
+        ttl: P1D
       k8s.namespace.name:
-        ttl: P1DT
+        ttl: P1D
       telemetry.sdk.name:
         entityTagName: instrumentation.provider
       telemetry.sdk.language:
@@ -64,11 +64,11 @@ synthesis:
       value: opentelemetry
     tags:
       k8s.cluster.name:
-        ttl: P1DT
+        ttl: P1D
       k8s.deployment.name:
-        ttl: P1DT
+        ttl: P1D
       k8s.namespace.name:
-        ttl: P1DT
+        ttl: P1D
       telemetry.sdk.language:
         entityTagName: language
       telemetry.sdk.version:


### PR DESCRIPTION
### Relevant information

Fix the time for ttl tags.

The `T` is only needed when defining time.
Like: `P1DT30M` or `PT1H`

Will add validators once finished all the testings

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
