### PR TITLE
fix: update metric kind query for cisco ironport telemetry

### DIFF
--- a/definitions/ext-email_gateway/golden_metrics.yml
+++ b/definitions/ext-email_gateway/golden_metrics.yml
@@ -33,6 +33,6 @@ emailLatency:
       from: Metric
       where: "provider = 'kentik-barracuda-email-gateway'"
     kentik/cisco-ironport-email:
-      select: max(kentik.snmp.oldestMessageAge)
+      select: average(kentik.snmp.oldestMessageAge)
       from: Metric
       where: "provider = 'kentik-ironport-email-appliance'"

--- a/definitions/ext-email_gateway/summary_metrics.yml
+++ b/definitions/ext-email_gateway/summary_metrics.yml
@@ -47,7 +47,7 @@ emailLatency:
       where: "provider = 'kentik-barracuda-email-gateway'"
       eventId: entity.guid
     kentik/cisco-ironport-email:
-      select: max(kentik.snmp.oldestMessageAge)
+      select: average(kentik.snmp.oldestMessageAge)
       from: Metric
       where: "provider = 'kentik-ironport-email-appliance'"
       eventId: entity.guid


### PR DESCRIPTION
### Relevant information

updated NRQL on GM/SM for `EXT-EMAIL_GATEWAY` to bring Cisco Ironport telemetry into the same metric kind as the existing Barracuda data.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
