### PR TITLE
fix: GM/SM queries for aruba wireless controllers

### DIFF
--- a/definitions/ext-wireless_controller/golden_metrics.yml
+++ b/definitions/ext-wireless_controller/golden_metrics.yml
@@ -9,9 +9,9 @@ activeAccessPoints:
       where: "provider = 'kentik-cloud-controller' AND kentik.snmp.devStatus[latest] = 1"
     # Aruba WC
     kentik/aruba-wireless-controller:
-      select: max(kentik.snmp.haActiveAPs)
+      select: uniqueCount(Index)
       from: Metric
-      where: "provider = 'kentik-wireless-controller'"
+      where: "provider = 'kentik-wireless-controller' AND `mib-table` = 'wlsxSwitchAccessPoint'"
     # Cisco WLC
     kentik/cisco-wlc:
       select: uniqueCount(Index)

--- a/definitions/ext-wireless_controller/summary_metrics.yml
+++ b/definitions/ext-wireless_controller/summary_metrics.yml
@@ -11,9 +11,9 @@ activeAccessPoints:
       eventId: entity.guid
     # Aruba WC
     kentik/aruba-wireless-controller:
-      select: max(kentik.snmp.haActiveAPs)
+      select: uniqueCount(Index)
       from: Metric
-      where: "provider = 'kentik-wireless-controller'"
+      where: "provider = 'kentik-wireless-controller' AND `mib-table` = 'wlsxSwitchAccessPoint'"
       eventId: entity.guid
     # Cisco WLC
     kentik/cisco-wlc:


### PR DESCRIPTION
### Relevant information

updating GM/SM definitions for `EXT-WIRELESS_CONTROLLER` to align all sources of telemetry to the same metric kind for the GMH.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
