### PR TITLE
NR-22605 Lambda function aliases not showing golden metrics in the ex…

### DIFF
--- a/definitions/infra-awslambdafunctionalias/golden_metrics.yml
+++ b/definitions/infra-awslambdafunctionalias/golden_metrics.yml
@@ -3,7 +3,7 @@ errorRate:
   unit: PERCENTAGE
   queries:
     aws:
-      select: 100 * sum(aws.lambda.Errors.byFunction) / sum(aws.lambda.Invocations.byFunction)
+      select: 100 * sum(aws.lambda.Errors.byFunctionAlias) / sum(aws.lambda.Invocations.byFunctionAlias)
       from: Metric
       eventId: entity.guid
       eventName: entity.name
@@ -18,7 +18,7 @@ totalInvocations:
   unit: COUNT
   queries:
     aws:
-      select: rate(sum(aws.lambda.Invocations.byFunction), 1 minute)
+      select: rate(sum(aws.lambda.Invocations.byFunctionAlias), 1 minute)
       from: Metric
       eventId: entity.guid
       eventName: entity.name
@@ -33,7 +33,7 @@ duration99PercentileS:
   unit: SECONDS
   queries:
     aws:
-      select: max(aws.lambda.Duration.byFunction) / 1000
+      select: max(aws.lambda.Duration.byFunctionAlias) / 1000
       from: Metric
       eventId: entity.guid
       eventName: entity.name
@@ -48,7 +48,7 @@ throttles:
   unit: COUNT        
   queries:
     aws:
-      select: rate(sum(aws.lambda.Throttles.byFunction), 1 minute)
+      select: rate(sum(aws.lambda.Throttles.byFunctionAlias), 1 minute)
       from: Metric
       eventId: entity.guid
       eventName: entity.name


### PR DESCRIPTION
…plorer

### Relevant information
We're looking for metrics like byFunction but it should be looking at byFunctionAlias

Update the golden metric definitions to use the byFunctionAlias metrics.


### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
