### PR TITLE
Fix metrics for infra-awsapigatewaystage

### DIFF
--- a/definitions/infra-awsapigatewaystage/golden_metrics.yml
+++ b/definitions/infra-awsapigatewaystage/golden_metrics.yml
@@ -33,7 +33,7 @@ latencyMs:
   unit: SECONDS
   queries:
     aws:
-      select: average(aws.apigateway.Latency.byApi)
+      select: average(aws.apigateway.Latency.byStage)
       from: Metric
       eventId: entity.guid
       eventName: entity.name

--- a/definitions/infra-awsapigatewaystage/golden_metrics.yml
+++ b/definitions/infra-awsapigatewaystage/golden_metrics.yml
@@ -33,12 +33,12 @@ latencyMs:
   unit: SECONDS
   queries:
     aws:
-      select: average(aws.apigateway.Latency.byStage)
+      select: average(aws.apigateway.Latency.byStage) / 1000
       from: Metric
       eventId: entity.guid
       eventName: entity.name
     awsSample:
-      select: average(provider.latency.Average)
+      select: average(provider.latency.Average) / 1000
       from: ApiGatewaySample
       where: provider='ApiGatewayStage'
       eventId: entityGuid

--- a/definitions/infra-awsapigatewaystage/golden_metrics.yml
+++ b/definitions/infra-awsapigatewaystage/golden_metrics.yml
@@ -30,15 +30,15 @@ errors4XxAnd5Xx:
       eventName: entityName
 latencyMs:
   title: Latency (ms)
-  unit: SECONDS
+  unit: MS
   queries:
     aws:
-      select: average(aws.apigateway.Latency.byStage) / 1000
+      select: average(aws.apigateway.Latency.byStage)
       from: Metric
       eventId: entity.guid
       eventName: entity.name
     awsSample:
-      select: average(provider.latency.Average) / 1000
+      select: average(provider.latency.Average)
       from: ApiGatewaySample
       where: provider='ApiGatewayStage'
       eventId: entityGuid

--- a/definitions/infra-awsapigatewaystage/summary_metrics.yml
+++ b/definitions/infra-awsapigatewaystage/summary_metrics.yml
@@ -23,7 +23,7 @@ latencyMs:
   goldenMetric: latencyMs
   query:
     eventId: entity.guid
-    select: (average(aws.apigateway.Latency.byStage))
+    select: (average(aws.apigateway.Latency.byStage)) / 1000
     from: Metric
   unit: SECONDS
   title: Latency

--- a/definitions/infra-awsapigatewaystage/summary_metrics.yml
+++ b/definitions/infra-awsapigatewaystage/summary_metrics.yml
@@ -23,7 +23,7 @@ latencyMs:
   goldenMetric: latencyMs
   query:
     eventId: entity.guid
-    select: (average(aws.apigateway.Latency.byStage)) / 1000
+    select: (average(aws.apigateway.Latency.byStage))
     from: Metric
   unit: SECONDS
   title: Latency


### PR DESCRIPTION
The main goal of this PR was to set the same units for latency metrics in SM and GM.

Apart from that, I assumed that the latency for the GM was wrong, since this is a gatewaystage, so I guess we need to pick the xxx.byStage rather than the byApi.