### PR TITLE
Align SM and GM definitions for EXT-DB2

### DIFF
--- a/definitions/ext-db2/golden_metrics.yml
+++ b/definitions/ext-db2/golden_metrics.yml
@@ -1,5 +1,6 @@
 executionTime:
   title: Execution time (ms)
+  unit: MS
   query:
     select: latest(average_execution_time_ms)
     from: db2
@@ -7,6 +8,7 @@ executionTime:
     eventName: database
 hitRatio:
   title: Hit ratio
+  unit: PERCENTAGE
   query:
     select: latest(total_hit_ratio_percent)
     from: db2
@@ -14,8 +16,16 @@ hitRatio:
     eventName: database
 errorRate:
   title: Error rate
+  unit: PERCENTAGE
   query:
     select: filter(count(errorCode), WHERE errorCode is NOT NULL)/count(*)*100
     from: db2
     eventId: entity.guid
     eventName: database
+tablespaceFree:
+  title: Tablespace free
+  unit: PERCENTAGE
+  query:
+    select: latest(100 - tbsp_utilization_percent) 
+    from: db2
+    eventId: entity.guid

--- a/definitions/ext-db2/summary_metrics.yml
+++ b/definitions/ext-db2/summary_metrics.yml
@@ -1,18 +1,21 @@
 tablespaceFree:
+  goldenMetric: tablespaceFree
   title: Tablespace free
   unit: PERCENTAGE
   query:
-    select: 100-(latest(tbsp_used_size_mb)/latest(tbsp_total_size_mb))*100
+    select: latest(100 - tbsp_utilization_percent)
     from: db2
     eventId: entity.guid
 hitRatio:
+  goldenMetric: hitRatio
   title: Hit ratio
   unit: PERCENTAGE
   query:
     select: latest(total_hit_ratio_percent)
     from: db2
     eventId: entity.guid
-errorCount:
+errorRate:
+  goldenMetric: errorRate
   title: Error rate
   unit: PERCENTAGE
   query:


### PR DESCRIPTION
### Relevant information

Introduced missing units in the GM definitions, aligned the name of the `errorRate` metric, added a new GM so that it can be referenced in the SM definition file. 

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
