### PR TITLE
fix/network gm queries

### DIFF
--- a/definitions/ext-access_point/golden_metrics.yml
+++ b/definitions/ext-access_point/golden_metrics.yml
@@ -2,11 +2,7 @@ cpuUtilization:
   title: CPU
   unit: PERCENTAGE
   queries:
-    kentik/aruba-access-point:
-      select: average(kentik.snmp.CPU)
-      from: Metric
-      where: "provider = 'kentik-wap'"
-    kentik/unifi-access-point:
+    kentik:
       select: average(kentik.snmp.CPU)
       from: Metric
       where: "provider = 'kentik-wap'"
@@ -15,11 +11,7 @@ memoryUtilization:
   title: Memory
   unit: PERCENTAGE
   queries:
-    kentik/aruba-access-point:
-      select: average(kentik.snmp.MemoryUtilization)
-      from: Metric
-      where: "provider = 'kentik-wap'"
-    kentik/unifi-access-point:
+    kentik:
       select: average(kentik.snmp.MemoryUtilization)
       from: Metric
       where: "provider = 'kentik-wap'"

--- a/definitions/ext-access_point/summary_metrics.yml
+++ b/definitions/ext-access_point/summary_metrics.yml
@@ -8,12 +8,7 @@ cpuUtilization:
   title: CPU
   unit: PERCENTAGE
   queries:
-    kentik/aruba-access-point:
-      select: average(kentik.snmp.CPU)
-      from: Metric
-      where: "provider = 'kentik-wap'"
-      eventId: entity.guid
-    kentik/unifi-access-point:
+    kentik:
       select: average(kentik.snmp.CPU)
       from: Metric
       where: "provider = 'kentik-wap'"
@@ -23,12 +18,7 @@ memoryUtilization:
   title: Memory
   unit: PERCENTAGE
   queries:
-    kentik/aruba-access-point:
-      select: average(kentik.snmp.MemoryUtilization)
-      from: Metric
-      where: "provider = 'kentik-wap'"
-      eventId: entity.guid
-    kentik/unifi-access-point:
+    kentik:
       select: average(kentik.snmp.MemoryUtilization)
       from: Metric
       where: "provider = 'kentik-wap'"

--- a/definitions/ext-firewall/golden_metrics.yml
+++ b/definitions/ext-firewall/golden_metrics.yml
@@ -2,61 +2,73 @@ cpuUtilization:
   title: CPU Utilization (%)
   unit: PERCENTAGE
   queries:
-    kentik/cisco-asa:
-      select: max(kentik.snmp.CPU)
-      from: Metric
-      where: "provider = 'kentik-firewall'"
+    # Palo Alto firewalls
     kentik/palo-alto:
       select: max(kentik.snmp.hrProcessorLoad)
       from: Metric
       where: "provider = 'kentik-firewall'"
+    # Fortinet Fortigate firewalls
     kentik/fortinet-fortigate:
       select: max(kentik.snmp.fgSysCpuUsage)
       from: Metric
       where: "provider = 'kentik-firewall'"
+    # Cisco Firepower firewalls
     kentik/cisco-firepower:
       select: max(kentik.snmp.CPU)
       from: Metric
       where: "provider = 'kentik-firepower'"
+    # Other Kentik firewalls
+    kentik:
+      select: max(kentik.snmp.CPU)
+      from: Metric
+      where: "provider = 'kentik-firewall'"
 
 memoryUtilization:
   title: Memory Utilization (%)
   unit: PERCENTAGE
   queries:
-    kentik/cisco-asa:
-      select: max(kentik.snmp.MemoryUtilization)
-      from: Metric
-      where: "provider = 'kentik-firewall'"
+    # Palo Alto firewalls
     kentik/palo-alto:
       select: (max(kentik.snmp.hrStorageUsed) / max(kentik.snmp.hrStorageSize)) * 100
       from: Metric
       where: "provider = 'kentik-firewall' AND storage_description LIKE '%Management Memory%'"
+    # Fortinet Fortigate firewalls
     kentik/fortinet-fortigate:
       select: (max(kentik.snmp.fgSysMemUsage) / max(kentik.snmp.fgSysMemCapacity)) * 100
       from: Metric
       where: "provider = 'kentik-firewall'"
+    # Cisco Firepower firewalls
     kentik/cisco-firepower:
       select: max(kentik.snmp.MemoryUtilization)
       from: Metric
       where: "provider = 'kentik-firepower'"
+    # Other Kentik firewalls
+    kentik:
+      select: max(kentik.snmp.MemoryUtilization)
+      from: Metric
+      where: "provider = 'kentik-firewall'"
 
 sessionsTotal:
   title: Current Sessions
   unit: COUNT
   queries:
-    kentik/cisco-asa:
-      select: latest(kentik.snmp.crasNumSessions)
-      from: Metric
-      where: "provider = 'kentik-firewall'"
+    # Palo Alto firewalls
     kentik/palo-alto:
       select: max(kentik.snmp.panSessionActive)
       from: Metric
       where: "provider = 'kentik-firewall'"
+    # Fortinet Fortigate firewalls
     kentik/fortinet-fortigate:
       select: max(kentik.snmp.fgSysSesCount) + max(kentik.snmp.fgSysSes6Count)
       from: Metric
       where: "provider = 'kentik-firewall'"
+    # Cisco Firepower firewalls
     kentik/cisco-firepower:
       select: latest(kentik.snmp.crasNumSessions)
       from: Metric
       where: "provider = 'kentik-firepower'"
+    # Other Kentik firewalls
+    kentik:
+      select: max(kentik.snmp.crasNumSessions)
+      from: Metric
+      where: "provider = 'kentik-firewall'"

--- a/definitions/ext-firewall/summary_metrics.yml
+++ b/definitions/ext-firewall/summary_metrics.yml
@@ -8,73 +8,85 @@ cpuUtilization:
   title: CPU
   unit: PERCENTAGE
   queries:
-    kentik/cisco-asa:
-      select: max(kentik.snmp.CPU)
-      from: Metric
-      where: "provider = 'kentik-firewall'"
-      eventId: entity.guid
+    # Palo Alto firewalls
     kentik/palo-alto:
       select: max(kentik.snmp.hrProcessorLoad)
       from: Metric
       where: "provider = 'kentik-firewall'"
       eventId: entity.guid
+    # Fortinet Fortigate firewalls
     kentik/fortinet-fortigate:
       select: max(kentik.snmp.fgSysCpuUsage)
       from: Metric
       where: "provider = 'kentik-firewall'"
       eventId: entity.guid
+    # Cisco Firepower firewalls
     kentik/cisco-firepower:
       select: max(kentik.snmp.CPU)
       from: Metric
       where: "provider = 'kentik-firepower'"
+      eventId: entity.guid
+    # Other Kentik firewalls
+    kentik:
+      select: max(kentik.snmp.CPU)
+      from: Metric
+      where: "provider = 'kentik-firewall'"
       eventId: entity.guid
 
 memoryUtilization:
   title: Memory
   unit: PERCENTAGE
   queries:
-    kentik/cisco-asa:
-      select: max(kentik.snmp.MemoryUtilization)
-      from: Metric
-      where: "provider = 'kentik-firewall'"
-      eventId: entity.guid
+    # Palo Alto firewalls
     kentik/palo-alto:
       select: (max(kentik.snmp.hrStorageUsed) / max(kentik.snmp.hrStorageSize)) * 100
       from: Metric
       where: "provider = 'kentik-firewall' AND storage_description LIKE '%Management Memory%'"
       eventId: entity.guid
+    # Fortinet Fortigate firewalls
     kentik/fortinet-fortigate:
       select: (max(kentik.snmp.fgSysMemUsage) / max(kentik.snmp.fgSysMemCapacity)) * 100
       from: Metric
       where: "provider = 'kentik-firewall'"
       eventId: entity.guid
+    # Cisco Firepower firewalls
     kentik/cisco-firepower:
       select: max(kentik.snmp.MemoryUtilization)
       from: Metric
       where: "provider = 'kentik-firepower'"
+      eventId: entity.guid
+    # Other Kentik firewalls
+    kentik:
+      select: max(kentik.snmp.MemoryUtilization)
+      from: Metric
+      where: "provider = 'kentik-firewall'"
       eventId: entity.guid
 
 sessionsTotal:
   title: Current Sessions
   unit: COUNT
   queries:
-    kentik/cisco-asa:
-      select: latest(kentik.snmp.crasNumSessions)
-      from: Metric
-      where: "provider = 'kentik-firewall'"
-      eventId: entity.guid
+    # Palo Alto firewalls
     kentik/palo-alto:
       select: max(kentik.snmp.panSessionActive)
       from: Metric
       where: "provider = 'kentik-firewall'"
       eventId: entity.guid
+    # Fortinet Fortigate firewalls
     kentik/fortinet-fortigate:
       select: max(kentik.snmp.fgSysSesCount) + max(kentik.snmp.fgSysSes6Count)
       from: Metric
       where: "provider = 'kentik-firewall'"
       eventId: entity.guid
+    # Cisco Firepower firewalls
     kentik/cisco-firepower:
       select: latest(kentik.snmp.crasNumSessions)
       from: Metric
       where: "provider = 'kentik-firepower'"
+      eventId: entity.guid
+    # Other Kentik firewalls
+    kentik:
+      select: latest(kentik.snmp.crasNumSessions)
+      from: Metric
+      where: "provider = 'kentik-firewall'"
       eventId: entity.guid

--- a/definitions/ext-nas/golden_metrics.yml
+++ b/definitions/ext-nas/golden_metrics.yml
@@ -2,11 +2,13 @@ cpuUtilization:
   title: CPU
   unit: PERCENTAGE
   queries:
+    # Netgear ReadyNAS
     kentik/readynas:
       select: latest(100 - kentik.snmp.ssCpuIdle)
       from: Metric
-      where: "provider = 'kentik-nas' AND SysObjectID = '.1.3.6.1.4.1.4526.100.16'"
-    kentik/netapp-cluster:
+      where: "provider = 'kentik-nas'"
+    # Most devices
+    kentik:
       select: average(kentik.snmp.CPU)
       from: Metric
       where: "provider = 'kentik-nas'"

--- a/definitions/ext-nas/summary_metrics.yml
+++ b/definitions/ext-nas/summary_metrics.yml
@@ -8,12 +8,14 @@ cpuUtilization:
   title: CPU
   unit: PERCENTAGE
   queries:
+    # Netgear ReadyNAS
     kentik/readynas:
       select: latest(100 - kentik.snmp.ssCpuIdle)
       from: Metric
-      where: "provider = 'kentik-nas' AND SysObjectID = '.1.3.6.1.4.1.4526.100.16'"
+      where: "provider = 'kentik-nas'"
       eventId: entity.guid
-    kentik/netapp-cluster:
+    # Most devices
+    kentik:
       select: average(kentik.snmp.CPU)
       from: Metric
       where: "provider = 'kentik-nas'"

--- a/definitions/ext-router/golden_metrics.yml
+++ b/definitions/ext-router/golden_metrics.yml
@@ -2,8 +2,8 @@ cpuUtilization:
   title: CPU Utilization (%)
   unit: PERCENTAGE
   queries:
-    # Cisco ASR profiles (default)
-    kentik/cisco-asr:
+    # Kentik profiles (default)
+    kentik:
       select: average(kentik.snmp.CPU)
       from: Metric
       where: "provider = 'kentik-router'"
@@ -16,8 +16,8 @@ memoryUtilization:
   title: Memory Utilization (%)
   unit: PERCENTAGE
   queries:
-    # Cisco ASR profiles (default)
-    kentik/cisco-asr:
+    # Kentik profiles (default)
+    kentik:
       select: average(kentik.snmp.MemoryUtilization)
       from: Metric
       where: "provider = 'kentik-router'"
@@ -30,8 +30,8 @@ receiveErrors:
   title: Aggregate Receive Errors (count)
   unit: COUNT
   queries:
-    # Cisco ASR profiles (default)
-    kentik/cisco-asr:
+    # Kentik profiles (default)
+    kentik:
       select: sum(kentik.snmp.ifInErrors)
       from: Metric
       where: "provider = 'kentik-router'"
@@ -44,8 +44,8 @@ transmitErrors:
   title: Aggregate Transmit Errors (count)
   unit: COUNT
   queries:
-    # Cisco ASR profiles (default)
-    kentik/cisco-asr:
+    # Kentik profiles (default)
+    kentik:
       select: sum(kentik.snmp.ifOutErrors)
       from: Metric
       where: "provider = 'kentik-router'"

--- a/definitions/ext-router/summary_metrics.yml
+++ b/definitions/ext-router/summary_metrics.yml
@@ -8,8 +8,8 @@ cpuUtilization:
   title: CPU
   unit: PERCENTAGE
   queries:
-    # Cisco ASR profiles (default)
-    kentik/cisco-asr:
+    # Kentik profiles (default)
+    kentik:
       select: average(kentik.snmp.CPU)
       from: Metric
       where: "provider = 'kentik-router'"
@@ -24,8 +24,8 @@ memoryUtilization:
   title: Memory
   unit: PERCENTAGE
   queries:
-    # Cisco ASR profiles (default)
-    kentik/cisco-asr:
+    # Kentik profiles (default)
+    kentik:
       select: average(kentik.snmp.MemoryUtilization)
       from: Metric
       where: "provider = 'kentik-router'"
@@ -40,8 +40,8 @@ receiveErrors:
   title: Receive Errors
   unit: COUNT
   queries:
-    # Cisco ASR profiles (default)
-    kentik/cisco-asr:
+    # Kentik profiles (default)
+    kentik:
       select: sum(kentik.snmp.ifInErrors)
       from: Metric
       where: "provider = 'kentik-router'"
@@ -56,8 +56,8 @@ transmitErrors:
   title: Transmit Errors
   unit: COUNT
   queries:
-    # Cisco ASR profiles (default)
-    kentik/cisco-asr:
+    # Kentik profiles (default)
+    kentik:
       select: sum(kentik.snmp.ifOutErrors)
       from: Metric
       eventId: entity.guid

--- a/definitions/ext-switch/golden_metrics.yml
+++ b/definitions/ext-switch/golden_metrics.yml
@@ -2,61 +2,38 @@ cpuUtilization:
   title: CPU Utilization (%)
   unit: PERCENTAGE
   queries:
-    kentik/cisco-catalyst:
-      select: average(kentik.snmp.CPU)
-      from: Metric
-      where: "provider = 'kentik-switch'"
-    kentik/cisco-nexus:
-      select: average(kentik.snmp.CPU)
-      from: Metric
-      where: "provider = 'kentik-switch'"
-    kentik/force10:
-      select: average(kentik.snmp.CPU)
-      from: Metric
-      where: "provider = 'kentik-switch'"
+    # Arista switches
     kentik/arista:
       select: average(kentik.snmp.CPU)
       from: Metric
       where: "provider = 'kentik-switch' AND Index = '.1'"
+    # Most devices
+    kentik:
+      select: average(kentik.snmp.CPU)
+      from: Metric
+      where: "provider = 'kentik-switch'"
 
 memoryUtilization:
   title: Memory Utilization (%)
   unit: PERCENTAGE
   queries:
-    kentik/cisco-catalyst:
-      select: average(kentik.snmp.MemoryUtilization)
-      from: Metric
-      where: "provider = 'kentik-switch'"
-    kentik/cisco-nexus:
-      select: average(kentik.snmp.MemoryUtilization)
-      from: Metric
-      where: "provider = 'kentik-switch'"
-    kentik/force10:
-      select: average(kentik.snmp.MemoryUtilization)
-      from: Metric
-      where: "provider = 'kentik-switch'"
+    # Arista switches
     kentik/arista:
       select: average(kentik.snmp.MemoryUtilization)
       from: Metric
       where: "provider = 'kentik-switch' AND storage_description = 'RAM'"
+    # Most devices
+    kentik:
+      select: average(kentik.snmp.MemoryUtilization)
+      from: Metric
+      where: "provider = 'kentik-switch'"
 
 receiveErrors:
   title: Aggregate Receive Errors (count)
   unit: COUNT
   queries:
-    kentik/cisco-catalyst:
-      select: sum(kentik.snmp.ifInErrors)
-      from: Metric
-      where: "provider = 'kentik-switch'"
-    kentik/cisco-nexus:
-      select: sum(kentik.snmp.ifInErrors)
-      from: Metric
-      where: "provider = 'kentik-switch'"
-    kentik/force10:
-      select: sum(kentik.snmp.ifInErrors)
-      from: Metric
-      where: "provider = 'kentik-switch'"
-    kentik/arista:
+    # All Kentik switches
+    kentik:
       select: sum(kentik.snmp.ifInErrors)
       from: Metric
       where: "provider = 'kentik-switch'"
@@ -65,19 +42,8 @@ transmitErrors:
   title: Aggregate Transmit Errors (count)
   unit: COUNT
   queries:
-    kentik/cisco-catalyst:
-      select: sum(kentik.snmp.ifOutErrors)
-      from: Metric
-      where: "provider = 'kentik-switch'"
-    kentik/cisco-nexus:
-      select: sum(kentik.snmp.ifOutErrors)
-      from: Metric
-      where: "provider = 'kentik-switch'"
-    kentik/force10:
-      select: sum(kentik.snmp.ifOutErrors)
-      from: Metric
-      where: "provider = 'kentik-switch'"
-    kentik/arista:
+    # All Kentik switches
+    kentik:
       select: sum(kentik.snmp.ifOutErrors)
       from: Metric
       where: "provider = 'kentik-switch'"

--- a/definitions/ext-switch/summary_metrics.yml
+++ b/definitions/ext-switch/summary_metrics.yml
@@ -1,3 +1,4 @@
+# All switches
 ipAddress:
   title: IP Address
   unit: STRING
@@ -8,72 +9,42 @@ cpuUtilization:
   title: CPU
   unit: PERCENTAGE
   queries:
-    kentik/cisco-catalyst:
-      select: average(kentik.snmp.CPU)
-      from: Metric
-      where: "provider = 'kentik-switch'"
-      eventId: entity.guid
-    kentik/cisco-nexus:
-      select: average(kentik.snmp.CPU)
-      from: Metric
-      where: "provider = 'kentik-switch'"
-      eventId: entity.guid
-    kentik/force10:
-      select: average(kentik.snmp.CPU)
-      from: Metric
-      where: "provider = 'kentik-switch'"
-      eventId: entity.guid
+    # Arista switches
     kentik/arista:
       select: average(kentik.snmp.CPU)
       from: Metric
       where: "provider = 'kentik-switch' AND Index = '.1'"
+      eventId: entity.guid
+    # Most devices
+    kentik:
+      select: average(kentik.snmp.CPU)
+      from: Metric
+      where: "provider = 'kentik-switch'"
       eventId: entity.guid
 
 memoryUtilization:
   title: Memory
   unit: PERCENTAGE
   queries:
-    kentik/cisco-catalyst:
-      select: average(kentik.snmp.MemoryUtilization)
-      from: Metric
-      where: "provider = 'kentik-switch'"
-      eventId: entity.guid
-    kentik/cisco-nexus:
-      select: average(kentik.snmp.MemoryUtilization)
-      from: Metric
-      where: "provider = 'kentik-switch'"
-      eventId: entity.guid
-    kentik/force10:
-      select: average(kentik.snmp.MemoryUtilization)
-      from: Metric
-      where: "provider = 'kentik-switch'"
-      eventId: entity.guid
+    # Arista switches
     kentik/arista:
       select: average(kentik.snmp.MemoryUtilization)
       from: Metric
       where: "provider = 'kentik-switch' AND storage_description = 'RAM'"
+      eventId: entity.guid
+    # Most devices
+    kentik:
+      select: average(kentik.snmp.MemoryUtilization)
+      from: Metric
+      where: "provider = 'kentik-switch'"
       eventId: entity.guid
 
 receiveErrors:
   title: Receive Errors
   unit: COUNT
   queries:
-    kentik/cisco-catalyst:
-      select: sum(kentik.snmp.ifInErrors)
-      from: Metric
-      where: "provider = 'kentik-switch'"
-      eventId: entity.guid
-    kentik/cisco-nexus:
-      select: sum(kentik.snmp.ifInErrors)
-      from: Metric
-      where: "provider = 'kentik-switch'"
-      eventId: entity.guid
-    kentik/force10:
-      select: sum(kentik.snmp.ifInErrors)
-      from: Metric
-      where: "provider = 'kentik-switch'"
-      eventId: entity.guid
-    kentik/arista:
+    # All Kentik switches
+    kentik:
       select: sum(kentik.snmp.ifInErrors)
       from: Metric
       where: "provider = 'kentik-switch'"
@@ -83,22 +54,8 @@ transmitErrors:
   title: Transmit Errors
   unit: COUNT
   queries:
-    kentik/cisco-catalyst:
-      select: sum(kentik.snmp.ifOutErrors)
-      from: Metric
-      where: "provider = 'kentik-switch'"
-      eventId: entity.guid
-    kentik/cisco-nexus:
-      select: sum(kentik.snmp.ifOutErrors)
-      from: Metric
-      where: "provider = 'kentik-switch'"
-      eventId: entity.guid
-    kentik/force10:
-      select: sum(kentik.snmp.ifOutErrors)
-      from: Metric
-      where: "provider = 'kentik-switch'"
-      eventId: entity.guid
-    kentik/arista:
+    # All Kentik switches
+    kentik:
       select: sum(kentik.snmp.ifOutErrors)
       from: Metric
       where: "provider = 'kentik-switch'"


### PR DESCRIPTION
### Relevant information

updating several network entities to support "default"/"catch-all" rule for the GM Harvester service. This change removes some of the `instrumentation.provider/instrumentation.name` patterns for GM and SM definitions and adds the more generic `instrumentation.provider` pattern to capture all telemetry for an entity type coming from Kentik's ktranslate container.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
