### PR TITLE
Fix units for throughput metric of APM-APPLICATION entities

### DIFF
--- a/definitions/apm-application/golden_metrics.yml
+++ b/definitions/apm-application/golden_metrics.yml
@@ -7,7 +7,7 @@ responseTimeMs:
     eventName: appName
 throughput:
   title: Throughput
-  unit: REQUESTS_PER_MINUTE
+  unit: REQUESTS_PER_SECOND
   query:
     select: count(newrelic.timeslice.value) AS 'Throughput'
     where: metricTimesliceName in ('HttpDispatcher', 'OtherTransaction/all')

--- a/definitions/apm-application/summary_metrics.yml
+++ b/definitions/apm-application/summary_metrics.yml
@@ -10,7 +10,7 @@ responseTimeMs:
 throughput:
   goldenMetric: throughput
   title: Throughput
-  unit: REQUESTS_PER_MINUTE
+  unit: REQUESTS_PER_SECOND
   query:
     select: count(newrelic.timeslice.value)
     from: Metric


### PR DESCRIPTION
### Relevant information

The correct unit is RPS instead of RPM. 

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
