### PR TITLE
Fix APM-APPLICATION throughput metric definition

### DIFF
--- a/definitions/apm-application/golden_metrics.yml
+++ b/definitions/apm-application/golden_metrics.yml
@@ -9,7 +9,7 @@ throughput:
   title: Throughput
   unit: REQUESTS_PER_MINUTE
   query:
-    select: count(newrelic.timeslice.value) AS 'Throughput'
+    select: rate(count(newrelic.timeslice.value), 1 minute) AS 'Throughput'
     where: metricTimesliceName in ('HttpDispatcher', 'OtherTransaction/all')
     eventName: appName
 errorRate:

--- a/definitions/apm-application/summary_metrics.yml
+++ b/definitions/apm-application/summary_metrics.yml
@@ -12,7 +12,7 @@ throughput:
   title: Throughput
   unit: REQUESTS_PER_MINUTE
   query:
-    select: count(newrelic.timeslice.value)
+    select: rate(count(newrelic.timeslice.value), 1 minute)
     from: Metric
     where: metricTimesliceName in ('HttpDispatcher', 'OtherTransaction/all')
     eventId: entityGuid


### PR DESCRIPTION
### Relevant information

Add missing `rate(, 1 minute)` for APM-APPLICATION's throughput metric in both golden & summary metric definitions. 

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
