### PR TITLE
Fix networkTrafficTotal golden metric for INFRA-CONTAINER

### DIFF
--- a/definitions/infra-container/golden_metrics.yml
+++ b/definitions/infra-container/golden_metrics.yml
@@ -23,4 +23,5 @@ networkTrafficTotal:
   title: Network traffic (bytes per second)
   unit: BYTES_PER_SECOND
   query:
-    select: average(docker.container.networkRxBytesPerSecond) + average(docker.container.networkTxBytesPerSecond) AS 'Network traffic (bytes per second)'
+    from: ContainerSample
+    select: average(networkRxBytesPerSecond + networkTxBytesPerSecond) AS 'Network traffic (bytes per second)'


### PR DESCRIPTION
### Relevant information

Rewrite the GM definition for the `networkTrafficTotal` metric for the INFRA-CONTAINER entity type to be based on `ContainerSample` instead of `Metric`. 

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
