### PR TITLE
NOJIRA Fix GM for azure redis shard

### DIFF
--- a/definitions/infra-azurerediscacheshard/golden_metrics.yml
+++ b/definitions/infra-azurerediscacheshard/golden_metrics.yml
@@ -1,14 +1,24 @@
 hitRate:
-  query:
-    eventId: entityGuid
-    select: sum(`cacheHits.Total`) * 100 / (sum(`cacheHits.Total`) + sum(`cacheMisses.Total`))
-    from: AzureRedisCacheShardSample
+  queries:
+    newrelic:
+      from: Metric
+      select: sum(`azure.cache.redis.cachehits0`)* 100 / (sum(`azure.cache.redis.cachehits0`) + sum(`azure.cache.redis.cachemisses0`))
+      eventId: entity.guid
+    newrelicSample:
+      eventId: entityGuid
+      select: sum(`cacheHits.Total`) * 100 / (sum(`cacheHits.Total`) + sum(`cacheMisses.Total`))
+      from: AzureRedisCacheShardSample
   unit: PERCENTAGE
   title: Hit rate
 operations:
-  query:
-    eventId: entityGuid
-    select: average(`operationsPerSecond.Maximum`)
-    from: AzureRedisCacheShardSample
+  queries:
+    newrelic:
+      from: Metric
+      select: max(`azure.cache.redis.operationsPerSecond0`)
+      eventId: entity.guid
+    newrelicSample:
+      eventId: entityGuid
+      select: average(`operationsPerSecond.Maximum`)
+      from: AzureRedisCacheShardSample
   unit: OPERATIONS_PER_SECOND
   title: Operations rate


### PR DESCRIPTION
### Relevant information

The GM from azure redis shard do not have the query that points to new relic Metrics. 
This PR is fixing this.