### PR TITLE
fix: Modified sanitization regex intended to remove trailing commas s…

### DIFF
--- a/validator/tools/tests/dashboards/rawDashboard.json
+++ b/validator/tools/tests/dashboards/rawDashboard.json
@@ -94,16 +94,17 @@
             "height": 3,
             "width": 4
           },
-          "title": "Packet Loss (%)",
+          "title": "Trailing commas test case",
           "rawConfiguration": {
+            "dataFormatters": ["one", "two",],
             "legend": {
-              "enabled": true
+              "enabled": true,
             },
             "nrqlQueries": [
               {
                 "accountId": 10,
                 "query": "FROM Metric SELECT latest(kentik.synth.lost_pct) FACET entity.name WHERE provider = 'kentik-network-synthetic' TIMESERIES"
-              }
+              },
             ],
             "yAxisLeft": {
               "max": 100,
@@ -112,6 +113,30 @@
             }
           },
           "linkedEntityGuids": null
+        },
+        {
+          "visualization": {
+            "id": "viz.table"
+          },
+          "layout": {
+            "column": 1,
+            "row": 12,
+            "height": 3,
+            "width": 4
+          },
+          "title": "Regression test case to not accidentally break nrql queries with regex substitution 'Remove trailing commas'",
+          "rawConfiguration": {
+            "dataFormatters": [],
+            "facet": {
+              "showOtherSeries": false
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT round(latest(kentik.snmp.hrStorageUsed)*100/latest(kentik.snmp.hrStorageSize),.01) AS 'Used %', round(latest(kentik.snmp.hrStorageSize)*1e-6,.01) AS 'Total MBytes', round(latest(kentik.snmp.hrStorageUsed)*1e-6,.01) AS 'Used MBytes' WHERE `mib-table` = 'hrStorage' FACET storage_description LIMIT MAX"
+              }
+            ]
+          }
         }
       ]
     }

--- a/validator/tools/tests/dashboards/sanitizedDashboard.json
+++ b/validator/tools/tests/dashboards/sanitizedDashboard.json
@@ -90,8 +90,9 @@
             "height": 3,
             "width": 4
           },
-          "title": "Packet Loss (%)",
+          "title": "Trailing commas test case",
           "rawConfiguration": {
+            "dataFormatters": ["one", "two"],
             "legend": {
               "enabled": true
             },
@@ -106,6 +107,30 @@
               "min": 0,
               "zero": false
             }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.table"
+          },
+          "layout": {
+            "column": 1,
+            "row": 12,
+            "height": 3,
+            "width": 4
+          },
+          "title": "Regression test case to not accidentally break nrql queries with regex substitution 'Remove trailing commas'",
+          "rawConfiguration": {
+            "dataFormatters": [],
+            "facet": {
+              "showOtherSeries": false
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT round(latest(kentik.snmp.hrStorageUsed)*100/latest(kentik.snmp.hrStorageSize),.01) AS 'Used %', round(latest(kentik.snmp.hrStorageSize)*1e-6,.01) AS 'Total MBytes', round(latest(kentik.snmp.hrStorageUsed)*1e-6,.01) AS 'Used MBytes' WHERE `mib-table` = 'hrStorage' FACET storage_description LIMIT MAX"
+              }
+            ]
           }
         }
       ]

--- a/validator/tools/utils.js
+++ b/validator/tools/utils.js
@@ -27,6 +27,11 @@ module.exports = {
                 .replace(/\"accountId\"\s*:\s*\d+\s*/g , '"accountId": 0') // Anonymize account ID
                 .replace(/^.+\"linkedEntityGuids\".+\n?/mg , '')           // Remove linkedEntityGuids
                 .replace(/^.+\"permissions\".+\n?/mg , '')                 // Remove permissions
-                .replace(/[\}\)\]]\,(?!\s*?[\{\[\"\'\w])/g, '}');          // Remove trailing commas if any left after json blocks
+                // Remove trailing commas - Pattern translation:
+                // A comma + positive look ahead for closing braces.
+                // Further, optional whitespaces and optional line breaks
+                // between comma and closing braces.
+                .replace(/\,(?=\s*[\r?\n]?\s*[\]\}])/g,'');
+
     }
 }


### PR DESCRIPTION
### Relevant information

fix: Modified sanitization regex intended to remove trailing commas so that it no longer accidentally breaks NRQL statements
    
    * changed regex
    * added regression test scenarios for not breaking NRQL queries in rawDashboard.json and sanitizedDashboard.json.
    * added trailing commas test cases in rawDashboard.json and sanitizedDashboard.json


### Checklist

* [X] I've read the guidelines and understand the acceptance criteria.
* ~~[ ] The value of the attribute marked as `identifier` will be unique and valid.~~
* ~~[ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.~~
