### PR TITLE
Revert "feat: Add entity synthesis for host from log data (#598)"

### DIFF
--- a/definitions/infra-host/definition.yml
+++ b/definitions/infra-host/definition.yml
@@ -1,24 +1,24 @@
 domain: INFRA
 type: HOST
 goldenTags:
-  - account
-  - windowsPlatform
-  - linuxDistribution
-  - aws.awsRegion
-  - aws.region
-  - aws.availabilityZone
-  - aws.accountId
-  - azure.regionName
-  - azure.subscriptionId
-  - azure.resourceGroup
-  - gcp.zone
-  - gcp.projectId
-  # opentelemetry semantic conventions for cloud instances
-  - cloud.provider
-  - cloud.account.id
-  - cloud.region
-  - cloud.availability_zone
-  - cloud.platform
+- account
+- windowsPlatform
+- linuxDistribution
+- aws.awsRegion
+- aws.region
+- aws.availabilityZone
+- aws.accountId
+- azure.regionName
+- azure.subscriptionId
+- azure.resourceGroup
+- gcp.zone
+- gcp.projectId
+# opentelemetry semantic conventions for cloud instances
+- cloud.provider
+- cloud.account.id
+- cloud.region
+- cloud.availability_zone
+- cloud.platform
 synthesis:
   rules:
     # opentelemetry host data from opentelemetry-collector
@@ -109,47 +109,6 @@ synthesis:
         host.image.id:
         host.image.version:
         instrumentation.provider:
-
-    # host information from log data
-    - identifier: host
-      name: host
-      encodeIdentifierInGUID: true
-      conditions:
-        - attribute: 'service_name'
-          present: false
-        - attribute: 'container.name'
-          present: false
-        - attribute: eventType
-          value: Log
-        - attribute: newrelic.source
-          value: 'api.logs'
-
-    - identifier: hostname
-      name: hostname
-      encodeIdentifierInGUID: true
-      conditions:
-        - attribute: 'service_name'
-          present: false
-        - attribute: 'container.name'
-          present: false
-        - attribute: eventType
-          value: Log
-        - attribute: newrelic.source
-          value: 'api.logs'
-
-    - identifier: host.name
-      name: host.name
-      encodeIdentifierInGUID: true
-      conditions:
-        - attribute: 'service_name'
-          present: false
-        - attribute: 'container.name'
-          present: false
-        - attribute: eventType
-          value: Log
-        - attribute: newrelic.source
-          value: 'api.logs'
-
 configuration:
   entityExpirationTime: DAILY
   alertable: true


### PR DESCRIPTION
### Relevant information

This reverts commit 4fa697c922ee9ca22aa272ac316b6fb6568f7c99.

We have found a few cases where these new rules are not working as it's expected.
To be cautious we decided to roll-back the rules that are related to logs

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
