### PR TITLE
Fix typo in VPC Ingress Bytes

### DIFF
--- a/definitions/ext-vpc_network/summary_metrics.yml
+++ b/definitions/ext-vpc_network/summary_metrics.yml
@@ -55,7 +55,7 @@ ingressBytes:
     aws-kinesis-firehose/vpc-flow-logs:
       select: sum(bytes*sample_rate)
       from: Log_VPC_Flows
-      where: "provider = 'firehose-vpc' and flow_direction = 'egress'"
+      where: "provider = 'firehose-vpc' and flow_direction = 'ingress'"
       eventId: entity.guid
 
 sampleRate:


### PR DESCRIPTION
### Relevant information

Looks like a minor copy-paste issue with VPC Flow Logs Ingress Bytes

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
