### PR TITLE
fix GM for gcpkubernetesnode

### DIFF
--- a/definitions/infra-gcpkubernetesnode/golden_metrics.yml
+++ b/definitions/infra-gcpkubernetesnode/golden_metrics.yml
@@ -1,14 +1,24 @@
 cpuUsage:
-  query:
-    eventId: entityGuid
-    select: average(`node.cpu.coreUsageTime`)
-    from: GcpKubernetesNodeSample
+  queries:
+    newrelic:
+      from: Metric
+      select: average(gcp.kubernetes.node.cpu.core_usage_time)
+      eventId: entity.guid
+    newrelicSample:  
+      eventId: entityGuid
+      select: average(`node.cpu.coreUsageTime`)
+      from: GcpKubernetesNodeSample
   unit: SECONDS
   title: Cumulative CPU utilization over 60s
 memoryUsage:
-  query:
-    eventId: entityGuid
-    select: average(`node.memory.usedBytes`)
-    from: GcpKubernetesNodeSample
+  queries:
+    newrelic:
+      from: Metric
+      select: average(gcp.kubernetes.node.memory.used_bytes)
+      eventId: entity.guid
+    newrelicSample:
+      eventId: entityGuid
+      select: average(`node.memory.usedBytes`)
+      from: GcpKubernetesNodeSample
   unit: BYTES
   title: Memory usage


### PR DESCRIPTION
the golden metrics for gcpkubernetesnode did not have the Metric queries...
this PR adds them.