### PR TITLE
feat: More convenient dashboard schema validation for linkedEntityGuids

### DIFF
--- a/validator/schemas/dashboard-schema-v1.json
+++ b/validator/schemas/dashboard-schema-v1.json
@@ -61,9 +61,6 @@
                   "$id": "#/properties/pages/items/anyOf/0/properties/widgets/items/anyOf/0",
                   "type": "object",
                   "title": "The widget definition",
-                  "not": {
-                    "required": ["linkedEntityGuids"]
-                  },
                   "required": [
                     "visualization",
                     "layout",
@@ -71,6 +68,13 @@
                     "rawConfiguration"
                   ],
                   "properties": {
+                    "linkedEntityGuids": {
+                      "$id": "#/properties/pages/items/anyOf/0/properties/widgets/items/anyOf/0/properties/linkedEntityGuids",
+                      "type": "null",
+                      "title": "The linked entity guids",
+                      "description": "Unsupported guids of linked entities. Only allowed with a null value. The dashboard exporter will always provide the field, so it's quite common that it is present. It is inconvenient to remove those fields manually, so it's syntactically allowed but only with a null value.",
+                      "const": null
+                    },
                     "visualization": {
                       "$id": "#/properties/pages/items/anyOf/0/properties/widgets/items/anyOf/0/properties/visualization",
                       "type": "object",


### PR DESCRIPTION
### Relevant information

Allowed the property linkedEntityGuids in the dashboard schema though it is unsupported.
The dashboard exporter will always provide the field, so it's quite common that it is present. It is inconvenient to remove those fields manually, so it's syntactically allowed but only with a null value.


### Checklist

* [X] I've read the guidelines and understand the acceptance criteria.
* ~~[ ] The value of the attribute marked as `identifier` will be unique and valid.~~ Does not apply here. 
* ~~[ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.~~ Does not apply here.
