### PR TITLE
feat: add new dashboard under ext-firewall

### DIFF
--- a/definitions/ext-firewall/cisco-asa-dashboard.json
+++ b/definitions/ext-firewall/cisco-asa-dashboard.json
@@ -1,125 +1,189 @@
 {
-    "name": "Cisco ASA Firewall",
-    "description": null,
-    "pages": [
-      {
-        "name": "Cisco ASA Firewall",
-        "description": null,
-        "widgets": [
-          {
-            "visualization": {
-              "id": "viz.billboard"
-            },
-            "layout": {
-              "column": 1,
-              "row": 1,
-              "height": 4,
-              "width": 4
-            },
-            "title": "Device Uptime",
-            "rawConfiguration": {
-              "dataFormatters": [
-                {
-                  "name": "Total Hours",
-                  "precision": null,
-                  "type": "decimal"
-                },
-                {
-                  "name": "Total Days",
-                  "precision": null,
-                  "type": "decimal"
-                }
-              ],
-              "nrqlQueries": [
-                {
-                  "accountId": 0,
-                  "query": "FROM Metric SELECT latest(`kentik.snmp.Uptime`)/100/60/60/24 AS 'Total Days', latest(`kentik.snmp.Uptime`)/100/60/60 AS 'Total Hours' WHERE provider = 'kentik-firewall'"
-                }
-              ],
-              "thresholds": []
-            }
+  "name": "Cisco ASA Firewall",
+  "description": null,
+  "pages": [
+    {
+      "name": "Cisco ASA Firewall",
+      "description": null,
+      "widgets": [
+        {
+          "title": "Summary",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 5
           },
-          {
-            "visualization": {
-              "id": "viz.line"
-            },
-            "layout": {
-              "column": 5,
-              "row": 1,
-              "height": 4,
-              "width": 6
-            },
-            "title": "CPU Utilization %",
-            "rawConfiguration": {
-              "dataFormatters": [],
-              "legend": {
-                "enabled": true
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "dataFormatters": [
+              {
+                "name": "Last Update",
+                "type": "recent-relative"
               },
-              "nrqlQueries": [
-                {
-                  "accountId": 0,
-                  "query": "FROM Metric SELECT max(kentik.snmp.CPU) AS 'CPU Utilization %' TIMESERIES 5 MINUTES"
-                }
-              ],
-              "yAxisLeft": {
-                "max": 100,
-                "min": 0,
-                "zero": false
+              {
+                "name": "Uptime (Days)",
+                "precision": 2,
+                "type": "decimal"
               }
-            }
-          },
-          {
-            "visualization": {
-              "id": "viz.billboard"
+            ],
+            "facet": {
+              "showOtherSeries": false
             },
-            "layout": {
-              "column": 1,
-              "row": 5,
-              "height": 4,
-              "width": 4
-            },
-            "title": "Total Active Sessions",
-            "rawConfiguration": {
-              "dataFormatters": [],
-              "nrqlQueries": [
-                {
-                  "accountId": 0,
-                  "query": "FROM Metric SELECT latest(kentik.snmp.crasNumSessions) AS 'Active Sessions' SINCE 10 MINUTES AGO COMPARE WITH 1 DAY AGO"
-                }
-              ],
-              "thresholds": []
-            }
-          },
-          {
-            "visualization": {
-              "id": "viz.line"
-            },
-            "layout": {
-              "column": 5,
-              "row": 5,
-              "height": 4,
-              "width": 6
-            },
-            "title": "Memory Utilization %",
-            "rawConfiguration": {
-              "dataFormatters": [],
-              "legend": {
-                "enabled": true
-              },
-              "nrqlQueries": [
-                {
-                  "accountId": 0,
-                  "query": "FROM Metric SELECT max(kentik.snmp.MemoryUtilization) AS 'Memory Utilization %' TIMESERIES 5 MINUTES"
-                }
-              ],
-              "yAxisLeft": {
-                "max": 100,
-                "min": 0,
-                "zero": false
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT latest(device_name) AS 'Device Name', latest(src_addr) AS 'Device IP', latest(kentik.snmp.Uptime)/8640000 AS 'Uptime (Days)', latest(SysObjectID) AS 'SysObjectID', latest(entity.type) AS 'Entity Type', latest(instrumentation.name) AS 'Ktranslate Profile', latest(timestamp) AS 'Last Update', latest(PollingHealth) AS 'Polling Health', latest(PollingHealthReason) AS 'Health Reason' WHERE entity.type  = 'FIREWALL'"
               }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
             }
           }
-        ]
-      }
-    ]
-  }
+        },
+        {
+          "title": "",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 1
+          },
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT latest(kentik.snmp.CPU) AS 'Current CPU Utilization %' WHERE entity.type  = 'FIREWALL'"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "thresholds": [
+              {
+                "alertSeverity": "WARNING",
+                "value": 90
+              },
+              {
+                "alertSeverity": "CRITICAL",
+                "value": 95
+              }
+            ]
+          }
+        },
+        {
+          "title": "",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 1
+          },
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT latest(kentik.snmp.MemoryUtilization) AS 'Current Memory Utilization %' WHERE entity.type  = 'FIREWALL'"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "thresholds": [
+              {
+                "alertSeverity": "WARNING",
+                "value": 90
+              },
+              {
+                "alertSeverity": "CRITICAL",
+                "value": 95
+              }
+            ]
+          }
+        },
+        {
+          "title": "CPU Utilization (%)",
+          "layout": {
+            "column": 5,
+            "row": 2,
+            "width": 4,
+            "height": 4
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT min(kentik.snmp.CPU) AS 'Min CPU', max(kentik.snmp.CPU) AS 'Max CPU', average(kentik.snmp.CPU) AS 'Average CPU' WHERE entity.type  = 'FIREWALL' TIMESERIES 5 MINUTES"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "max": 100,
+              "min": 0,
+              "zero": false
+            }
+          }
+        },
+        {
+          "title": "Memory Utilization (%)",
+          "layout": {
+            "column": 9,
+            "row": 2,
+            "width": 4,
+            "height": 4
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT min(kentik.snmp.MemoryUtilization) AS 'Min Memory', max(kentik.snmp.MemoryUtilization) AS 'Max Memory', average(kentik.snmp.MemoryUtilization) AS 'Average Memory' WHERE entity.type  = 'FIREWALL' TIMESERIES 5 MINUTES"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "max": 100,
+              "min": 0,
+              "zero": false
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/definitions/ext-firewall/definition.yml
+++ b/definitions/ext-firewall/definition.yml
@@ -51,3 +51,6 @@ dashboardTemplates:
   # Sophos Firewall profiles
   kentik/xgs-firewall:
     template: sophos-xgs-dashboard.json
+  # Pulse Secure Appliance profiles
+  kentik/pulse-secure:
+    template: pulse-secure-dashboard.json

--- a/definitions/ext-firewall/pulse-secure-dashboard.json
+++ b/definitions/ext-firewall/pulse-secure-dashboard.json
@@ -1,0 +1,404 @@
+{
+  "name": "Pulse Secure",
+  "description": null,
+  "pages": [
+    {
+      "name": "Pulse Secure",
+      "description": null,
+      "widgets": [
+        {
+          "title": "Summary",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 5
+          },
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "dataFormatters": [
+              {
+                "name": "Last Update",
+                "type": "recent-relative"
+              },
+              {
+                "name": "Uptime (Days)",
+                "precision": 2,
+                "type": "decimal"
+              }
+            ],
+            "facet": {
+              "showOtherSeries": false
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT latest(device_name) AS 'Device Name', latest(src_addr) AS 'Device IP', latest(kentik.snmp.Uptime)/8640000 AS 'Uptime (Days)', latest(SysObjectID) AS 'SysObjectID', latest(entity.type) AS 'Entity Type', latest(instrumentation.name) AS 'Ktranslate Profile', latest(timestamp) AS 'Last Update', latest(PollingHealth) AS 'Polling Health', latest(PollingHealthReason) AS 'Health Reason' WHERE instrumentation.name = 'pulse-secure'"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 1
+          },
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT latest(kentik.snmp.CPU) AS 'Current CPU Utilization %' WHERE instrumentation.name = 'pulse-secure'"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "thresholds": [
+              {
+                "alertSeverity": "WARNING",
+                "value": 90
+              },
+              {
+                "alertSeverity": "CRITICAL",
+                "value": 95
+              }
+            ]
+          }
+        },
+        {
+          "title": "",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 1
+          },
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT latest(kentik.snmp.MemoryUtilization) AS 'Current Memory Utilization %' WHERE instrumentation.name = 'pulse-secure'"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "thresholds": [
+              {
+                "alertSeverity": "WARNING",
+                "value": 90
+              },
+              {
+                "alertSeverity": "CRITICAL",
+                "value": 95
+              }
+            ]
+          }
+        },
+        {
+          "title": "CPU Utilization (%)",
+          "layout": {
+            "column": 5,
+            "row": 2,
+            "width": 4,
+            "height": 4
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT min(kentik.snmp.CPU) AS 'Min CPU', max(kentik.snmp.CPU) AS 'Max CPU', average(kentik.snmp.CPU) AS 'Average CPU' WHERE instrumentation.name = 'pulse-secure' TIMESERIES 5 MINUTES"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "max": 100,
+              "min": 0,
+              "zero": false
+            }
+          }
+        },
+        {
+          "title": "Memory Utilization (%)",
+          "layout": {
+            "column": 9,
+            "row": 2,
+            "width": 4,
+            "height": 4
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT min(kentik.snmp.MemoryUtilization) AS 'Min Memory', max(kentik.snmp.MemoryUtilization) AS 'Max Memory', average(kentik.snmp.MemoryUtilization) AS 'Average Memory' WHERE instrumentation.name = 'pulse-secure' TIMESERIES 5 MINUTES"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "max": 100,
+              "min": 0,
+              "zero": false
+            }
+          }
+        },
+        {
+          "title": "Appliance Details",
+          "layout": {
+            "column": 1,
+            "row": 6,
+            "width": 2,
+            "height": 4
+          },
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "From Metric SELECT latest(product_name), latest(product_version), latest(esap_version), latest(licensed_capacity) where instrumentation.name = 'pulse-secure'"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "Storage Summary",
+          "layout": {
+            "column": 3,
+            "row": 6,
+            "width": 5,
+            "height": 4
+          },
+          "visualization": {
+            "id": "viz.table"
+          },
+          "rawConfiguration": {
+            "dataFormatters": [],
+            "facet": {
+              "showOtherSeries": false
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT round(latest(kentik.snmp.hrStorageUsed)*100/latest(kentik.snmp.hrStorageSize}.01) AS 'Used %', round(latest(kentik.snmp.hrStorageSize)*1e-6,.01) AS 'Total MBytes', round(latest(kentik.snmp.hrStorageUsed)*1e-6,.01) AS 'Used MBytes' WHERE instrumentation.name = 'pulse-secure' FACET storage_description LIMIT MAX"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "Log and Disk utilization %",
+          "layout": {
+            "column": 8,
+            "row": 6,
+            "width": 5,
+            "height": 4
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "From Metric SELECT max(kentik.snmp.logFullPercent) AS 'Log full %', max(kentik.snmp.diskFullPercent) AS 'Disk full %' where instrumentation.name = 'pulse-secure' limit max timeseries 5 minutes"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "max": 100,
+              "min": 0,
+              "zero": false
+            }
+          }
+        },
+        {
+          "title": "Connections",
+          "layout": {
+            "column": 1,
+            "row": 10,
+            "width": 6,
+            "height": 4
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "From Metric SELECT max(kentik.snmp.iveVPNTunnels) as 'Concurrent VPN Users', max(kentik.snmp.iveSSLConnections) AS 'SSL Connections' where instrumentation.name = 'pulse-secure' limit max TIMESERIES 5 minutes"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Users",
+          "layout": {
+            "column": 7,
+            "row": 10,
+            "width": 6,
+            "height": 4
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "From Metric SELECT max(kentik.snmp.iveTotalSignedInUsers) AS 'Total Signed In Users', max(kentik.snmp.signedInMailUsers) AS 'Signed In Mail Users', max(kentik.snmp.signedInWebUsers) AS 'Signed In Web Users', max(kentik.snmp.iveConcurrentUsers) AS 'Concurrent Licenses in Use - Node', max(kentik.snmp.clusterConcurrentUsers) AS 'Concurrent Licenses in Use - Cluster' where instrumentation.name = 'pulse-secure' limit max TIMESERIES 5 minutes"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Temperature",
+          "layout": {
+            "column": 1,
+            "row": 14,
+            "width": 6,
+            "height": 4
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "From Metric SELECT max(kentik.snmp.iveTemperature) where instrumentation.name = 'pulse-secure' limit max TIMESERIES 5 minutes"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Hits since last reboot",
+          "layout": {
+            "column": 7,
+            "row": 14,
+            "width": 6,
+            "height": 4
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "From Metric SELECT max(kentik.snmp.iveTotalHits) AS 'Total hits', max(kentik.snmp.iveFileHits) AS 'File hits', max(kentik.snmp.iveWebHits) AS 'Web hits', max(kentik.snmp.iveAppletHits) AS 'Applet hits', max(kentik.snmp.ivetermHits) AS 'Terminal hits', max(kentik.snmp.iveSAMHits) AS 'SAM hits', max(kentik.snmp.iveNCHits) AS 'Network connect hits', max(kentik.snmp.meetingHits) AS 'Meeting hits' where instrumentation.name = 'pulse-secure' limit max TIMESERIES 5 minutes"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Relevant information

Added a new dashboard for pulse-secure vpn appliances
updated definition to link to that dashboard
updated ASA (default) dashboard to be in line with other current dashboards.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
