### PR TITLE
ESA-1239 metric name for infra-kubernetespod

### DIFF
--- a/definitions/infra-kubernetes_pod/summary_metrics.yml
+++ b/definitions/infra-kubernetes_pod/summary_metrics.yml
@@ -18,7 +18,7 @@ createdKind:
   unit: STRING
   tag:
     key: k8s.createdKind
-errorsNetwork:
+networkErrors:
   query:
     eventId: entityGuid
     select: average(net.errorsPerSecond)


### PR DESCRIPTION
change summary metric name `errorsNetwork` to `networkErrors` to be equivalent to golden metrics

### Relevant information

This is part of the epic to make all the summary metrics to be a subset of golden metrics.

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
