### PR TITLE
NR-30515 fix units of metrics in MS or RPM

### DIFF
--- a/definitions/ext-cloudflare_host/golden_metrics.yml
+++ b/definitions/ext-cloudflare_host/golden_metrics.yml
@@ -1,5 +1,6 @@
 throughput:
   title: Throughput (rpm)
+  unit: REQUESTS_PER_MINUTE
   query:
     select: rate(sum(cloudflare_request_total), 1 minute)
     from: Metric
@@ -13,6 +14,7 @@ errorRate:
     where: cloudflare_request_total IS NOT NULL
 
 responseTimeMs:
+  unit: MS
   title: Response time (ms)
   query:
     select: average(cloudflare_response_time_ms)

--- a/definitions/ext-istio_service/golden_metrics.yml
+++ b/definitions/ext-istio_service/golden_metrics.yml
@@ -10,6 +10,7 @@ errorRate:
     where: reporter = 'destination'
     from: Metric
 responseTimeMs:
+  unit: MS
   title: Response time (ms)
   query:
     select: sum(istio_request_duration_milliseconds_sum) / count(istio_request_duration_milliseconds_count)

--- a/definitions/infra-awsalbtargetgroup/golden_metrics.yml
+++ b/definitions/infra-awsalbtargetgroup/golden_metrics.yml
@@ -45,7 +45,7 @@ responseTime:
       eventName: entityName
 requests:
   title: Requests
-  unit: COUNT
+  unit: REQUESTS_PER_MINUTE
   queries:
     aws:
       select: rate(sum(aws.applicationelb.RequestCountPerTarget), 1 minute)

--- a/definitions/infra-awsapigatewayapi/golden_metrics.yml
+++ b/definitions/infra-awsapigatewayapi/golden_metrics.yml
@@ -30,7 +30,7 @@ errors4XxAnd5Xx:
       eventName: entityName
 latencyMs:
   title: Latency (ms)
-  unit: SECONDS
+  unit: MS
   queries:
     aws:
       select: average(aws.apigateway.Latency.byApi)

--- a/definitions/infra-awsapigatewayresourcewithmetrics/golden_metrics.yml
+++ b/definitions/infra-awsapigatewayresourcewithmetrics/golden_metrics.yml
@@ -30,7 +30,7 @@ errors4XxAnd5Xx:
       eventName: entityName
 latencyMs:
   title: Latency (ms)
-  unit: SECONDS
+  unit: MS
   queries:
     aws:
       select: average(aws.apigateway.Latency.byApi)

--- a/definitions/infra-awselasticsearchcluster/golden_metrics.yml
+++ b/definitions/infra-awselasticsearchcluster/golden_metrics.yml
@@ -30,7 +30,7 @@ indexingRateReqsMin:
       eventName: entityName
 searchLatencyMs:
   title: Search latency (ms)
-  unit: SECONDS
+  unit: MS
   queries:
     aws:
       select: average(aws.es.SearchLatency.byCluster)
@@ -45,7 +45,7 @@ searchLatencyMs:
       eventName: entityName
 indexingLatencyMs:
   title: Indexing latency (ms)
-  unit: SECONDS
+  unit: MS
   queries:
     aws:
       select: average(aws.es.IndexingLatency.byCluster)

--- a/definitions/infra-awselasticsearchnode/golden_metrics.yml
+++ b/definitions/infra-awselasticsearchnode/golden_metrics.yml
@@ -30,7 +30,7 @@ indexingRateReqsMin:
       eventName: entityName
 searchLatencyMs:
   title: Search latency (ms)
-  unit: SECONDS
+  unit: MS
   queries:
     aws:
       select: average(aws.es.SearchLatency.byCluster)
@@ -45,7 +45,7 @@ searchLatencyMs:
       eventName: entityName
 indexingLatencyMs:
   title: Indexing latency (ms)
-  unit: SECONDS
+  unit: MS
   queries:
     aws:
       select: average(aws.es.IndexingLatency.byCluster)

--- a/definitions/infra-awslambdafunction/golden_metrics.yml
+++ b/definitions/infra-awslambdafunction/golden_metrics.yml
@@ -15,7 +15,7 @@ errorRate:
       eventName: entityName
 totalInvocations:
   title: Total Invocations
-  unit: COUNT
+  unit: REQUESTS_PER_MINUTE
   queries:
     aws:
       select: rate(sum(aws.lambda.Invocations.byFunction), 1 minute)

--- a/definitions/infra-awslambdafunction/summary_metrics.yml
+++ b/definitions/infra-awslambdafunction/summary_metrics.yml
@@ -20,7 +20,7 @@ errorRate:
 totalInvocations:
   goldenMetric: totalInvocations
   title: Total Invocations
-  unit: COUNT
+  unit: REQUESTS_PER_MINUTE
   query:
     select: rate(sum(provider.invocations.Sum),1 minute)
     from: ServerlessSample

--- a/definitions/infra-awslambdafunctionalias/golden_metrics.yml
+++ b/definitions/infra-awslambdafunctionalias/golden_metrics.yml
@@ -15,7 +15,7 @@ errorRate:
       eventName: entityName
 totalInvocations:
   title: Total Invocations
-  unit: COUNT
+  unit: REQUESTS_PER_MINUTE
   queries:
     aws:
       select: rate(sum(aws.lambda.Invocations.byFunctionAlias), 1 minute)

--- a/definitions/infra-awsmediapackagevodpackagingconfiguration/golden_metrics.yml
+++ b/definitions/infra-awsmediapackagevodpackagingconfiguration/golden_metrics.yml
@@ -14,7 +14,7 @@ bytesSuccessfullySentPerRequest:
       eventName: entityName
 processTimeOfOutputRequestsMs:
   title: Process time of output requests (ms)
-  unit: SECONDS
+  unit: MS
   queries:
     aws:
       select: average(aws.mediapackage.EgressResponseTime)

--- a/definitions/infra-awsstatesstatemachine/golden_metrics.yml
+++ b/definitions/infra-awsstatesstatemachine/golden_metrics.yml
@@ -15,7 +15,7 @@ successfulExecutions:
       eventName: entityName
 executionTimeMs:
   title: Execution time (ms)
-  unit: SECONDS
+  unit: MS
   queries:
     aws:
       select: average(aws.states.ExecutionTime)

--- a/definitions/infra-azureapplicationgateway/golden_metrics.yml
+++ b/definitions/infra-azureapplicationgateway/golden_metrics.yml
@@ -84,7 +84,7 @@ inboundTrafficB:
       eventName: entityName
 rttMs:
   title: RTT (ms)
-  unit: SECONDS
+  unit: MS
   queries:
     azure:
       select: average(azure.network.applicationgateways.ClientRtt)
@@ -98,7 +98,7 @@ rttMs:
       eventName: entityName
 responseTimeMs:
   title: Response time (ms)
-  unit: SECONDS
+  unit: MS
   queries:
     azure:
       select: average(azure.network.applicationgateways.ApplicationGatewayTotalTime)

--- a/definitions/infra-azurefrontdoorfrontdoor/golden_metrics.yml
+++ b/definitions/infra-azurefrontdoorfrontdoor/golden_metrics.yml
@@ -28,7 +28,7 @@ responseSizeBytes:
       eventName: entityName
 latencyMs:
   title: Latency (ms)
-  unit: SECONDS
+  unit: MS
   queries:
     azure:
       select: sum(azure.network.frontdoors.TotalLatency)

--- a/definitions/infra-azurekeyvaultvault/golden_metrics.yml
+++ b/definitions/infra-azurekeyvaultvault/golden_metrics.yml
@@ -14,7 +14,7 @@ serviceApiHits:
       eventName: entityName
 serviceApiLatencyMs:
   title: Service API latency (ms)
-  unit: SECONDS
+  unit: MS
   queries:
     azure:
       select: average(azure.keyvault.vaults.ServiceApiLatency)

--- a/definitions/infra-azurepowerbidedicatedcapacity/golden_metrics.yml
+++ b/definitions/infra-azurepowerbidedicatedcapacity/golden_metrics.yml
@@ -1,6 +1,6 @@
 daxQueryDurationInLastIntervalMs:
   title: DAX query duration in last interval (ms)
-  unit: SECONDS
+  unit: MS
   queries:
     azure:
       select: average(azure.powerbidedicated.capacities.QueryDuration)

--- a/definitions/infra-gcpbigtabletable/golden_metrics.yml
+++ b/definitions/infra-gcpbigtabletable/golden_metrics.yml
@@ -1,6 +1,6 @@
 replicationRequestLatenciesMs:
   title: Replication request latencies (ms)
-  unit: SECONDS
+  unit: MS
   queries:
     gcp:
       select: average(gcp.bigtable.table.replication.latency)

--- a/definitions/infra-gcphttploadbalancer/golden_metrics.yml
+++ b/definitions/infra-gcphttploadbalancer/golden_metrics.yml
@@ -14,7 +14,7 @@ requestsRate:
       eventName: entityName
 totalLatencyMs:
   title: Total latency
-  unit: SECONDS
+  unit: MS
   queries:
     gcp:
       select: average(gcp.loadbalancing.https.total_latencies) / 1000

--- a/definitions/infra-mssqlinstance/golden_metrics.yml
+++ b/definitions/infra-mssqlinstance/golden_metrics.yml
@@ -28,7 +28,7 @@ blockedProcesses:
       eventName: entityName
 waitTimeMs:
   title: Wait time (ms)
-  unit: SECONDS
+  unit: MS
   queries:
     newRelic:
       select: average(mssql.instance.system.waitTimeInMillisecondsPerSecond)


### PR DESCRIPTION
### Relevant information

The goal of this PR is to fix those metrics that are reported in Milliseconds but the UNIT is wrong. Also those metrics that are reported in RPM, but the unit is wrong.