### PR TITLE
Updated documentation for golden metric references

### DIFF
--- a/docs/summary_metrics.md
+++ b/docs/summary_metrics.md
@@ -2,7 +2,7 @@
 
 Summary metrics are data related to entities which describe how certain parameters behave, based on the available telemetry. 
 
-We recommend adding 3 metrics, and never more of 10. We also recommend defining them like the golden metrics.
+We recommend adding 3 metrics, and never more than 10. We also recommend defining them as a reference to a golden metric.
 
 ## Defining summary metrics
 
@@ -10,6 +10,7 @@ Summary metrics are defined in a map where each key is a camel-case name that de
 
 ```yaml
 memoryUsage:
+  goldenMetric: memoryUsage
   title: "A title explaining what the user is seeing"
   unit: PERCENTAGE
   query:
@@ -19,16 +20,15 @@ memoryUsage:
     eventId: entity.guid
 ```
  
-A summary metric can be either an **NRDB-query-based metric**, a **tag metric** (summary tag), or a **derived metric**, depending on the source of the information. Therefore, you need to configure exactly ONE out of `query`, `tag` or `derive`. If an amount different to one is detected, the metric definition will not be valid.
+A summary metric can be either an **NRDB-query-based metric**, a **tag metric** (summary tag), or a **golden metric reference**, depending on the source of the information. Therefore, you need to configure exactly ONE out of `query` or `tag`. If an amount different to one is detected, the metric definition will not be valid. `query` can coexist with `goldenMetric` for the time being, but the former is being deprecated in favor of the latter.
 
 | **Name** | **Type**                      | **Description**                                            |
 | -------- | ----------------------------- | ---------------------------------------------------------- |
-| title    | String                        | The human-readable name of the metric.                      |
-| unit     | [Metric Unit](#metric-unit)    | The unit of the metric .                                    |
-| hidden     | Boolean   | If the metric is hidden, it will not appear on any UI visualizations. It can only be used to define intermediate metrics referenced by others. Defaults to false.  |
-| query    | [NRDB Query](#nrdb-query)     | The configuration for an NRDB-query-based metric.                 |
+| title    | String                        | The human-readable name of the metric.                     |
+| unit     | [Metric Unit](#metric-unit)    | The unit of the metric.                                   |
+| query    | [NRDB Query](#nrdb-query)     | The configuration for an NRDB-query-based metric (deprecated: use `goldenMetric` instead). |
 | tag      | [Tag](#tag)                    | The configuration for a tag metric.        |
-| derive   | [Derive String](#derive-string) | The string to define a derived metric.                      |
+| goldenMetric | [Golden Metric Reference](#golden-metric-reference) | A reference to the [golden metric](golden_metrics.md) this summary metric should be based on. |
 
 ### Metric unit
 
@@ -64,32 +64,22 @@ The `query` map contains the information used to define a NRDB-query-based metri
 | where         | String                         | An *optional* NRQL filter, for example `foo = 'bar'`.                                                  |
 | eventId       | String                         | The event attribute you want to facet and filter for, for example `entity.guid`.                           |
 
+**Note**: `query` is deprecated: use `goldenMetric` instead.
+
 ### Tag
 
 | **Name** | **Type** | **Description**                                                                       |
 | -------- | -------- | ------------------------------------------------------------------------------------- |
 | key      | String   | The tag key you want to fetch the corresponding value for, for example `providerAccountName`. |
 
-### Derive string 
+### Golden metric reference
 
-The `derive` string can be used to derive a summary metric out of others. It's possible to reference other metrics using `@metricName`. Metrics can be added, subtracted, multiplied, and divided by other metrics or numbers.
+In most cases, summary metrics definitions are the same as, or a subset of [golden metrics](golden_metrics.md) definitions. Because of that, a summary metric definition can reuse a golden metric definition by having a reference to it. For consistency, the key defining a summary metric and the key defining a golden metric should be the same. In the following example, the `memoryUsage` summary metric definition points to the `memoryUsage` golden metric definition:
+```yaml
+memoryUsage:
+  goldenMetric: memoryUsage
 
-Example: 
-
-    (@metricA * 100) / (@metricB + @metricC)
-
-* If a derived metric references a metric that doesn't exist, it will result in an error.
-* If a derived metric references a metric whose value is `null`, its value will be `null` too: 
-
-    @metricA + @metricB + 100
-
-If either `metricA` or `metricB` is null, the value of the derived metric will be `null` too.
-
-Aside from normal mathematical operations, the `||` (or) operator can be used, which returns the value of the first metric that has a value different from `null`:  
-
-    @metricA || 10
-
-It returns the value of `metricA` if it's not `null`, `10` otherwise.
+```
 
 ### Roll-up entities
 
@@ -97,6 +87,7 @@ When the entity type can be ingested from multiple sources, you'll be required t
 
 ```yaml
 memoryUsage:
+  goldenMetric: memoryUsage
   title: "A title explaining what the user is seeing (unit displayed in the dashboard)"
   unit: COUNT
   queries:
@@ -112,6 +103,7 @@ In this example, the entity must have `prometheus` and `newRelic` in the `instru
 
 ```yaml
 destinations:
+  goldenMetric: destinations
   title: Unique Destinations
   queries:
     kentik/netflow-events:


### PR DESCRIPTION
- Updated the docs to reflect the new `goldenMetric` reference capability
- Removed mentions to `hidden` and `derive` since we're using them internally only
- Leaving for the time being `query`, mentioning its deprecation in favor of `goldenMetric` 