### PR TITLE
fix: gm/sm queries for ReadyNAS telemetry

### DIFF
--- a/definitions/ext-nas/golden_metrics.yml
+++ b/definitions/ext-nas/golden_metrics.yml
@@ -4,7 +4,7 @@ cpuUtilization:
   queries:
     # Netgear ReadyNAS
     kentik/readynas:
-      select: latest(100 - kentik.snmp.ssCpuIdle)
+      select: average(kentik.snmp.CPU)
       from: Metric
       where: "provider = 'kentik-nas'"
     # Most devices

--- a/definitions/ext-nas/summary_metrics.yml
+++ b/definitions/ext-nas/summary_metrics.yml
@@ -11,7 +11,7 @@ cpuUtilization:
   queries:
     # Netgear ReadyNAS
     kentik/readynas:
-      select: latest(100 - kentik.snmp.ssCpuIdle)
+      select: average(kentik.snmp.CPU)
       from: Metric
       where: "provider = 'kentik-nas'"
       eventId: entity.guid


### PR DESCRIPTION
### Relevant information

updating `EXT-NAS` GM/SM queries for ReadyNAS telemetry

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
