### PR TITLE
Infra host metrics have precedence over cloud metrics

### DIFF
--- a/definitions/infra-host/summary_metrics.yml
+++ b/definitions/infra-host/summary_metrics.yml
@@ -38,7 +38,7 @@ cpuUtilizationPercentGcp:
 cpuUtilizationPercent:
   title: CPU utilization percent
   unit: PERCENTAGE
-  derive: '@cpuUtilizationPercentEc2 || @cpuUtilizationPercentAzure || @cpuUtilizationPercentGcp || @cpuUtilizationPercentHost'
+  derive: '@cpuUtilizationPercentHost || @cpuUtilizationPercentEc2 || @cpuUtilizationPercentAzure || @cpuUtilizationPercentGcp'
 memoryUsedPercent:
   title: Memory used percent
   unit: PERCENTAGE
@@ -148,4 +148,4 @@ networkTrafficOtel:
 networkTraffic:
   title: Network traffic
   unit: BYTES_PER_SECOND
-  derive: '@networkTrafficEc2 || @networkTrafficAzure || @networkTrafficGcp || @networkTrafficHost || @networkTrafficOtel'
+  derive: '@networkTrafficHost || @networkTrafficOtel || @networkTrafficEc2 || @networkTrafficAzure || @networkTrafficGcp'


### PR DESCRIPTION
### Relevant information

Summary metrics for hosts should use host metrics if available, and then fall back to cloud if available

https://github.com/newrelic/infrastructure-agent/issues/1219

### Checklist

* [X] I've read the guidelines and understand the acceptance criteria.
* [X] The value of the attribute marked as `identifier` will be unique and valid. 
* [X] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
