### PR TITLE
feat: ext-host add missing sample

### DIFF
--- a/definitions/ext-host/definition.yml
+++ b/definitions/ext-host/definition.yml
@@ -51,7 +51,13 @@ synthesis:
       conditions:
       - attribute: eventType
         value: AnsibleDiskIOSample 
-        
+    - identifier: displayName
+      name: displayName
+      encodeIdentifierInGUID: true
+      conditions:
+      - attribute: eventType
+        value: AnsibleVmSystemSample 
+
   tags:
     localIp:
       multiValue: false


### PR DESCRIPTION
This sample was meant to be included in the original PR but was missed.
As previously mentioned needed for the cloud accelerator initiative. 

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
