### PR TITLE
TTL k8s tags from pixie

### DIFF
--- a/definitions/ext-service/definition.yml
+++ b/definitions/ext-service/definition.yml
@@ -124,8 +124,10 @@ synthesis:
     tags:
       k8s.cluster.name:
         entityTagName: k8s.clusterName
+        ttl: P1D
       k8s.namespace.name:
         entityTagName: k8s.namespaceName
+        ttl: P1D
 
     # IMPORTANT:
     # This rule matches on any telemetry with service.name 


### PR DESCRIPTION
### Relevant information

In https://github.com/newrelic/entity-definitions/pull/535 I added TTL for K8s tags but forgot about the pixie ones.

This PR also adds the same TTL for the tags when they come from pixie

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
