### PR TITLE
feat: Add entity synthesis for host from log data

### DIFF
--- a/definitions/ext-host/definition.yml
+++ b/definitions/ext-host/definition.yml
@@ -50,7 +50,32 @@ synthesis:
       encodeIdentifierInGUID: true
       conditions:
       - attribute: eventType
-        value: AnsibleDiskIOSample 
+        value: AnsibleDiskIOSample
+
+    # logging data
+    - identifier: hostname
+      name: hostname
+      conditions:
+        - attribute: 'service_name'
+          present: false
+        - attribute: 'container.name'
+          present: false
+
+    - identifier: host
+      name: host
+      conditions:
+        - attribute: 'service_name'
+          present: false
+        - attribute: 'container.name'
+          present: false
+
+    - identifier: host.name
+      name: host.name
+      conditions:
+        - attribute: 'service_name'
+          present: false
+        - attribute: 'container.name'
+          present: false
         
   tags:
     localIp:

--- a/definitions/ext-host/definition.yml
+++ b/definitions/ext-host/definition.yml
@@ -53,14 +53,6 @@ synthesis:
         value: AnsibleDiskIOSample
 
     # logging data
-    - identifier: hostname
-      name: hostname
-      conditions:
-        - attribute: 'service_name'
-          present: false
-        - attribute: 'container.name'
-          present: false
-
     - identifier: host
       name: host
       conditions:
@@ -68,6 +60,18 @@ synthesis:
           present: false
         - attribute: 'container.name'
           present: false
+        - attribute: eventType
+          value: Log
+
+    - identifier: hostname
+      name: hostname
+      conditions:
+        - attribute: 'service_name'
+          present: false
+        - attribute: 'container.name'
+          present: false
+        - attribute: eventType
+          value: Log
 
     - identifier: host.name
       name: host.name
@@ -76,7 +80,9 @@ synthesis:
           present: false
         - attribute: 'container.name'
           present: false
-        
+        - attribute: eventType
+          value: Log
+
   tags:
     localIp:
       multiValue: false

--- a/definitions/ext-host/definition.yml
+++ b/definitions/ext-host/definition.yml
@@ -52,37 +52,6 @@ synthesis:
       - attribute: eventType
         value: AnsibleDiskIOSample
 
-    # logging data
-    - identifier: host
-      name: host
-      conditions:
-        - attribute: 'service_name'
-          present: false
-        - attribute: 'container.name'
-          present: false
-        - attribute: eventType
-          value: Log
-
-    - identifier: hostname
-      name: hostname
-      conditions:
-        - attribute: 'service_name'
-          present: false
-        - attribute: 'container.name'
-          present: false
-        - attribute: eventType
-          value: Log
-
-    - identifier: host.name
-      name: host.name
-      conditions:
-        - attribute: 'service_name'
-          present: false
-        - attribute: 'container.name'
-          present: false
-        - attribute: eventType
-          value: Log
-
   tags:
     localIp:
       multiValue: false

--- a/definitions/infra-host/definition.yml
+++ b/definitions/infra-host/definition.yml
@@ -79,6 +79,41 @@ synthesis:
         host.image.id:
         host.image.version:
         instrumentation.provider:
+
+    # host information from log data
+    - identifier: host
+      name: host
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: 'service_name'
+          present: false
+        - attribute: 'container.name'
+          present: false
+        - attribute: eventType
+          value: Log
+
+    - identifier: hostname
+      name: hostname
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: 'service_name'
+          present: false
+        - attribute: 'container.name'
+          present: false
+        - attribute: eventType
+          value: Log
+
+    - identifier: host.name
+      name: host.name
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: 'service_name'
+          present: false
+        - attribute: 'container.name'
+          present: false
+        - attribute: eventType
+          value: Log
+
 configuration:
   entityExpirationTime: DAILY
   alertable: true

--- a/definitions/infra-host/definition.yml
+++ b/definitions/infra-host/definition.yml
@@ -1,24 +1,24 @@
 domain: INFRA
 type: HOST
 goldenTags:
-- account
-- windowsPlatform
-- linuxDistribution
-- aws.awsRegion
-- aws.region
-- aws.availabilityZone
-- aws.accountId
-- azure.regionName
-- azure.subscriptionId
-- azure.resourceGroup
-- gcp.zone
-- gcp.projectId
-# opentelemetry semantic conventions for cloud instances
-- cloud.provider
-- cloud.account.id
-- cloud.region
-- cloud.availability_zone
-- cloud.platform
+  - account
+  - windowsPlatform
+  - linuxDistribution
+  - aws.awsRegion
+  - aws.region
+  - aws.availabilityZone
+  - aws.accountId
+  - azure.regionName
+  - azure.subscriptionId
+  - azure.resourceGroup
+  - gcp.zone
+  - gcp.projectId
+  # opentelemetry semantic conventions for cloud instances
+  - cloud.provider
+  - cloud.account.id
+  - cloud.region
+  - cloud.availability_zone
+  - cloud.platform
 synthesis:
   rules:
     # opentelemetry host data from opentelemetry-collector
@@ -91,6 +91,8 @@ synthesis:
           present: false
         - attribute: eventType
           value: Log
+        - attribute: newrelic.source
+          value: 'api.logs'
 
     - identifier: hostname
       name: hostname
@@ -102,6 +104,8 @@ synthesis:
           present: false
         - attribute: eventType
           value: Log
+        - attribute: newrelic.source
+          value: 'api.logs'
 
     - identifier: host.name
       name: host.name
@@ -113,6 +117,8 @@ synthesis:
           present: false
         - attribute: eventType
           value: Log
+        - attribute: newrelic.source
+          value: 'api.logs'
 
 configuration:
   entityExpirationTime: DAILY


### PR DESCRIPTION
### Relevant information
https://issues.newrelic.com/browse/NR-6568

Per the ticket above, we want to use entity synthesis on log data that has host information but is missing a service name or container. If it has either of those, we want entity synthesis to use the service name if available, or container name instead. 

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
