### PR TITLE
feat: Add support for GCP VPCs

### DIFF
--- a/definitions/ext-vpc_network/definition.yml
+++ b/definitions/ext-vpc_network/definition.yml
@@ -16,14 +16,41 @@ synthesis:
       conditions:
         - attribute: provider
           value: firehose-vpc
+    # gcp pubsub -> dataflow (DEST)
+    - compositeIdentifier:
+        separator: "/"
+        attributes:
+          - jsonPayload.dest_vpc.project_id
+          - jsonPayload.dest_vpc.vpc_name
+      name: jsonPayload.dest_vpc.vpc_name
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: jsonPayload.reporter
+          value: "DEST"
+    # gcp pubsub -> dataflow (SRC)
+    - compositeIdentifier:
+        separator: "/"
+        attributes:
+          - jsonPayload.src_vpc.project_id
+          - jsonPayload.src_vpc.vpc_name
+      name: jsonPayload.src_vpc.vpc_name
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: jsonPayload.reporter
+          value: "SRC"
+
 
 goldenTags:
   - sample_rate
   - account_id
   - region
+  - resource.labels.project_id
+  - resource.labels.subnetwork_id
 
 dashboardTemplates:
   kentik/aws-vpc-flow-events:
     template: kentik-aws-vpc-dashboard.json
   aws-kinesis-firehose/vpc-flow-logs:
     template: aws-kinesis-firehose-vpc-flow-logs-dashboard.json
+  gcp-pubsub-dataflow/vpc-flow-logs-gcp:
+    template: gcp-pubsub-dataflow-vpc-flow-logs-dashboard.json

--- a/definitions/ext-vpc_network/gcp-pubsub-dataflow-vpc-flow-logs-dashboard.json
+++ b/definitions/ext-vpc_network/gcp-pubsub-dataflow-vpc-flow-logs-dashboard.json
@@ -1,0 +1,496 @@
+{
+  "name": "GCP VPC Network",
+  "description": null,
+  "pages": [
+    {
+      "name": "VPC Network",
+      "description": null,
+      "widgets": [
+        {
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "height": 3,
+            "width": 2
+          },
+          "title": "VPC Network Summary",
+          "rawConfiguration": {
+            "dataFormatters": [],
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Log_VPC_Flows_GCP SELECT filter(latest(jsonPayload.src_vpc.vpc_name), WHERE jsonPayload.reporter = 'SRC') OR filter(latest(jsonPayload.dest_vpc.vpc_name), WHERE jsonPayload.reporter = 'DEST') as 'VPC Name', rate(count(*),1 second) as 'Flows per Second', latest(timestamp) as 'Last Update', uniqueCount(jsonPayload.connection.src_ip, jsonPayload.connection.dest_ip) as 'Observed IP Addresses', uniqueCount(concat(jsonPayload.connection.dest_ip, ':', jsonPayload.connection.dest_port), concat(jsonPayload.connection.src_ip, ':', jsonPayload.connection.src_port)) as 'Observed Endpoint Tuples'"
+              }
+            ],
+            "thresholds": []
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.area"
+          },
+          "layout": {
+            "column": 3,
+            "row": 1,
+            "height": 3,
+            "width": 5
+          },
+          "title": "Flow Bytes",
+          "rawConfiguration": {
+            "dataFormatters": [],
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Log_VPC_Flows_GCP\nSELECT sum(numeric(jsonPayload.bytes_sent))\nFacet CASES (\n  WHERE jsonPayload.reporter = 'SRC' as 'Egress Bytes',\n  WHERE jsonPayload.reporter = 'DEST' as 'Ingress Bytes') \nTIMESERIES 5 MINUTES"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.area"
+          },
+          "layout": {
+            "column": 8,
+            "row": 1,
+            "height": 3,
+            "width": 5
+          },
+          "title": "Flow Packets",
+          "rawConfiguration": {
+            "dataFormatters": [],
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Log_VPC_Flows_GCP\nSELECT sum(numeric(jsonPayload.packets_sent))\nFacet CASES (\n  WHERE jsonPayload.reporter = 'SRC' as 'Egress Packets',\n WHERE jsonPayload.reporter = 'DEST' as 'Ingress Packets') \nTIMESERIES 5 MINUTES"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "height": 3,
+            "width": 2
+          },
+          "title": "Sources",
+          "rawConfiguration": {
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Log_VPC_Flows_GCP SELECT uniqueCount(jsonPayload.connection.src_ip) AS 'Sources' TIMESERIES 5 MINUTES"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.pie"
+          },
+          "layout": {
+            "column": 3,
+            "row": 7,
+            "height": 3,
+            "width": 5
+          },
+          "title": "Top 25 - Sources",
+          "rawConfiguration": {
+            "dataFormatters": [],
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Log_VPC_Flows_GCP\nSELECT sum(numeric(jsonPayload.bytes_sent)) AS Bytes\nWHERE jsonPayload.reporter = 'SRC'\nFACET jsonPayload.connection.src_ip\nLIMIT 25"
+              }
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.area"
+          },
+          "layout": {
+            "column": 8,
+            "row": 7,
+            "height": 3,
+            "width": 5
+          },
+          "title": "Top 25 - Sources",
+          "rawConfiguration": {
+            "dataFormatters": [],
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Log_VPC_Flows_GCP\nSELECT sum(numeric(jsonPayload.bytes_sent)) AS Bytes\nWHERE jsonPayload.reporter = 'SRC'\nFACET jsonPayload.connection.src_ip\nLIMIT 25 TIMESERIES 5 MINUTES"
+              }
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 1,
+            "row": 10,
+            "height": 3,
+            "width": 2
+          },
+          "title": "Destinations",
+          "rawConfiguration": {
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Log_VPC_Flows_GCP SELECT uniqueCount(jsonPayload.connection.dest_ip) AS 'Destinations' TIMESERIES 5 MINUTES"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.pie"
+          },
+          "layout": {
+            "column": 3,
+            "row": 10,
+            "height": 3,
+            "width": 5
+          },
+          "title": "Top 25 - Destinations",
+          "rawConfiguration": {
+            "dataFormatters": [],
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Log_VPC_Flows_GCP\nSELECT sum(numeric(jsonPayload.bytes_sent)) AS Bytes\nFACET jsonPayload.connection.dest_ip\nLIMIT 25"
+              }
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.area"
+          },
+          "layout": {
+            "column": 8,
+            "row": 10,
+            "height": 3,
+            "width": 5
+          },
+          "title": "Top 25 - Destinations",
+          "rawConfiguration": {
+            "dataFormatters": [],
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Log_VPC_Flows_GCP\nSELECT sum(numeric(jsonPayload.bytes_sent)) AS Bytes\nFACET jsonPayload.connection.dest_ip\nLIMIT 25 TIMESERIES 5 MINUTES"
+              }
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 1,
+            "row": 13,
+            "height": 3,
+            "width": 2
+          },
+          "title": "Protocols",
+          "rawConfiguration": {
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Log_VPC_Flows_GCP SELECT uniqueCount(jsonPayload.connection.protocol) AS 'Protocols' TIMESERIES 5 MINUTES"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.pie"
+          },
+          "layout": {
+            "column": 3,
+            "row": 13,
+            "height": 3,
+            "width": 2
+          },
+          "title": "Top 5 - Inbound Protocols",
+          "rawConfiguration": {
+            "dataFormatters": [],
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Log_VPC_Flows_GCP\nSELECT sum(numeric(jsonPayload.bytes_sent)) AS Bytes\nWHERE jsonPayload.reporter = 'DEST'\nFACET jsonPayload.connection.protocol\nLIMIT 5"
+              }
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.area"
+          },
+          "layout": {
+            "column": 5,
+            "row": 13,
+            "height": 3,
+            "width": 3
+          },
+          "title": "Top 25 - Inbound Protocols",
+          "rawConfiguration": {
+            "dataFormatters": [],
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Log_VPC_Flows_GCP\nSELECT sum(numeric(jsonPayload.bytes_sent)) AS Bytes\nWHERE jsonPayload.reporter = 'DEST'\nFACET jsonPayload.connection.protocol\nLIMIT 25 TIMESERIES 5 MINUTES"
+              }
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.pie"
+          },
+          "layout": {
+            "column": 8,
+            "row": 13,
+            "height": 3,
+            "width": 2
+          },
+          "title": "Top 5 - Outbound Protocols",
+          "rawConfiguration": {
+            "dataFormatters": [],
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Log_VPC_Flows_GCP\nSELECT sum(numeric(jsonPayload.bytes_sent)) AS Bytes\nWHERE jsonPayload.reporter = 'SRC'\nFACET jsonPayload.connection.protocol\nLIMIT 5"
+              }
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.area"
+          },
+          "layout": {
+            "column": 10,
+            "row": 13,
+            "height": 3,
+            "width": 3
+          },
+          "title": "Top 25 - Outbound Protocols",
+          "rawConfiguration": {
+            "dataFormatters": [],
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Log_VPC_Flows_GCP\nSELECT sum(numeric(jsonPayload.bytes_sent)) AS Bytes\nWHERE jsonPayload.reporter = 'SRC'\nFACET jsonPayload.connection.protocol\nLIMIT 25 TIMESERIES 5 MINUTES"
+              }
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.table"
+          },
+          "layout": {
+            "column": 1,
+            "row": 22,
+            "height": 3,
+            "width": 4
+          },
+          "title": "Devices with most outbound partners",
+          "rawConfiguration": {
+            "dataFormatters": [],
+            "facet": {
+              "showOtherSeries": false
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Log_VPC_Flows_GCP SELECT uniqueCount(jsonPayload.connection.dest_ip) AS 'Destination IPS', uniqueCount(jsonPayload.connection.dest_port) AS 'Outbound Ports' FACET jsonPayload.connection.src_ip AS 'Source' LIMIT 25"
+              }
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 5,
+            "row": 22,
+            "height": 3,
+            "width": 8
+          },
+          "title": "Devices with most outbound partners",
+          "rawConfiguration": {
+            "dataFormatters": [],
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Log_VPC_Flows_GCP SELECT uniqueCount(jsonPayload.connection.dest_ip) FACET jsonPayload.connection.src_ip LIMIT 25 TIMESERIES 5 MINUTES"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.table"
+          },
+          "layout": {
+            "column": 1,
+            "row": 25,
+            "height": 3,
+            "width": 4
+          },
+          "title": "Devices with most inbound partners",
+          "rawConfiguration": {
+            "dataFormatters": [],
+            "facet": {
+              "showOtherSeries": false
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Log_VPC_Flows_GCP SELECT uniqueCount(jsonPayload.connection.dest_port) AS 'Destination Ports', uniqueCount(jsonPayload.connection.src_ip) AS 'Source IPS' FACET jsonPayload.connection.dest_ip AS 'Destination' LIMIT 25"
+              }
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 5,
+            "row": 25,
+            "height": 3,
+            "width": 8
+          },
+          "title": "Devices with most inbound partners",
+          "rawConfiguration": {
+            "dataFormatters": [],
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Log_VPC_Flows_GCP SELECT uniqueCount(jsonPayload.connection.src_ip) FACET jsonPayload.connection.dest_ip LIMIT 25 TIMESERIES 5 MINUTES"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/definitions/ext-vpc_network/golden_metrics.yml
+++ b/definitions/ext-vpc_network/golden_metrics.yml
@@ -10,6 +10,9 @@ sources:
       select: uniqueCount(src_endpoint)
       from: Log_VPC_Flows
       where: "provider = 'firehose-vpc'"
+    gcp-pubsub-dataflow/vpc-flow-logs-gcp:
+      select: uniqueCount(jsonPayload.connection.src_ip, jsonPayload.connection.src_port)
+      from: Log_VPC_Flows_GCP
 destinations:
   title: Unique destinations
   unit: COUNT
@@ -22,8 +25,9 @@ destinations:
       select: uniqueCount(dest_endpoint)
       from: Log_VPC_Flows
       where: "provider = 'firehose-vpc'"
-
-
+    gcp-pubsub-dataflow/vpc-flow-logs-gcp:
+      select: uniqueCount(jsonPayload.connection.dest_ip, jsonPayload.connection.dest_port)
+      from: Log_VPC_Flows_GCP
 egressBytes:
   title: Egress bytes
   unit: BYTES
@@ -36,7 +40,10 @@ egressBytes:
       select: sum(bytes*numeric(sample_rate))
       from: Log_VPC_Flows
       where: "provider = 'firehose-vpc' and flow_direction = 'egress'"
-
+    gcp-pubsub-dataflow/vpc-flow-logs-gcp:
+      select: sum(jsonPayload.bytes_sent)
+      from: Log_VPC_Flows_GCP
+      where: "jsonPayload.reporter = 'SRC'"
 ingressBytes:
   title: Ingress bytes
   unit: BYTES
@@ -49,4 +56,8 @@ ingressBytes:
       select: sum(bytes*numeric(sample_rate))
       from: Log_VPC_Flows
       where: "provider = 'firehose-vpc' and flow_direction = 'ingress'"
+    gcp-pubsub-dataflow/vpc-flow-logs-gcp:
+      select: sum(jsonPayload.bytes_sent)
+      from: Log_VPC_Flows_GCP
+      where: "jsonPayload.reporter = 'DEST'"
 

--- a/definitions/ext-vpc_network/summary_metrics.yml
+++ b/definitions/ext-vpc_network/summary_metrics.yml
@@ -13,7 +13,10 @@ sources:
       from: Log_VPC_Flows
       where: "provider = 'firehose-vpc'"
       eventId: entity.guid
-
+    gcp-pubsub-dataflow/vpc-flow-logs-gcp:
+      select: uniqueCount(jsonPayload.connection.src_ip, jsonPayload.connection.src_port)
+      from: Log_VPC_Flows_GCP
+      eventId: entity.guid
 destinations:
   goldenMetric: destinations
   title: Unique destinations
@@ -29,7 +32,10 @@ destinations:
       from: Log_VPC_Flows
       where: "provider = 'firehose-vpc'"
       eventId: entity.guid
-
+    gcp-pubsub-dataflow/vpc-flow-logs-gcp:
+      select: uniqueCount(jsonPayload.connection.dest_ip, jsonPayload.connection.dest_port)
+      from: Log_VPC_Flows_GCP
+      eventId: entity.guid
 egressBytes:
   goldenMetric: egressBytes
   title: Egress bytes
@@ -45,7 +51,11 @@ egressBytes:
       from: Log_VPC_Flows
       where: "provider = 'firehose-vpc' and flow_direction = 'egress'"
       eventId: entity.guid
-
+    gcp-pubsub-dataflow/vpc-flow-logs-gcp:
+      select: sum(jsonPayload.bytes_sent)
+      from: Log_VPC_Flows_GCP
+      where: "jsonPayload.reporter = 'SRC'"
+      eventId: entity.guid
 ingressBytes:
   goldenMetric: ingressBytes
   title: Ingress bytes
@@ -61,7 +71,11 @@ ingressBytes:
       from: Log_VPC_Flows
       where: "provider = 'firehose-vpc' and flow_direction = 'ingress'"
       eventId: entity.guid
-
+    gcp-pubsub-dataflow/vpc-flow-logs-gcp:
+      select: sum(jsonPayload.bytes_sent)
+      from: Log_VPC_Flows_GCP
+      where: "jsonPayload.reporter = 'DEST'"
+      eventId: entity.guid
 sampleRate:
   title: Sample rate
   unit: STRING


### PR DESCRIPTION
### Relevant information

This PR adds support for synthesizing VPC entities from GCP VPC Flow Logs. I tried to follow the same pattern that AWS Flow Logs use but things are a little more awkward in GCP for a couple reasons:

1. VPC IDs are not annotated onto flow logs like in GCP. As a result, I had to make the entity identifier the VPC name and the project ID. GCP Project IDs [must be globally unique](https://cloud.google.com/resource-manager/docs/creating-managing-projects#:~:text=A%20globally%20unique%20identifier%20for%20your%20project) and then VPC names [must be unique in a project](https://cloud.google.com/vpc/docs/create-modify-vpc-networks#:~:text=Each%20new%20network%20that%20you%20create%20must%20have%20a%20unique%20name%20within%20the%20same%20project). Also, VPC names cannot be changed after they are created. I don't love this approach but I think it's the best way to get things working?
2. GCP VPC Flow Logs report the source and destination VPC when applicable so I had to use a semi-awkward workaround to pick the "right" VPC to synthesize. I make sure to select the "reporting" VPC's by using a condition on the `jsonPayload.reporter` and adding two rules for synthesis. LMK if you think there's a better approach.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
