### PR TITLE
Fix unit for Oracle golden metrics. 

### DIFF
--- a/definitions/ext-oracle/golden_metrics.yml
+++ b/definitions/ext-oracle/golden_metrics.yml
@@ -10,7 +10,7 @@ dbSpaceUsed:
   title: DB Space Used
   unit: BYTES
   query:
-    select: average(NR.SAP.DB.KPI.USED)
+    select: average(NR.SAP.DB.KPI.USED) * 1000000
     from: Metric 
     eventId: entity.guid
 
@@ -18,7 +18,7 @@ dbSize:
   title: DB Size
   unit: BYTES
   query:
-    select: average(NR.SAP.DB.KPI.SIZE)
+    select: average(NR.SAP.DB.KPI.SIZE) * 1000000
     from: Metric 
     eventId: entity.guid
 

--- a/definitions/ext-oracle/summary_metrics.yml
+++ b/definitions/ext-oracle/summary_metrics.yml
@@ -10,7 +10,7 @@ dbSpaceUsed:
   title: DB Space Used
   unit: BYTES
   query:
-    select: average(NR.SAP.DB.KPI.USED)
+    select: average(NR.SAP.DB.KPI.USED) * 1000000
     from: Metric 
     eventId: entity.guid
 
@@ -18,7 +18,7 @@ dbSize:
   title: DB Size
   unit: BYTES
   query:
-    select: average(NR.SAP.DB.KPI.SIZE)
+    select: average(NR.SAP.DB.KPI.SIZE) * 1000000
     from: Metric 
     eventId: entity.guid
 


### PR DESCRIPTION
The data source for db size is in Megabytes, the golden metrics and summary metrics are expecting it in bytes, Convert db space size metric to be in bytes.

### Relevant information

Describe what you have done and any details that you think are relevant or that you might want to discuss with us. 

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
