### PR TITLE
Add Postman Monitor entity type

### DIFF
--- a/definitions/ext-postman_monitor/definition.yml
+++ b/definitions/ext-postman_monitor/definition.yml
@@ -3,24 +3,12 @@ type: POSTMAN_MONITOR
 
 synthesis:
   rules:
-  - identifier: monitor.id
-    name: monitor.name
-    encodeIdentifierInGUID: true
-    conditions:
-    - attribute: metricName
-      prefix: postman.monitor
-  
-  tags:
-    region:
-    collection.id:
-    collection.name:
-    monitor.id:
-    monitor.name:
-    environment.id:
-    environment.name:
-    user.id:
-    user.name:
-    region:
+    - identifier: monitor.id
+      name: monitor.name
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: metricName
+          prefix: postman.monitor
 
 dashboardTemplates:
   postman-monitor:

--- a/definitions/ext-postman_monitor/definition.yml
+++ b/definitions/ext-postman_monitor/definition.yml
@@ -1,0 +1,31 @@
+domain: EXT
+type: POSTMAN_MONITOR
+
+synthesis:
+  name: monitor.name
+  identifier: monitor.id
+  encodeIdentifierInGUID: true
+
+  conditions:
+    - attribute: metricName
+      prefix: postman.monitor
+
+  tags:
+    region:
+    collection.id:
+    collection.name:
+    monitor.id:
+    monitor.name:
+    environment.id:
+    environment.name:
+    user.id:
+    user.name:
+    region:
+
+dashboardTemplates:
+  postman-monitor:
+    template: postman-monitor-dashboard.json
+
+configuration:
+  entityExpirationTime: EIGHT_DAYS
+  alertable: true

--- a/definitions/ext-postman_monitor/definition.yml
+++ b/definitions/ext-postman_monitor/definition.yml
@@ -2,14 +2,14 @@ domain: EXT
 type: POSTMAN_MONITOR
 
 synthesis:
-  name: monitor.name
-  identifier: monitor.id
-  encodeIdentifierInGUID: true
-
-  conditions:
+  rules:
+  - identifier: monitor.id
+    name: monitor.name
+    encodeIdentifierInGUID: true
+    conditions:
     - attribute: metricName
       prefix: postman.monitor
-
+  
   tags:
     region:
     collection.id:

--- a/definitions/ext-postman_monitor/postman-monitor-dashboard.json
+++ b/definitions/ext-postman_monitor/postman-monitor-dashboard.json
@@ -19,8 +19,7 @@
           "title": "",
           "rawConfiguration": {
             "text": "![Postman logo](https://media.slid.es/uploads/327261/images/5065937/pm-logo-vert.png)"
-          },
-          "linkedEntityGuids": null
+          }
         },
         {
           "visualization": {
@@ -46,8 +45,7 @@
             "yAxisLeft": {
               "zero": true
             }
-          },
-          "linkedEntityGuids": null
+          }
         },
         {
           "visualization": {
@@ -73,8 +71,7 @@
             "yAxisLeft": {
               "zero": true
             }
-          },
-          "linkedEntityGuids": null
+          }
         },
         {
           "visualization": {
@@ -103,8 +100,7 @@
             "yAxisLeft": {
               "zero": true
             }
-          },
-          "linkedEntityGuids": null
+          }
         },
         {
           "visualization": {
@@ -126,8 +122,7 @@
               }
             ],
             "thresholds": []
-          },
-          "linkedEntityGuids": null
+          }
         },
         {
           "visualization": {
@@ -149,8 +144,7 @@
               }
             ],
             "thresholds": []
-          },
-          "linkedEntityGuids": null
+          }
         },
         {
           "visualization": {
@@ -172,8 +166,7 @@
               }
             ],
             "thresholds": []
-          },
-          "linkedEntityGuids": null
+          }
         },
         {
           "visualization": {
@@ -195,8 +188,7 @@
               }
             ],
             "thresholds": []
-          },
-          "linkedEntityGuids": null
+          }
         }
       ]
     }

--- a/definitions/ext-postman_monitor/postman-monitor-dashboard.json
+++ b/definitions/ext-postman_monitor/postman-monitor-dashboard.json
@@ -1,0 +1,204 @@
+{
+  "name": "Postman Monitor",
+  "description": null,
+  "pages": [
+    {
+      "name": "Postman Monitor",
+      "description": null,
+      "widgets": [
+        {
+          "visualization": {
+            "id": "viz.markdown"
+          },
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "height": 2,
+            "width": 2
+          },
+          "title": "",
+          "rawConfiguration": {
+            "text": "![Postman logo](https://media.slid.es/uploads/327261/images/5065937/pm-logo-vert.png)"
+          },
+          "linkedEntityGuids": null
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 3,
+            "row": 1,
+            "height": 2,
+            "width": 10
+          },
+          "title": "Total Average Latency",
+          "rawConfiguration": {
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(postman.monitor.run.totallatency) as 'Average of total latency' FROM Metric COMPARE WITH 1 month ago TIMESERIES SINCE 1800 seconds ago"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          },
+          "linkedEntityGuids": null
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 1,
+            "row": 3,
+            "height": 3,
+            "width": 6
+          },
+          "title": "Requests Over Time",
+          "rawConfiguration": {
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum (postman.monitor.run.requestcount) as 'Requests' FROM Metric COMPARE WITH 1 month ago TIMESERIES SINCE 1800 seconds ago"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          },
+          "linkedEntityGuids": null
+        },
+        {
+          "visualization": {
+            "id": "viz.stacked-bar"
+          },
+          "layout": {
+            "column": 7,
+            "row": 3,
+            "height": 3,
+            "width": 6
+          },
+          "title": "Average request bytes ",
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(postman.monitor.request.requestbytes) as 'Bytes' FROM Metric TIMESERIES FACET `request.name` SINCE 1800 seconds ago"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          },
+          "linkedEntityGuids": null
+        },
+        {
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "layout": {
+            "column": 1,
+            "row": 6,
+            "height": 3,
+            "width": 3
+          },
+          "title": "HTTP 4xx responses",
+          "rawConfiguration": {
+            "dataFormatters": [],
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(postman.monitor.run.httpstatus4xx) as '4xx responses' FROM Metric SINCE 1800 seconds ago"
+              }
+            ],
+            "thresholds": []
+          },
+          "linkedEntityGuids": null
+        },
+        {
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "layout": {
+            "column": 4,
+            "row": 6,
+            "height": 3,
+            "width": 3
+          },
+          "title": "HTTP 5xx responses",
+          "rawConfiguration": {
+            "dataFormatters": [],
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(postman.monitor.run.httpstatus5xx) as '5xx responses' FROM Metric SINCE 1800 seconds ago"
+              }
+            ],
+            "thresholds": []
+          },
+          "linkedEntityGuids": null
+        },
+        {
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "layout": {
+            "column": 7,
+            "row": 6,
+            "height": 3,
+            "width": 3
+          },
+          "title": "Errors",
+          "rawConfiguration": {
+            "dataFormatters": [],
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum (postman.monitor.run.errors) as 'errors' FROM Metric SINCE 1800 seconds ago"
+              }
+            ],
+            "thresholds": []
+          },
+          "linkedEntityGuids": null
+        },
+        {
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "layout": {
+            "column": 10,
+            "row": 6,
+            "height": 3,
+            "width": 3
+          },
+          "title": "Failed tests",
+          "rawConfiguration": {
+            "dataFormatters": [],
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(postman.monitor.run.failedtests) as 'Tests' FROM Metric SINCE 1800 seconds ago"
+              }
+            ],
+            "thresholds": []
+          },
+          "linkedEntityGuids": null
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Relevant information

Added a Postman Monitor entity type based off of [the Postman quickstart](https://github.com/newrelic/newrelic-quickstarts/tree/main/quickstarts/postman).

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
