### PR TITLE
chore: add cisco-wlc to existing wireless controller entity

### DIFF
--- a/definitions/ext-wireless_controller/cisco-wlc-dashboard.json
+++ b/definitions/ext-wireless_controller/cisco-wlc-dashboard.json
@@ -1,0 +1,360 @@
+{
+    "name": "Cisco Wireless LAN Controller",
+    "description": null,
+    "pages": [
+      {
+        "name": "Cisco Wireless LAN Controller",
+        "description": null,
+        "widgets": [
+          {
+            "title": "Summary",
+            "layout": {
+              "column": 1,
+              "row": 1,
+              "width": 4,
+              "height": 5
+            },
+            "visualization": {
+              "id": "viz.billboard"
+            },
+            "rawConfiguration": {
+              "dataFormatters": [
+                {
+                  "name": "Last Update",
+                  "type": "date"
+                },
+                {
+                  "name": "Uptime (Days)",
+                  "precision": 2,
+                  "type": "decimal"
+                }
+              ],
+              "facet": {
+                "showOtherSeries": false
+              },
+              "nrqlQueries": [
+                {
+                  "accountId": 0,
+                  "query": "FROM Metric SELECT latest(device_name) AS 'Device Name', latest(src_addr) AS 'Device IP', latest(SysLocation) AS 'Location', latest(kentik.snmp.Uptime)/8640000 AS 'Uptime (Days)', latest(SysObjectID) AS 'SysObjectID', latest(entity.type) AS 'Entity Type', latest(instrumentation.name) AS 'Ktranslate Profile', latest(timestamp) AS 'Last Update', latest(PollingHealth) AS 'Polling Health', latest(PollingHealthReason) AS 'Health Reason' WHERE provider = 'kentik-wireless-controller'"
+                }
+              ],
+              "platformOptions": {
+                "ignoreTimeRange": false
+              }
+            }
+          },
+          {
+            "title": "Current CPU Utilization (%)",
+            "layout": {
+              "column": 5,
+              "row": 1,
+              "width": 4,
+              "height": 1
+            },
+            "visualization": {
+              "id": "viz.billboard"
+            },
+            "rawConfiguration": {
+              "facet": {
+                "showOtherSeries": false
+              },
+              "nrqlQueries": [
+                {
+                  "accountId": 0,
+                  "query": "FROM Metric SELECT latest(kentik.snmp.CPU) AS 'Current CPU Utilization (%)' WHERE provider = 'kentik-wireless-controller'"
+                }
+              ],
+              "platformOptions": {
+                "ignoreTimeRange": false
+              },
+              "thresholds": [
+                {
+                  "alertSeverity": "WARNING",
+                  "value": 90
+                },
+                {
+                  "alertSeverity": "CRITICAL",
+                  "value": 95
+                }
+              ]
+            }
+          },
+          {
+            "title": "Current Memory Utilization (%)",
+            "layout": {
+              "column": 9,
+              "row": 1,
+              "width": 4,
+              "height": 1
+            },
+            "visualization": {
+              "id": "viz.billboard"
+            },
+            "rawConfiguration": {
+              "facet": {
+                "showOtherSeries": false
+              },
+              "nrqlQueries": [
+                {
+                  "accountId": 0,
+                  "query": "FROM Metric SELECT latest(kentik.snmp.MemoryUtilization) AS 'Current Memory Utilization (%)' WHERE provider = 'kentik-wireless-controller'"
+                }
+              ],
+              "platformOptions": {
+                "ignoreTimeRange": false
+              },
+              "thresholds": [
+                {
+                  "alertSeverity": "WARNING",
+                  "value": 90
+                },
+                {
+                  "alertSeverity": "CRITICAL",
+                  "value": 95
+                }
+              ]
+            }
+          },
+          {
+            "title": "CPU Utilization (%)",
+            "layout": {
+              "column": 5,
+              "row": 2,
+              "width": 4,
+              "height": 4
+            },
+            "visualization": {
+              "id": "viz.line"
+            },
+            "rawConfiguration": {
+              "facet": {
+                "showOtherSeries": false
+              },
+              "legend": {
+                "enabled": true
+              },
+              "nrqlQueries": [
+                {
+                  "accountId": 0,
+                  "query": "FROM Metric SELECT min(kentik.snmp.CPU) AS 'Min CPU', max(kentik.snmp.CPU) AS 'Max CPU', average(kentik.snmp.CPU) AS 'Average CPU' WHERE provider = 'kentik-wireless-controller' TIMESERIES 5 MINUTES"
+                }
+              ],
+              "platformOptions": {
+                "ignoreTimeRange": false
+              },
+              "yAxisLeft": {
+                "max": 100,
+                "min": 0,
+                "zero": false
+              }
+            }
+          },
+          {
+            "title": "Memory Utilization (%)",
+            "layout": {
+              "column": 9,
+              "row": 2,
+              "width": 4,
+              "height": 4
+            },
+            "visualization": {
+              "id": "viz.line"
+            },
+            "rawConfiguration": {
+              "facet": {
+                "showOtherSeries": false
+              },
+              "legend": {
+                "enabled": true
+              },
+              "nrqlQueries": [
+                {
+                  "accountId": 0,
+                  "query": "FROM Metric SELECT min(kentik.snmp.MemoryUtilization) AS 'Min Memory', max(kentik.snmp.MemoryUtilization) AS 'Max Memory', average(kentik.snmp.MemoryUtilization) AS 'Average Memory' WHERE provider = 'kentik-wireless-controller' TIMESERIES 5 MINUTES"
+                }
+              ],
+              "platformOptions": {
+                "ignoreTimeRange": false
+              },
+              "yAxisLeft": {
+                "max": 100,
+                "min": 0,
+                "zero": false
+              }
+            }
+          },
+          {
+            "title": "Interfaces Summary",
+            "layout": {
+              "column": 1,
+              "row": 6,
+              "width": 12,
+              "height": 3
+            },
+            "visualization": {
+              "id": "viz.table"
+            },
+            "rawConfiguration": {
+              "facet": {
+                "showOtherSeries": false
+              },
+              "nrqlQueries": [
+                {
+                  "accountId": 0,
+                  "query": "FROM Metric SELECT latest(if_OperStatus) AS 'Operational Status', latest(if_Speed) AS 'Interface Speed', latest(kentik.snmp.IfInUtilization) AS 'RX %', latest(kentik.snmp.IfOutUtilization) AS 'TX %', latest(kentik.snmp.ifInErrorPercent) AS 'RX Error %', latest(kentik.snmp.ifOutErrorPercent) AS 'TX Error %' FACET if_interface_name AS 'Interface', if_Description AS 'Description' WHERE provider = 'kentik-wireless-controller' LIMIT MAX"
+                }
+              ],
+              "platformOptions": {
+                "ignoreTimeRange": false
+              }
+            }
+          },
+          {
+            "title": "Access Point Inventory",
+            "layout": {
+              "column": 1,
+              "row": 9,
+              "width": 12,
+              "height": 4
+            },
+            "visualization": {
+              "id": "viz.table"
+            },
+            "rawConfiguration": {
+              "facet": {
+                "showOtherSeries": false
+              },
+              "nrqlQueries": [
+                {
+                  "accountId": 0,
+                  "query": "FROM Metric SELECT latest(bsnAPOperationStatus) AS 'Status' FACET bsnAPName AS 'AP Name', bsnApIpAddress AS 'AP IP', bsnAPDot3MacAddress AS 'AP MAC', bsnAPModel AS 'AP Model', bsnAPSerialNumber AS 'AP Serial', Index WHERE provider = 'kentik-wireless-controller' LIMIT MAX"
+                }
+              ],
+              "platformOptions": {
+                "ignoreTimeRange": false
+              }
+            }
+          },
+          {
+            "title": "AP Interface Statistics",
+            "layout": {
+              "column": 1,
+              "row": 13,
+              "width": 12,
+              "height": 5
+            },
+            "visualization": {
+              "id": "viz.table"
+            },
+            "rawConfiguration": {
+              "facet": {
+                "showOtherSeries": false
+              },
+              "nrqlQueries": [
+                {
+                  "accountId": 0,
+                  "query": "FROM Metric SELECT (latest(kentik.snmp.bsnAPIfPoorSNRClients)/latest(kentik.snmp.bsnAPIfLoadNumOfClients) )*100 AS 'Poor SNR %', latest(bsnAPIfOperStatus) AS 'Status', latest(kentik.snmp.bsnAPIfLoadChannelUtilization) AS 'Channel Utilization', latest(kentik.snmp.bsnAPIfPoorSNRClients) AS 'Clients with Poor SNR', latest(kentik.snmp.bsnAPIfLoadNumOfClients) AS 'Total Clients', latest(kentik.snmp.bsnAPIfPhyTxPowerLevel) AS 'TX Power Level' FACET Index AS 'AP Index' WHERE provider = 'kentik-wireless-controller' LIMIT MAX"
+                }
+              ],
+              "platformOptions": {
+                "ignoreTimeRange": false
+              }
+            }
+          },
+          {
+            "title": "Extended Service Set Inventory",
+            "layout": {
+              "column": 1,
+              "row": 18,
+              "width": 12,
+              "height": 3
+            },
+            "visualization": {
+              "id": "viz.table"
+            },
+            "rawConfiguration": {
+              "facet": {
+                "showOtherSeries": false
+              },
+              "nrqlQueries": [
+                {
+                  "accountId": 0,
+                  "query": "FROM Metric SELECT latest(kentik.snmp.bsnDot11EssNumberOfMobileStations) AS 'Number of Mobile Stations', latest(bsnDot11EssAdminStatus) AS 'Admin Status', latest(bsnDot11EssBroadcastSsid) AS 'Broadcast SSID', latest(bsnDot11EssQualityOfService) AS 'Quality of Service', latest(bsnDot11EssRadioPolicy) AS 'Radio Policy' FACET bsnDot11EssSsid AS 'SSID' WHERE provider = 'kentik-wireless-controller' LIMIT MAX"
+                }
+              ],
+              "platformOptions": {
+                "ignoreTimeRange": false
+              }
+            }
+          },
+          {
+            "title": "Interference Details",
+            "layout": {
+              "column": 1,
+              "row": 21,
+              "width": 12,
+              "height": 5
+            },
+            "visualization": {
+              "id": "viz.table"
+            },
+            "rawConfiguration": {
+              "facet": {
+                "showOtherSeries": false
+              },
+              "nrqlQueries": [
+                {
+                  "accountId": 0,
+                  "query": "FROM Metric SELECT max(kentik.snmp.bsnAPIfInterferenceUtilization) AS 'Interference %' FACET Index AS 'AP Index' WHERE provider = 'kentik-wireless-controller' LIMIT MAX"
+                }
+              ],
+              "platformOptions": {
+                "ignoreTimeRange": false
+              }
+            }
+          },
+          {
+            "title": "RADIUS Server Statistics",
+            "layout": {
+              "column": 1,
+              "row": 26,
+              "width": 12,
+              "height": 3
+            },
+            "visualization": {
+              "id": "viz.table"
+            },
+            "rawConfiguration": {
+              "dataFormatters": [
+                {
+                  "name": "RTT (secs)",
+                  "precision": 2,
+                  "type": "decimal"
+                },
+                {
+                  "name": "Timeouts",
+                  "type": "decimal"
+                },
+                {
+                  "name": "Retransmissions",
+                  "type": "decimal"
+                }
+              ],
+              "facet": {
+                "showOtherSeries": false
+              },
+              "nrqlQueries": [
+                {
+                  "accountId": 0,
+                  "query": "FROM Metric SELECT max(kentik.snmp.bsnRadiusAuthClientAccessRetransmissions) AS 'Retransmissions', max(kentik.snmp.bsnRadiusAuthClientTimeouts) AS 'Timeouts', max(kentik.snmp.bsnRadiusAuthClientRoundTripTime)/100 AS 'RTT (secs)' FACET bsnRadiusAuthServerAddress AS 'RADIUS Server' WHERE provider = 'kentik-wireless-controller' LIMIT MAX"
+                }
+              ],
+              "platformOptions": {
+                "ignoreTimeRange": false
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }

--- a/definitions/ext-wireless_controller/definition.yml
+++ b/definitions/ext-wireless_controller/definition.yml
@@ -1,5 +1,4 @@
 domain: EXT
-# Currently scoped to Meraki Cloud Controllers from Kentik Integration
 type: WIRELESS_CONTROLLER
 synthesis:
   rules:
@@ -14,8 +13,11 @@ synthesis:
       src_addr:
         entityTagName: device_ip
         multiValue: false
+      kentik.model:
+        entityTagName: device_model
+        multiValue: false
 
-  # Aruba Mobility Controller devices
+  # Traditional wireless controllers
   - identifier: device_name
     name: device_name
     encodeIdentifierInGUID: true
@@ -26,9 +28,13 @@ synthesis:
       src_addr:
         entityTagName: device_ip
         multiValue: false
+      kentik.model:
+        entityTagName: device_model
+        multiValue: false
 
 goldenTags:
 - device_ip
+- device_model
 
 dashboardTemplates:
   # Kentik Meraki Cloud Controller
@@ -37,3 +43,6 @@ dashboardTemplates:
   # Aruba WC
   kentik/aruba-wireless-controller:
     template: aruba-dashboard.json
+  # Cisco WLC
+  kentik/cisco-wlc:
+    template: cisco-wlc-dashboard.json

--- a/definitions/ext-wireless_controller/golden_metrics.yml
+++ b/definitions/ext-wireless_controller/golden_metrics.yml
@@ -1,7 +1,19 @@
 activeAccessPoints:
-  title: Active access points
+  title: Active APs
   unit: COUNT
-  query:
-    select: uniqueCount(ap_name)
-    from: Metric
-    where: "provider = 'kentik-cloud-controller' AND kentik.snmp.devStatus[latest] = 1"
+  queries:
+    # Meraki Cloud Controller
+    kentik/meraki-cloud-controller:
+      select: uniqueCount(ap_name)
+      from: Metric
+      where: "provider = 'kentik-cloud-controller' AND kentik.snmp.devStatus[latest] = 1"
+    # Aruba WC
+    kentik/aruba-wireless-controller:
+      select: max(kentik.snmp.haActiveAPs)
+      from: Metric
+      where: "provider = 'kentik-wireless-controller'"
+    # Cisco WLC
+    kentik/cisco-wlc:
+      select: uniqueCount(Index)
+      from: Metric
+      where: "provider = 'kentik-wireless-controller' AND bsnAPOperationStatus = 'associated'"

--- a/definitions/ext-wireless_controller/summary_metrics.yml
+++ b/definitions/ext-wireless_controller/summary_metrics.yml
@@ -2,8 +2,22 @@ activeAccessPoints:
   goldenMetric: activeAccessPoints
   title: Active APs
   unit: COUNT
-  query:
-    select: uniqueCount(ap_name)
-    from: Metric
-    where: "provider = 'kentik-cloud-controller' AND kentik.snmp.devStatus[latest] = 1"
-    eventId: entity.guid
+  queries:
+    # Meraki Cloud Controller
+    kentik/meraki-cloud-controller:
+      select: uniqueCount(ap_name)
+      from: Metric
+      where: "provider = 'kentik-cloud-controller' AND kentik.snmp.devStatus[latest] = 1"
+      eventId: entity.guid
+    # Aruba WC
+    kentik/aruba-wireless-controller:
+      select: max(kentik.snmp.haActiveAPs)
+      from: Metric
+      where: "provider = 'kentik-wireless-controller'"
+      eventId: entity.guid
+    # Cisco WLC
+    kentik/cisco-wlc:
+      select: uniqueCount(Index)
+      from: Metric
+      where: "provider = 'kentik-wireless-controller' AND bsnAPOperationStatus = 'associated'"
+      eventId: entity.guid


### PR DESCRIPTION
### Relevant information

adding `cisco-wlc` as a new source of data for the existing `EXT-WIRELESS_CONTROLLER` entity definition. also has a few small fixes on the existing Meraki and Aruba items in the same definition.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
