### PR TITLE
Fix network synth metric name

### DIFF
--- a/definitions/ext-network_synth/golden_metrics.yml
+++ b/definitions/ext-network_synth/golden_metrics.yml
@@ -27,6 +27,6 @@ packetLoss:
   title: Packet loss (%)
   unit: PERCENTAGE
   query:
-    select: latest(kentik.synth.lost_pct)
+    select: latest(kentik.synth.lost)
     from: Metric
     where: "provider = 'kentik-network-synthetic'"

--- a/definitions/ext-network_synth/network-synth-dashboard.json
+++ b/definitions/ext-network_synth/network-synth-dashboard.json
@@ -47,7 +47,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "FROM Metric SELECT round(average(kentik.synth.lost_pct),2) as 'Average Loss %' since 10 minutes ago compare with 1 day ago"
+                "query": "FROM Metric SELECT round(average(kentik.synth.lost),2) as 'Average Loss %' since 10 minutes ago compare with 1 day ago"
               }
             ],
             "thresholds": []
@@ -124,7 +124,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "FROM Metric SELECT average(kentik.synth.lost_pct)/1000 FACET agent_name as Location TIMESERIES limit max "
+                "query": "FROM Metric SELECT average(kentik.synth.lost) FACET agent_name as Location TIMESERIES limit max "
               }
             ],
             "yAxisLeft": {

--- a/definitions/ext-network_synth/summary_metrics.yml
+++ b/definitions/ext-network_synth/summary_metrics.yml
@@ -33,7 +33,7 @@ packetLoss:
   title: Packet loss (%)
   unit: PERCENTAGE
   query:
-    select: latest(kentik.synth.lost_pct)
+    select: latest(kentik.synth.lost)
     from: Metric
     where: "provider = 'kentik-network-synthetic'"
     eventId: entity.guid


### PR DESCRIPTION
### Relevant information

One of the attribute names used in the dashboard and golden metrics needed to be updated from an earlier version.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
