### PR TITLE
Update ext-ibmmqqueue/definition.yml

### DIFF
--- a/definitions/ext-ibmmqqueue/definition.yml
+++ b/definitions/ext-ibmmqqueue/definition.yml
@@ -11,16 +11,16 @@ synthesis:
   tags:
     qManagerName:
       multiValue: true
-      ttl: P1D
+      ttl: P1W
     qManagerHost:
       multiValue: true
-      ttl: P1D
+      ttl: P1W
     agentName:
       multiValue: true
-      ttl: P1D
+      ttl: P1W
     object:
       multiValue: false
-      ttl: P1D
+      ttl: P1W
 
 dashboardTemplates:
   newRelic:

--- a/definitions/ext-ibmmqqueue/definition.yml
+++ b/definitions/ext-ibmmqqueue/definition.yml
@@ -11,16 +11,16 @@ synthesis:
   tags:
     qManagerName:
       multiValue: true
-      ttl: P1W
+      ttl: P7D
     qManagerHost:
       multiValue: true
-      ttl: P1W
+      ttl: P7D
     agentName:
       multiValue: true
-      ttl: P1W
+      ttl: P7D
     object:
       multiValue: false
-      ttl: P1W
+      ttl: P7D
 
 dashboardTemplates:
   newRelic:


### PR DESCRIPTION
### Relevant information

Added a TTL tag to the ext-ibmmqqueue/definition.yml file of P1W. This should remove any tags that aren't present within a week solving the issue of older/historical tags remaining in the NR UI. 

### Checklist

* [X] I've read the guidelines and understand the acceptance criteria.
* [X] The value of the attribute marked as `identifier` will be unique and valid. 
* [X] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
