### PR TITLE
Updating some golden and summary metrics queries to metrics from events

### DIFF
--- a/definitions/mobile-application/golden_metrics.yml
+++ b/definitions/mobile-application/golden_metrics.yml
@@ -2,9 +2,8 @@ appLaunchCount:
   title: App launches 
   unit: COUNT
   query:
-    select: uniqueCount(sessionId)
-    from: Mobile
-    eventId: entityGuid
+    select: count(newrelic.timeslice.value)
+    where: metricTimesliceName = 'Session/Start'
     eventName: appName
 crashCount:
   title: Crash count
@@ -14,21 +13,26 @@ crashCount:
     from: MobileCrash
     eventId: entityGuid
     eventName: appName
-httpResponseTime95S:
-  title: HTTP response time (95%) (s)
-  unit: SECONDS
+httpResponseTimeMs:
+  title: HTTP response time (ms)
+  unit: MS
   query:
-    select: percentile(responseTime,95)
-    from: MobileRequest
-    eventId: entityGuid
+    select: average(newrelic.timeslice.value) * 1000
+    where: metricTimesliceName = 'External/all'
     eventName: appName
-httpErrorsAndNetworkFailuresCount:
-  title: HTTP errors and network failures count
+networkFailuresCount:
+  title: Network failure count
   unit: COUNT
   query:
-    select: count(*)
-    from: MobileRequestError
-    eventId: entityGuid
+    select: average(`newrelic`.`timeslice.value`) as Network failures
+    where: metricTimesliceName = 'Mobile/FailedCallRate'
+    eventName: appName
+httpErrorsCount:
+  title: HTTP error count
+  unit: COUNT
+  query:
+    select: average(`newrelic`.`timeslice.value`) as HTTP errors
+    where: metricTimesliceName = 'Mobile/StatusErrorRate'
     eventName: appName
 requestsPerMinute:
   title: Requests per minute (req/min)

--- a/definitions/mobile-application/summary_metrics.yml
+++ b/definitions/mobile-application/summary_metrics.yml
@@ -3,10 +3,10 @@ appLaunchCount:
   unit: COUNT
   title: App launches
   query:
-    from: Mobile
-    select: uniqueCount(sessionId)
+    from: Metric
+    select: count(newrelic.timeslice.value)
+    where: metricTimesliceName = 'Session/Start'
     eventId: appId
-    eventObjectId: DOMAIN_IDS
 crashCount:
   goldenMetric: crashCount
   unit: COUNT
@@ -15,25 +15,33 @@ crashCount:
     from: MobileCrash
     select: count(*)
     eventId: appId
-    eventObjectId: DOMAIN_IDS
-httpResponseTime95S:
-  goldenMetric: httpResponseTime95S
-  title: HTTP response time (95%)
-  unit: SECONDS
+httpResponseTimeMs:
+  goldenMetric: httpResponseTimeMs
+  title: HTTP response time (ms)
+  unit: MS
   query:
-    from: MobileRequest
-    select: percentile(responseTime,95)
+    from: Metric
+    select: average(newrelic.timeslice.value) * 1000
+    where: metricTimesliceName = 'External/all'
     eventId: appId
-    eventObjectId: DOMAIN_IDS
-httpErrorsAndNetworkFailuresCount:
-  goldenMetric: httpErrorsAndNetworkFailuresCount
-  title: HTTP errors and network failures count
+networkFailuresCount:
+  goldenMetric: networkFailuresCount
+  title: Network errors count
   unit: COUNT
   query:
-    from: MobileRequestError
-    select: count(*)
+    from: Metric
+    select: average(`newrelic`.`timeslice.value`) as Network failures
+    where: metricTimesliceName = 'Mobile/FailedCallRate'
     eventId: appId
-    eventObjectId: DOMAIN_IDS
+httpErrorsCount:
+  goldenMetric: httpErrorsCount
+  title: HTTP errors count
+  unit: COUNT
+  query:
+    from: Metric
+    select: average(`newrelic`.`timeslice.value`) as HTTP errors
+    where: metricTimesliceName = 'Mobile/StatusErrorRate'
+    eventId: appId
 requestsPerMinute:
   goldenMetric: requestsPerMinute
   title: Requests per minute
@@ -42,4 +50,3 @@ requestsPerMinute:
     from: MobileRequest
     select: rate(count(*), 1 minute)
     eventId: appId
-    eventObjectId: DOMAIN_IDS


### PR DESCRIPTION
### Relevant information

We are trying to create consistency between the Mobile summary page charts and the List and Lookout views in Explorer. To do that, we wanted to update App launches, http response time, and network errors, and http errors count to metrics queries instead of event queries.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
