### PR TITLE
Add the access point prometheous

### DIFF
--- a/definitions/ext-access_point/definition.yml
+++ b/definitions/ext-access_point/definition.yml
@@ -1,18 +1,34 @@
 domain: EXT
 type: ACCESS_POINT
 synthesis:
-  name: device_name
-  identifier: device_name
-  encodeIdentifierInGUID: true
+  rules: 
+    - identifier: device_name
+      name: device_name
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: provider
+          value: kentik-wap
 
-  conditions:
-  - attribute: provider
-    value: kentik-wap
-
-  tags:
-    src_addr:
-      entityTagName: device_ip
-      multiValue: false
+      tags:
+        src_addr:
+          entityTagName: device_ip
+          multiValue: false
+    - identifier: serial
+      name: ip
+      debug: true
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: eventType
+          value: MetricRaw
+        - attribute: metricName
+          value: 'unifipoller_device_name'
+      tags:
+        model:
+        version:
+        mac:
+        ip:
+          entityTagName: device_ip
+          multiValue: false
 
 goldenTags:
 - device_ip

--- a/definitions/ext-access_point/tests/MetricRaw.json
+++ b/definitions/ext-access_point/tests/MetricRaw.json
@@ -1,0 +1,23 @@
+[
+  {
+    "id": "62250b20d958c90f0104bfe1",
+    "instance": "localhost:9130",
+    "instrumentation.name": "remote-write",
+    "instrumentation.provider": "prometheus",
+    "instrumentation.source": "prometheus-ap-server",
+    "instrumentation.version": "0.0.2",
+    "ip": "192.168.1.253",
+    "job": "unifipoller",
+    "mac": "78:45:58:f2:05:3d",
+    "metricName": "unifipoller_device_info",
+    "model": "UAP6MP",
+    "name": "78:45:58:f2:05:3d",
+    "newrelic.source": "prometheusAPI",
+    "prometheus_server": "prometheus-ap-server",
+    "serial": "784558F2053D",
+    "site_name": "Default (default)",
+    "source": "https://127.0.0.1:8443",
+    "type": "uap",
+    "version": "6.0.15.13647"
+  }
+]


### PR DESCRIPTION
### Relevant information

Add the access point from unifipoller and prometheous.

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
