### PR TITLE
Remove otel summary metrics for infra-host

### DIFF
--- a/definitions/infra-host/summary_metrics.yml
+++ b/definitions/infra-host/summary_metrics.yml
@@ -67,23 +67,6 @@ networkInGcp:
     select: average(gcp.compute.instance.network.received_bytes_count)
     eventId: entity.guid
   hidden: true
-networkInOtel:
-  title: "Network In Otel"
-  unit: BYTES_PER_SECOND
-  query:
-    select: sum(system.network.io) / sum((endTimestamp - timestamp) / 1000)
-    where: device != 'lo' AND direction='receive'
-    from: Metric
-    eventId: entity.guid
-  hidden: true
-networkOutHost:
-  title: "Network Out Host"
-  unit: BYTES_PER_SECOND
-  query:
-    from: Metric
-    select: average(host.net.transmitBytesPerSecond)
-    eventId: entity.guid
-  hidden: true
 networkOutEc2:
   title: "Network Out Ec2"
   unit: BYTES_PER_SECOND
@@ -142,9 +125,9 @@ networkTrafficTx:
   goldenMetric: networkTrafficTx
   title: Network transmit traffic (bytes/s)
   unit: BYTES_PER_SECOND
-  derive: '@networkOutHost || @networkOutEc2 || @networkOutAzure || @networkOutGcp || @networkOutOtel'
+  derive: '@networkOutHost || @networkOutEc2 || @networkOutAzure || @networkOutGcp'
 networkTrafficRx:
   goldenMetric: networkTrafficRx
   title: Network receive traffic (bytes/s)
   unit: BYTES_PER_SECOND
-  derive: '@networkInHost || @networkInEc2 || @networkInAzure || @networkInGcp || @networkInOtel'
+  derive: '@networkInHost || @networkInEc2 || @networkInAzure || @networkInGcp'


### PR DESCRIPTION
### Relevant information

Remove the OTel metrics from the summary metric definition file of INFRA-HOST. They were added in the previous PR and might be causing all queries to time out. 

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
