### PR TITLE
remove rabbitmq cluster entity

### DIFF
--- a/definitions/infra-rabbitmqcluster/definition.yml
+++ b/definitions/infra-rabbitmqcluster/definition.yml
@@ -1,7 +1,0 @@
-domain: INFRA
-type: RABBITMQCLUSTER
-goldenTags:
-- account
-configuration:
-  entityExpirationTime: DAILY
-  alertable: true


### PR DESCRIPTION
### Relevant information
Removing the Rabbitmq cluster entity so it's no longer synthetized and present in the platform.

We have deprecated this entity and[ EOL anouncement](https://discuss.newrelic.com/t/q1-bulk-eol-announcement-fy23/181744)

The entity didn't have any metrics by it's own but was just using metrics from other entities. The charts were broken and fixing them for Dimensional Metrics was not possible.

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
