### PR TITLE
Add eventName to awsalb requests sample GM

### DIFF
--- a/definitions/infra-awsalb/golden_metrics.yml
+++ b/definitions/infra-awsalb/golden_metrics.yml
@@ -56,3 +56,4 @@ requests:
       from: LoadBalancerSample
       where: provider='Alb'
       eventId: entityGuid
+      eventName: entityName


### PR DESCRIPTION
I want the requests metric to be processed by the golden metric harvester, but Its not. I guess is because the event name field was missing.