### PR TITLE
feat: Add browser summary metric file

### DIFF
--- a/definitions/browser-application/summary_metrics.yml
+++ b/definitions/browser-application/summary_metrics.yml
@@ -1,0 +1,54 @@
+throughputPpm:
+  goldenMetric: throughputPpm
+  unit: PAGES_PER_SECOND
+  title: Throughput (ppm)
+  query:
+    from: PageView
+    select: rate(count(*), 1 minute)
+    eventId: appId
+    eventName: DOMAIN_IDS
+largestContentfulPaint75PercentileS:
+  goldenMetric: largestContentfulPaint75PercentileS
+  unit: SECONDS
+  title: Largest contentful paint (75 percentile) (s)
+  query:
+    from: PageViewTiming
+    select: percentile(largestContentfulPaint, 75)
+    eventId: appId
+    eventName: DOMAIN_IDS
+firstInputDelay75PercentileMs:
+  goldenMetric: firstInputDelay75PercentileMs
+  unit: MS
+  title: First input delay (75 percentile) (ms)
+  query:
+    select: percentile(firstInputDelay, 75)
+    from: PageViewTiming
+    eventId: appId
+    eventName: DOMAIN_IDS
+errors:
+  goldenMetric: errors
+  unit: COUNT
+  title: Errors
+  query:
+    from: JavaScriptError
+    select: count(*)
+    eventId: appId
+    eventName: DOMAIN_IDS
+pageLoadSeconds:
+  goldenMetric: pageLoadSeconds
+  unit: SECONDS
+  title: Pageload time (s)
+  query:
+    from: PageView
+    select: average(duration)
+    eventId: appId
+    eventName: DOMAIN_IDS
+throughputAjax:
+  goldenMetric: throughputAjax
+  unit: REQUESTS_PER_MINUTE
+  title: Ajax throughput (rpm)
+  query:
+    from: AjaxRequest
+    select: rate(count(*), 1 minute)
+    eventId: appId
+    eventName: DOMAIN_IDS

--- a/definitions/browser-application/summary_metrics.yml
+++ b/definitions/browser-application/summary_metrics.yml
@@ -6,7 +6,7 @@ throughputPpm:
     from: PageView
     select: rate(count(*), 1 minute)
     eventId: appId
-    eventName: DOMAIN_IDS
+    eventObjectId: DOMAIN_IDS
 largestContentfulPaint75PercentileS:
   goldenMetric: largestContentfulPaint75PercentileS
   unit: SECONDS
@@ -15,7 +15,7 @@ largestContentfulPaint75PercentileS:
     from: PageViewTiming
     select: percentile(largestContentfulPaint, 75)
     eventId: appId
-    eventName: DOMAIN_IDS
+    eventObjectId: DOMAIN_IDS
 firstInputDelay75PercentileMs:
   goldenMetric: firstInputDelay75PercentileMs
   unit: MS
@@ -24,7 +24,7 @@ firstInputDelay75PercentileMs:
     select: percentile(firstInputDelay, 75)
     from: PageViewTiming
     eventId: appId
-    eventName: DOMAIN_IDS
+    eventObjectId: DOMAIN_IDS
 errors:
   goldenMetric: errors
   unit: COUNT
@@ -33,7 +33,7 @@ errors:
     from: JavaScriptError
     select: count(*)
     eventId: appId
-    eventName: DOMAIN_IDS
+    eventObjectId: DOMAIN_IDS
 pageLoadSeconds:
   goldenMetric: pageLoadSeconds
   unit: SECONDS
@@ -42,7 +42,7 @@ pageLoadSeconds:
     from: PageView
     select: average(duration)
     eventId: appId
-    eventName: DOMAIN_IDS
+    eventObjectId: DOMAIN_IDS
 throughputAjax:
   goldenMetric: throughputAjax
   unit: REQUESTS_PER_MINUTE
@@ -51,4 +51,4 @@ throughputAjax:
     from: AjaxRequest
     select: rate(count(*), 1 minute)
     eventId: appId
-    eventName: DOMAIN_IDS
+    eventObjectId: DOMAIN_IDS

--- a/definitions/browser-application/summary_metrics.yml
+++ b/definitions/browser-application/summary_metrics.yml
@@ -6,11 +6,7 @@ throughputPpm:
     from: PageView
     select: rate(count(*), 1 minute)
     eventId: appId
-<<<<<<< HEAD
     eventObjectId: DOMAIN_IDS
-=======
-    eventName: DOMAIN_IDS
->>>>>>> 80efdcb14b48b4584123cb4206f2150ade03b5c9
 largestContentfulPaint75PercentileS:
   goldenMetric: largestContentfulPaint75PercentileS
   unit: SECONDS
@@ -19,11 +15,7 @@ largestContentfulPaint75PercentileS:
     from: PageViewTiming
     select: percentile(largestContentfulPaint, 75)
     eventId: appId
-<<<<<<< HEAD
     eventObjectId: DOMAIN_IDS
-=======
-    eventName: DOMAIN_IDS
->>>>>>> 80efdcb14b48b4584123cb4206f2150ade03b5c9
 firstInputDelay75PercentileMs:
   goldenMetric: firstInputDelay75PercentileMs
   unit: MS


### PR DESCRIPTION
### Relevant information

Currently, the Browser summary metrics come from the summary metric service, which we want to get away from. This provides summary metrics that match the golden metrics for browser. 

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
