### PR TITLE
fix: Correct where clause on error rate for golden metric of ext

### DIFF
--- a/definitions/ext-service/golden_metrics.yml
+++ b/definitions/ext-service/golden_metrics.yml
@@ -20,7 +20,7 @@ errorRate:
     opentelemetry:
       select: (filter(count(*), WHERE otel.status_code = 'ERROR') * 100) / count(*)
       from: Span
-      where: span.kind IN ('server', 'consumer') OR kind IN ('server', 'consumer')
+      where: span.kind LIKE 'server' OR span.kind LIKE 'consumer' OR kind LIKE 'server' OR kind LIKE 'consumer'
     kamon-agent:
       select: (filter(sum(http.server.requests), where http.status_code = '5xx') * 100) / sum(http.server.requests)
       from: Metric


### PR DESCRIPTION
### Relevant information

This PR corrects the where clause on the error rate for golden metrics of ext-services. Replacing the In keyword with the like keyword will allow this metric to catch relevant values for error rates.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
