### PR TITLE
Remove eventId and from as required fields in SM query configuration

### DIFF
--- a/validator/schemas/summary-metrics-schema-v1.json
+++ b/validator/schemas/summary-metrics-schema-v1.json
@@ -138,9 +138,7 @@
         "eventId": "entity.guid"
       }],
       "required": [
-        "select",
-        "from",
-        "eventId"
+        "select"
       ],
       "properties": {
         "select": {


### PR DESCRIPTION
### Relevant information

The two fields are not required as, when not present, default values will be assigned for them. 

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
