### PR TITLE
Address non-unique istio entities (fixed omitted tags)

### DIFF
--- a/definitions/ext-istio_service/definition.yml
+++ b/definitions/ext-istio_service/definition.yml
@@ -2,31 +2,47 @@ domain: EXT
 type: ISTIO_SERVICE
 synthesis:
   rules:
-  - identifier: "label.service.istio.io/canonical-name"
+  - compositeIdentifier:
+      separator: ":"
+      attributes:
+      - clusterName
+      - label.service.istio.io/canonical-name
     encodeIdentifierInGUID: true
-    name: "label.service.istio.io/canonical-name"
+    name: label.service.istio.io/canonical-name
     conditions:
     - attribute: metricName
       prefix: istio_request
 
-  - identifier: "label.service.istio.io/canonical-name"
+  - compositeIdentifier:
+      separator: ":"
+      attributes:
+      - clusterName
+      - label.service.istio.io/canonical-name
     encodeIdentifierInGUID: true
-    name: "label.service.istio.io/canonical-name"
+    name: label.service.istio.io/canonical-name
     conditions:
     - attribute: metricName
       prefix: istio_response
 
-  - identifier: "label.service.istio.io/canonical-name"
+  - compositeIdentifier:
+      separator: ":"
+      attributes:
+      - clusterName
+      - label.service.istio.io/canonical-name
     encodeIdentifierInGUID: true
-    name: "label.service.istio.io/canonical-name"
+    name: label.service.istio.io/canonical-name
     conditions:
     - attribute: metricName
       prefix: istio_tcp
-      
+
   # Support for prometheus instrumentation provider
-  - identifier: "service_istio_io_canonical_name"
+  - compositeIdentifier:
+      separator: ":"
+      attributes:
+      - clusterName
+      - service_istio_io_canonical_name
     encodeIdentifierInGUID: true
-    name: "service_istio_io_canonical_name"
+    name: service_istio_io_canonical_name
     conditions:
     - attribute: metricName
       prefix: istio_request
@@ -48,10 +64,14 @@ synthesis:
       clusterName:
       namespaceName:
       deploymentName:
-      
-  - identifier: "service_istio_io_canonical_name"
+
+  - compositeIdentifier:
+      separator: ":"
+      attributes:
+      - clusterName
+      - service_istio_io_canonical_name
     encodeIdentifierInGUID: true
-    name: "service_istio_io_canonical_name"
+    name: service_istio_io_canonical_name
     conditions:
     - attribute: metricName
       prefix: istio_response
@@ -74,9 +94,13 @@ synthesis:
       namespaceName:
       deploymentName:
 
-  - identifier: "service_istio_io_canonical_name"
+  - compositeIdentifier:
+      separator: ":"
+      attributes:
+      - clusterName
+      - service_istio_io_canonical_name
     encodeIdentifierInGUID: true
-    name: "service_istio_io_canonical_name"
+    name: service_istio_io_canonical_name
     conditions:
     - attribute: metricName
       prefix: istio_tcp
@@ -110,7 +134,7 @@ synthesis:
     clusterName:
     namespaceName:
     deploymentName:
-
+    
 goldenTags:
   - clusterName
   - namespaceName

--- a/definitions/ext-istio_service/definition.yml
+++ b/definitions/ext-istio_service/definition.yml
@@ -6,6 +6,7 @@ synthesis:
       separator: ":"
       attributes:
       - clusterName
+      - namespaceName
       - label.service.istio.io/canonical-name
     encodeIdentifierInGUID: true
     name: label.service.istio.io/canonical-name
@@ -17,6 +18,7 @@ synthesis:
       separator: ":"
       attributes:
       - clusterName
+      - namespaceName
       - label.service.istio.io/canonical-name
     encodeIdentifierInGUID: true
     name: label.service.istio.io/canonical-name
@@ -28,6 +30,7 @@ synthesis:
       separator: ":"
       attributes:
       - clusterName
+      - namespaceName
       - label.service.istio.io/canonical-name
     encodeIdentifierInGUID: true
     name: label.service.istio.io/canonical-name
@@ -40,6 +43,7 @@ synthesis:
       separator: ":"
       attributes:
       - clusterName
+      - namespaceName
       - service_istio_io_canonical_name
     encodeIdentifierInGUID: true
     name: service_istio_io_canonical_name
@@ -69,6 +73,7 @@ synthesis:
       separator: ":"
       attributes:
       - clusterName
+      - namespaceName
       - service_istio_io_canonical_name
     encodeIdentifierInGUID: true
     name: service_istio_io_canonical_name
@@ -98,6 +103,7 @@ synthesis:
       separator: ":"
       attributes:
       - clusterName
+      - namespaceName
       - service_istio_io_canonical_name
     encodeIdentifierInGUID: true
     name: service_istio_io_canonical_name


### PR DESCRIPTION
### Relevant information

The current entity definition produces non-unique entities that are common across K8s clusters (e.g. prod, pre-prod, etc). This makes it unusable. This change updates entity synthesis to incorporate composite identifiers that include the K8s cluster name.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
