### PR TITLE
Fix Total inference to actually show data per minute

### DIFF
--- a/definitions/mlops-machine_learning_model/golden_metrics.yml
+++ b/definitions/mlops-machine_learning_model/golden_metrics.yml
@@ -2,6 +2,6 @@ totalInferences:
   title: "Total Inference"
   unit: REQUESTS_PER_MINUTE
   query:
-    select: uniqueCount(inference_id)
+    select: (uniqueCount(inference_id) / 30)
     from: InferenceData
     eventId: entity.guid

--- a/definitions/mlops-machine_learning_model/summary_metrics.yml
+++ b/definitions/mlops-machine_learning_model/summary_metrics.yml
@@ -3,6 +3,6 @@ totalInferences:
   title: "Total Inference"
   unit: REQUESTS_PER_MINUTE
   query:
-    select: uniqueCount(inference_id)
+    select: (uniqueCount(inference_id) / 30)
     from: InferenceData
     eventId: entity.guid


### PR DESCRIPTION
### Relevant information

The total for 30 minutes is shown, instead of request per minute.
This is a fix that divides by 30.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
