### PR TITLE
fix ext-ibmmqueue SM

### DIFF
--- a/definitions/ext-ibmmqqueue/golden_metrics.yml
+++ b/definitions/ext-ibmmqqueue/golden_metrics.yml
@@ -33,3 +33,10 @@ producerCount:
     from: MQQueueSample
     eventId: entity.guid
     eventName: entity.name
+queueDepthPercent:
+  title: Queue Depth (%)
+  unit: PERCENTAGE
+  query:
+    select: latest(qDepthPercent)
+    from: MQQueueSample
+    eventId: entity.guid


### PR DESCRIPTION
### Relevant information

From ticket NR-17236 this copy SummaryMetric into GoldenMetric with the purpose of have all SummaryMetric be a subset of GoldenMetric for ext-ibmmqueue

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
