### PR TITLE
Corrected typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ You can test that the synthesis rules from your entity definition match the expe
 
 ### How to add testing data
 
-1. If it does not exist, create a folder named `test` under your entity definition directory. If it already exists, skip this step.
+1. If it does not exist, create a folder named `tests` under your entity definition directory. If it already exists, skip this step.
 
   i.e. `definitions/ext-pihole/tests/`
 


### PR DESCRIPTION
One character update to fix typo - folder name for test files needs to be `tests` not `test`

### Relevant information

Describe what you have done and any details that you think are relevant or that you might want to discuss with us. 

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.

N/A - just changing README.md
