### PR TITLE
Update: [argocd] Remove 'debug' from definition for ArgoCD

### DIFF
--- a/definitions/ext-argocd/definition.yml
+++ b/definitions/ext-argocd/definition.yml
@@ -5,7 +5,6 @@ synthesis:
   - identifier: "label.app.kubernetes.io/name"
     encodeIdentifierInGUID: true
     name: "label.app.kubernetes.io/name"
-    debug: true
     conditions:
     - attribute: metricName
       prefix: argocd_app_
@@ -13,7 +12,6 @@ synthesis:
   - identifier: "label.app.kubernetes.io/name"
     encodeIdentifierInGUID: true
     name: "label.app.kubernetes.io/name"
-    debug: true
     conditions:
     - attribute: metricName
       prefix: argocd_cluster_
@@ -21,7 +19,6 @@ synthesis:
   - identifier: "label.app.kubernetes.io/name"
     encodeIdentifierInGUID: true
     name: "label.app.kubernetes.io/name"
-    debug: true
     conditions:
     - attribute: metricName
       prefix: argocd_git_
@@ -29,7 +26,6 @@ synthesis:
   - identifier: "label.app.kubernetes.io/name"
     encodeIdentifierInGUID: true
     name: "label.app.kubernetes.io/name"
-    debug: true
     conditions:
     - attribute: metricName
       prefix: argocd_kubectl_
@@ -37,7 +33,6 @@ synthesis:
   - identifier: "label.app.kubernetes.io/name"
     encodeIdentifierInGUID: true
     name: "label.app.kubernetes.io/name"
-    debug: true
     conditions:
     - attribute: metricName
       prefix: argocd_redis_
@@ -45,7 +40,6 @@ synthesis:
   - identifier: "label.app.kubernetes.io/name"
     encodeIdentifierInGUID: true
     name: "label.app.kubernetes.io/name"
-    debug: true
     conditions:
     - attribute: metricName
       prefix: grpc_server_


### PR DESCRIPTION
### Relevant information

Removed the `debug:true` key from the `definition.yaml` file as requested post entity merge.

