### PR TITLE
Rewrite some queries for EXT-FIREWALL metrics

### DIFF
--- a/definitions/ext-firewall/golden_metrics.yml
+++ b/definitions/ext-firewall/golden_metrics.yml
@@ -34,12 +34,12 @@ memoryUtilization:
   queries:
     # Palo Alto firewalls
     kentik/palo-alto:
-      select: (max(kentik.snmp.hrStorageUsed) / max(kentik.snmp.hrStorageSize)) * 100
+      select: (max(kentik.snmp.hrStorageUsed / kentik.snmp.hrStorageSize)) * 100
       from: Metric
       where: "provider = 'kentik-firewall' AND storage_description LIKE '%Management Memory%'"
     # Fortinet Fortigate firewalls
     kentik/fortinet-fortigate:
-      select: (max(kentik.snmp.fgSysMemUsage) / max(kentik.snmp.fgSysMemCapacity)) * 100
+      select: (max(kentik.snmp.fgSysMemUsage / kentik.snmp.fgSysMemCapacity)) * 100
       from: Metric
       where: "provider = 'kentik-firewall'"
     # Cisco Firepower firewalls
@@ -64,7 +64,7 @@ sessionsTotal:
       where: "provider = 'kentik-firewall'"
     # Fortinet Fortigate firewalls
     kentik/fortinet-fortigate:
-      select: max(kentik.snmp.fgSysSesCount) + max(kentik.snmp.fgSysSes6Count)
+      select: max(kentik.snmp.fgSysSesCount + kentik.snmp.fgSysSes6Count)
       from: Metric
       where: "provider = 'kentik-firewall'"
     # Cisco Firepower firewalls

--- a/definitions/ext-firewall/summary_metrics.yml
+++ b/definitions/ext-firewall/summary_metrics.yml
@@ -47,13 +47,13 @@ memoryUtilization:
   queries:
     # Palo Alto firewalls
     kentik/palo-alto:
-      select: (max(kentik.snmp.hrStorageUsed) / max(kentik.snmp.hrStorageSize)) * 100
+      select: (max(kentik.snmp.hrStorageUsed / kentik.snmp.hrStorageSize)) * 100
       from: Metric
       where: "provider = 'kentik-firewall' AND storage_description LIKE '%Management Memory%'"
       eventId: entity.guid
     # Fortinet Fortigate firewalls
     kentik/fortinet-fortigate:
-      select: (max(kentik.snmp.fgSysMemUsage) / max(kentik.snmp.fgSysMemCapacity)) * 100
+      select: (max(kentik.snmp.fgSysMemUsage / kentik.snmp.fgSysMemCapacity)) * 100
       from: Metric
       where: "provider = 'kentik-firewall'"
       eventId: entity.guid
@@ -83,7 +83,7 @@ sessionsTotal:
       eventId: entity.guid
     # Fortinet Fortigate firewalls
     kentik/fortinet-fortigate:
-      select: max(kentik.snmp.fgSysSesCount) + max(kentik.snmp.fgSysSes6Count)
+      select: max(kentik.snmp.fgSysSesCount + kentik.snmp.fgSysSes6Count)
       from: Metric
       where: "provider = 'kentik-firewall'"
       eventId: entity.guid


### PR DESCRIPTION
### Relevant information

Rewrite max(smth) / max(smth) expressions as max(smth / smth) 
Rewrite max(smth) + max(smth) as max(smth + smth)  

Golden metrics cannot be synthesized for EXT-FIREWALL as some of its queries are not valid. 

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
