### PR TITLE
 On branch fix-ext-oracle-dashboard-units

### DIFF
--- a/definitions/ext-oracle/dashboard.json
+++ b/definitions/ext-oracle/dashboard.json
@@ -114,7 +114,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "FROM Metric SELECT average(NR.SAP.DB.KPI.SIZE)/1000000 as `DB Size(GB)` FACET entity.name TIMESERIES 5 minutes SINCE 1 day ago"
+                "query": "FROM Metric SELECT average(NR.SAP.DB.KPI.SIZE)/1000 as `DB Size(GB)` FACET entity.name TIMESERIES 5 minutes SINCE 1 day ago"
               }
             ],
             "yAxisLeft": {


### PR DESCRIPTION
 Update ext-oracle dashboard definition. The unit of the DB Size conversion to GB from MB, not from KB.

### Relevant information

For SAP Observability, add the proposed ext-mssql entity for MicroSoft SQL Server. Metrics are collected by NR SAP agents. 

### Checklist

* [x ] I've read the guidelines and understand the acceptance criteria.
* [x ] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
