### PR TITLE
Add Postman Monitor entity type

### DIFF
--- a/definitions/ext-postman_monitor/definition.yml
+++ b/definitions/ext-postman_monitor/definition.yml
@@ -1,0 +1,19 @@
+domain: EXT
+type: POSTMAN_MONITOR
+
+synthesis:
+  rules:
+    - identifier: monitor.id
+      name: monitor.name
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: metricName
+          prefix: postman.monitor
+
+dashboardTemplates:
+  postman-monitor:
+    template: postman-monitor-dashboard.json
+
+configuration:
+  entityExpirationTime: EIGHT_DAYS
+  alertable: true

--- a/definitions/ext-postman_monitor/postman-monitor-dashboard.json
+++ b/definitions/ext-postman_monitor/postman-monitor-dashboard.json
@@ -1,0 +1,196 @@
+{
+    "name": "Postman Monitor",
+    "description": null,
+    "pages": [
+        {
+            "name": "Postman Monitor",
+            "description": null,
+            "widgets": [
+                {
+                    "visualization": {
+                        "id": "viz.markdown"
+                    },
+                    "layout": {
+                        "column": 1,
+                        "row": 1,
+                        "height": 2,
+                        "width": 2
+                    },
+                    "title": "",
+                    "rawConfiguration": {
+                        "text": "![Postman logo](https://media.slid.es/uploads/327261/images/5065937/pm-logo-vert.png)"
+                    }
+                },
+                {
+                    "visualization": {
+                        "id": "viz.line"
+                    },
+                    "layout": {
+                        "column": 3,
+                        "row": 1,
+                        "height": 2,
+                        "width": 10
+                    },
+                    "title": "Total Average Latency",
+                    "rawConfiguration": {
+                        "legend": {
+                            "enabled": true
+                        },
+                        "nrqlQueries": [
+                            {
+                                "accountId": 0,
+                                "query": "SELECT average(postman.monitor.run.totallatency) as 'Average of total latency' FROM Metric COMPARE WITH 1 month ago TIMESERIES SINCE 1800 seconds ago"
+                            }
+                        ],
+                        "yAxisLeft": {
+                            "zero": true
+                        }
+                    }
+                },
+                {
+                    "visualization": {
+                        "id": "viz.line"
+                    },
+                    "layout": {
+                        "column": 1,
+                        "row": 3,
+                        "height": 3,
+                        "width": 6
+                    },
+                    "title": "Requests Over Time",
+                    "rawConfiguration": {
+                        "legend": {
+                            "enabled": true
+                        },
+                        "nrqlQueries": [
+                            {
+                                "accountId": 0,
+                                "query": "SELECT sum (postman.monitor.run.requestcount) as 'Requests' FROM Metric COMPARE WITH 1 month ago TIMESERIES SINCE 1800 seconds ago"
+                            }
+                        ],
+                        "yAxisLeft": {
+                            "zero": true
+                        }
+                    }
+                },
+                {
+                    "visualization": {
+                        "id": "viz.stacked-bar"
+                    },
+                    "layout": {
+                        "column": 7,
+                        "row": 3,
+                        "height": 3,
+                        "width": 6
+                    },
+                    "title": "Average request bytes ",
+                    "rawConfiguration": {
+                        "facet": {
+                            "showOtherSeries": false
+                        },
+                        "legend": {
+                            "enabled": true
+                        },
+                        "nrqlQueries": [
+                            {
+                                "accountId": 0,
+                                "query": "SELECT average(postman.monitor.request.requestbytes) as 'Bytes' FROM Metric TIMESERIES FACET `request.name` SINCE 1800 seconds ago"
+                            }
+                        ],
+                        "yAxisLeft": {
+                            "zero": true
+                        }
+                    }
+                },
+                {
+                    "visualization": {
+                        "id": "viz.billboard"
+                    },
+                    "layout": {
+                        "column": 1,
+                        "row": 6,
+                        "height": 3,
+                        "width": 3
+                    },
+                    "title": "HTTP 4xx responses",
+                    "rawConfiguration": {
+                        "dataFormatters": [],
+                        "nrqlQueries": [
+                            {
+                                "accountId": 0,
+                                "query": "SELECT sum(postman.monitor.run.httpstatus4xx) as '4xx responses' FROM Metric SINCE 1800 seconds ago"
+                            }
+                        ],
+                        "thresholds": []
+                    }
+                },
+                {
+                    "visualization": {
+                        "id": "viz.billboard"
+                    },
+                    "layout": {
+                        "column": 4,
+                        "row": 6,
+                        "height": 3,
+                        "width": 3
+                    },
+                    "title": "HTTP 5xx responses",
+                    "rawConfiguration": {
+                        "dataFormatters": [],
+                        "nrqlQueries": [
+                            {
+                                "accountId": 0,
+                                "query": "SELECT sum(postman.monitor.run.httpstatus5xx) as '5xx responses' FROM Metric SINCE 1800 seconds ago"
+                            }
+                        ],
+                        "thresholds": []
+                    }
+                },
+                {
+                    "visualization": {
+                        "id": "viz.billboard"
+                    },
+                    "layout": {
+                        "column": 7,
+                        "row": 6,
+                        "height": 3,
+                        "width": 3
+                    },
+                    "title": "Errors",
+                    "rawConfiguration": {
+                        "dataFormatters": [],
+                        "nrqlQueries": [
+                            {
+                                "accountId": 0,
+                                "query": "SELECT sum (postman.monitor.run.errors) as 'errors' FROM Metric SINCE 1800 seconds ago"
+                            }
+                        ],
+                        "thresholds": []
+                    }
+                },
+                {
+                    "visualization": {
+                        "id": "viz.billboard"
+                    },
+                    "layout": {
+                        "column": 10,
+                        "row": 6,
+                        "height": 3,
+                        "width": 3
+                    },
+                    "title": "Failed tests",
+                    "rawConfiguration": {
+                        "dataFormatters": [],
+                        "nrqlQueries": [
+                            {
+                                "accountId": 0,
+                                "query": "SELECT sum(postman.monitor.run.failedtests) as 'Tests' FROM Metric SINCE 1800 seconds ago"
+                            }
+                        ],
+                        "thresholds": []
+                    }
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
### Relevant information

Added a Postman Monitor entity type based off of [the Postman quickstart](https://github.com/newrelic/newrelic-quickstarts/tree/main/quickstarts/postman).

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
