### PR TITLE
Update mlops-machine_learning_model metrics to use rate

### DIFF
--- a/definitions/mlops-machine_learning_model/golden_metrics.yml
+++ b/definitions/mlops-machine_learning_model/golden_metrics.yml
@@ -2,6 +2,6 @@ totalInferences:
   title: "Total Inference"
   unit: REQUESTS_PER_MINUTE
   query:
-    select: (uniqueCount(inference_id) / 30)
+    select: rate(uniqueCount(inference_id), 1 minute)
     from: InferenceData
     eventId: entity.guid

--- a/definitions/mlops-machine_learning_model/summary_metrics.yml
+++ b/definitions/mlops-machine_learning_model/summary_metrics.yml
@@ -3,6 +3,6 @@ totalInferences:
   title: "Total Inference"
   unit: REQUESTS_PER_MINUTE
   query:
-    select: (uniqueCount(inference_id) / 30)
+    select: rate(uniqueCount(inference_id), 1 minute)
     from: InferenceData
     eventId: entity.guid


### PR DESCRIPTION
### Relevant information

Adjusts metrics to work for both SMs and GMs by using uniqueCount wrapped in rate.

Fixes the code changes from the previous PR [here](https://github.com/newrelic/entity-definitions/pull/740).

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
