### PR TITLE
Updated golden metrics as subset of summary metrics

### DIFF
--- a/definitions/ext-fastly_pop/golden_metrics.yml
+++ b/definitions/ext-fastly_pop/golden_metrics.yml
@@ -34,3 +34,30 @@ clientbps:
     where: fastly_datacenter IS NOT NULL
     eventId: entity.guid
     eventName: entity.name
+ clients:
+  title: Unique Clients
+  displayAsValue: true
+  query:
+    select: uniqueCount(client_ip)
+    from: Log
+    where: "fastly_datacenter IS NOT NULL"
+    eventId: entity.guid
+    eventName: entity.name
+response:
+  title: Response OK Rate (%)
+  displayAsValue: true
+  query:
+    select: (filter(count(response), WHERE response ='OK')/count(response))*100
+    from: Log
+    where: "fastly_datacenter IS NOT NULL"
+    eventId: entity.guid
+    eventName: entity.name
+cacheHitRate:
+  title: Cache Hit Rate (%)
+  displayAsValue: true
+  query:
+    select: (filter(count(cache_status), WHERE cache_status ='HIT')/count(cache_status))*100
+    from: Log
+    where: "fastly_datacenter IS NOT NULL"
+    eventId: entity.guid
+    eventName: entity.name


### PR DESCRIPTION
### Relevant information

In order to support the initiative of making summary metrics a subset of golden metrics, this PR adds the summary metrics to the golden metrics definition. While this does expand the GMs from 4 to 7, this entity type requires that level of uniqueness in the metrics.

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
