### PR TITLE
Add missing eventName for INFRA-VARNISHINSTANCE GM definitions

### DIFF
--- a/definitions/infra-varnishinstance/golden_metrics.yml
+++ b/definitions/infra-varnishinstance/golden_metrics.yml
@@ -1,6 +1,7 @@
 requests:
   query:
     eventId: entityGuid
+    eventName: entityName
     select: average(`backend.requests`)
     from: VarnishSample
   unit: COUNT
@@ -8,6 +9,7 @@ requests:
 threads:
   query:
     eventId: entityGuid
+    eventName: entityName
     select: average(`main.threads`)
     from: VarnishSample
   unit: COUNT
@@ -15,6 +17,7 @@ threads:
 sessionsDropped:
   query:
     eventId: entityGuid
+    eventName: entityName
     select: average(`sess.dropped`)
     from: VarnishSample
   unit: COUNT


### PR DESCRIPTION
### Relevant information

As the telemetry does not contain `entity.name`, but `entityName` attributes only, we need to explicitly tell the configuration to not use the default eventName. 

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
