### PR TITLE
Fix golden metrics for aws-iot-rule

### DIFF
--- a/definitions/infra-awsiotrule/golden_metrics.yml
+++ b/definitions/infra-awsiotrule/golden_metrics.yml
@@ -1,14 +1,26 @@
 matches:
-  query:
-    eventId: entity.guid
-    select: sum(aws.iot.TopicMatch)
-    from: Metric
+  queries:
+    newrelic:
+      eventId: entity.guid
+      select: sum(aws.iot.TopicMatch)
+      from: Metric
+    newRelicSample:
+      from: IOTRuleSample
+      select: sum(provider.topicMatch)
+      eventId: entityGuid
+      eventName: entityName
   unit: COUNT
   title: Topic matches
 errors:
-  query:
-    eventId: entity.guid
-    select: sum(aws.iot.ParseError)
-    from: Metric
+  queries:
+    newrelic:
+      eventId: entity.guid
+      select: sum(aws.iot.ParseError)
+      from: Metric
+    newrelicSample:
+      from: IOTRuleSample
+      select: sum(provider.ParseError)
+      eventId: entityGuid
+      eventName: entityName
   unit: COUNT
   title: Parse errors

--- a/definitions/infra-awsiotrule/golden_metrics.yml
+++ b/definitions/infra-awsiotrule/golden_metrics.yml
@@ -6,7 +6,7 @@ matches:
       from: Metric
     newRelicSample:
       from: IOTRuleSample
-      select: sum(provider.topicMatch)
+      select: sum(provider.topicMatch.Sum)
       eventId: entityGuid
       eventName: entityName
   unit: COUNT
@@ -19,7 +19,7 @@ errors:
       from: Metric
     newrelicSample:
       from: IOTRuleSample
-      select: sum(provider.ParseError)
+      select: sum(provider.ParseError.Sum)
       eventId: entityGuid
       eventName: entityName
   unit: COUNT


### PR DESCRIPTION
After checking the golden signals for some accounts, I've realized the queries ara not 100% accurate.