### PR TITLE
ESA-1239 metric name for infra-azurepostgresqlserver

### DIFF
--- a/definitions/infra-azurepostgresqlserver/summary_metrics.yml
+++ b/definitions/infra-azurepostgresqlserver/summary_metrics.yml
@@ -17,7 +17,7 @@ memory:
     from: AzurePostgreSqlServerSample
   unit: PERCENTAGE
   title: Memory usage
-storage:
+storageUsed:
   query:
     eventId: entityGuid
     select: average(`storagePercent.Average`)


### PR DESCRIPTION
Change summary metric `storage` for entity types infra-azurepostgresqlserver to be the same as golden metric

### Relevant information

This is part of the epic to make all the summary metrics to be a subset of golden metrics.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
