### PR TITLE
Add Azure HOST entity synthesis rule

### DIFF
--- a/definitions/infra-host/definition.yml
+++ b/definitions/infra-host/definition.yml
@@ -109,6 +109,13 @@ synthesis:
         host.image.id:
         host.image.version:
         instrumentation.provider:
+    # Azure host from Microsoft.Compute/virtualMachines
+    - identifier: azure.resourceId
+      name: displayName
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: azure.resourceType
+          value: Microsoft.Compute/virtualMachines
 configuration:
   entityExpirationTime: DAILY
   alertable: true


### PR DESCRIPTION
### Relevant information

Added an entity Synthesis rule for Azure Hosts (resourceType `Microsoft.Compute/virtualMachines`). 

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
