### PR TITLE
Validate ttl

### DIFF
--- a/docs/synthesis.md
+++ b/docs/synthesis.md
@@ -198,10 +198,14 @@ synthesis:
         entityTagNames: [container.state, k8s.status]
 ```
 
+- TTL tags
+
+
 | **Name** | **Type** | **Required** | **Description**  |
 | -------- | -------- | ------------ | ---------------- |
 | multiValue | Boolean  | No | If set to `false`, any update will replace all existing values in the tag, making it a tag with only one value. Defaults to `true`. |
 | entityTagNames | List<String> | No | If provided, the attribute value will be copied into a tag using each value of the list as the key. Defaults to list with the attribute name. |
+| ttl | String | No | If provided, the tag will be removed if it's not reported again on the given period of time, the period is defined in [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601#Durations). |
 
 #### Default tags
 

--- a/validator/schemas/entity-schema-v1.json
+++ b/validator/schemas/entity-schema-v1.json
@@ -244,41 +244,37 @@
                 "$id": "#/synthesis/rules/items/tags",
                 "type": "object",
                 "description": "Tags associated to the entity that can be extracted from the metrics information received.",
-                "anyOf": [{
-                  "$id": "#/properties/tags/items/anyOf/0",
-                  "type": "object",
-                  "title": "Tag configuration",
-                  "description": "The configuration of the tag being synthesized",
-                  "examples": [{
-                    "multiValue": "false",
-                    "entityTagName": "intendedTagName"
-                  }],
-                  "properties": {
-                    "multiValue": {
-                      "$id": "#/properties/tags/items/anyOf/0/properties/multiValue",
-                      "type": "boolean",
-                      "title": "If the tag should allow a list of string values or a single string value"
-                    },
-                    "entityTagName": {
-                      "$id": "#/properties/tags/items/anyOf/0/properties/entityTagName",
-                      "type": "string",
-                      "title": "The key of the tag to be created with the value of the provided attribute"
-                    },
-                    "entityTagNames": {
-                      "$id": "#/properties/tags/items/anyOf/0/properties/entityTagNames",
-                      "type": "array",
-                      "title": "A list of tag names to create from this attribute",
-                      "items": {
-                        "$id": "#/properties/tags/items/anyOf/0/properties/entityTagNames/items",
-                        "anyOf": [{
-                          "$id": "#/properties/tags/items/anyOf/0/properties/entityTagNames/items/0",
-                          "type": "string",
-                          "title": "The key of the tag to be created with the value of the provided attribute"
-                        }]
+                "patternProperties": {
+                  "^": {
+                    "type": ["object", "null"],
+                    "properties": {
+                      "multiValue": {
+                        "$id": "#/properties/tags/items/anyOf/0/properties/multiValue",
+                        "type": "boolean",
+                        "title": "If the tag should allow a list of string values or a single string value"
+                      },
+                      "entityTagName": {
+                        "$id": "#/properties/tags/items/anyOf/0/properties/entityTagName",
+                        "type": "string",
+                        "title": "The key of the tag to be created with the value of the provided attribute"
+                      },
+                      "entityTagNames": {
+                        "$id": "#/properties/tags/items/anyOf/0/properties/entityTagNames",
+                        "type": "array",
+                        "title": "A list of tag names to create from this attribute",
+                        "items": {
+                          "$id": "#/properties/tags/items/anyOf/0/properties/entityTagNames/items",
+                          "anyOf": [{
+                            "$id": "#/properties/tags/items/anyOf/0/properties/entityTagNames/items/0",
+                            "type": "string",
+                            "title": "The key of the tag to be created with the value of the provided attribute"
+                          }]
+                        }
                       }
-                    }
-                  }
-                }]
+                    },
+                    "additionalProperties": false
+                }
+                }
               },
               "legacyFeatures": {
                 "$id": "#/synthesis/rules/items/legacyFeatures",

--- a/validator/schemas/entity-schema-v1.json
+++ b/validator/schemas/entity-schema-v1.json
@@ -249,27 +249,32 @@
                     "type": ["object", "null"],
                     "properties": {
                       "multiValue": {
-                        "$id": "#/properties/tags/items/anyOf/0/properties/multiValue",
+                        "$id": "#/synthesis/rules/items/tags/properties/multiValue",
                         "type": "boolean",
                         "title": "If the tag should allow a list of string values or a single string value"
                       },
                       "entityTagName": {
-                        "$id": "#/properties/tags/items/anyOf/0/properties/entityTagName",
+                        "$id": "#/synthesis/rules/items/tags/properties/entityTagName",
                         "type": "string",
                         "title": "The key of the tag to be created with the value of the provided attribute"
                       },
                       "entityTagNames": {
-                        "$id": "#/properties/tags/items/anyOf/0/properties/entityTagNames",
+                        "$id": "#/synthesis/rules/items/tags/properties/entityTagNames",
                         "type": "array",
                         "title": "A list of tag names to create from this attribute",
                         "items": {
-                          "$id": "#/properties/tags/items/anyOf/0/properties/entityTagNames/items",
+                          "$id": "#/synthesis/rules/items/tags/properties/entityTagNames/items",
                           "anyOf": [{
-                            "$id": "#/properties/tags/items/anyOf/0/properties/entityTagNames/items/0",
+                            "$id": "#/synthesis/rules/items/tags/properties/entityTagNames/items/0",
                             "type": "string",
                             "title": "The key of the tag to be created with the value of the provided attribute"
                           }]
                         }
+                      },
+                      "ttl": {
+                        "$id": "#/synthesis/rules/items/tags/properties/ttl",
+                        "type": "string",
+                        "title": "The TTL to expire this tag on. In ISO-8601 format"
                       }
                     },
                     "additionalProperties": false


### PR DESCRIPTION
### Relevant information

Validate the TTL field on the schema.

I noticed that we where not actually validating anything on the tags field since `additionalProperties` was not set to false.
So, as with TTL, any property could be set in the tags section.

I changed `properties` into `patternProperties` to allow any key under the tags map and it validates if it either has a map with the expected keys or a null

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
