### PR TITLE
Address non-unique istio entities

### DIFF
--- a/definitions/ext-istio_service/definition.yml
+++ b/definitions/ext-istio_service/definition.yml
@@ -2,31 +2,47 @@ domain: EXT
 type: ISTIO_SERVICE
 synthesis:
   rules:
-  - identifier: "label.service.istio.io/canonical-name"
+  - compositeIdentifier:
+      separator: ":"
+      attributes:
+      - clusterName
+      - label.service.istio.io/canonical-name
     encodeIdentifierInGUID: true
-    name: "label.service.istio.io/canonical-name"
+    name: label.service.istio.io/canonical-name
     conditions:
     - attribute: metricName
       prefix: istio_request
 
-  - identifier: "label.service.istio.io/canonical-name"
+  - compositeIdentifier:
+      separator: ":"
+      attributes:
+      - clusterName
+      - label.service.istio.io/canonical-name
     encodeIdentifierInGUID: true
-    name: "label.service.istio.io/canonical-name"
+    name: label.service.istio.io/canonical-name
     conditions:
     - attribute: metricName
       prefix: istio_response
 
-  - identifier: "label.service.istio.io/canonical-name"
+  - compositeIdentifier:
+      separator: ":"
+      attributes:
+      - clusterName
+      - label.service.istio.io/canonical-name
     encodeIdentifierInGUID: true
-    name: "label.service.istio.io/canonical-name"
+    name: label.service.istio.io/canonical-name
     conditions:
     - attribute: metricName
       prefix: istio_tcp
-      
+
   # Support for prometheus instrumentation provider
-  - identifier: "service_istio_io_canonical_name"
+  - compositeIdentifier:
+      separator: ":"
+      attributes:
+      - clusterName
+      - service_istio_io_canonical_name
     encodeIdentifierInGUID: true
-    name: "service_istio_io_canonical_name"
+    name: service_istio_io_canonical_name
     conditions:
     - attribute: metricName
       prefix: istio_request
@@ -48,10 +64,14 @@ synthesis:
       clusterName:
       namespaceName:
       deploymentName:
-      
-  - identifier: "service_istio_io_canonical_name"
+
+  - compositeIdentifier:
+      separator: ":"
+      attributes:
+      - clusterName
+      - service_istio_io_canonical_name
     encodeIdentifierInGUID: true
-    name: "service_istio_io_canonical_name"
+    name: service_istio_io_canonical_name
     conditions:
     - attribute: metricName
       prefix: istio_response
@@ -74,9 +94,13 @@ synthesis:
       namespaceName:
       deploymentName:
 
-  - identifier: "service_istio_io_canonical_name"
+  - compositeIdentifier:
+      separator: ":"
+      attributes:
+      - clusterName
+      - service_istio_io_canonical_name
     encodeIdentifierInGUID: true
-    name: "service_istio_io_canonical_name"
+    name: service_istio_io_canonical_name
     conditions:
     - attribute: metricName
       prefix: istio_tcp
@@ -98,18 +122,6 @@ synthesis:
       clusterName:
       namespaceName:
       deploymentName:
-
-  tags:
-    label.service.istio.io/canonical-revision:
-    label.app:
-    label.version:
-    label.istio:
-    label.istio.io/rev:
-    label.operator.istio.io/component:
-    k8s.cluster.name:
-    clusterName:
-    namespaceName:
-    deploymentName:
 
 goldenTags:
   - clusterName


### PR DESCRIPTION
The current entity definition produces non-unique entities that are common across K8s clusters (e.g. prod, pre-prod, etc). This makes it unusable. This change updates entity synthesis to incorporate composite identifiers that include the K8s cluster name.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
