### PR TITLE
Update ext-kentik_default ping-dashboard

### DIFF
--- a/definitions/ext-kentik_default/ping-dashboard.json
+++ b/definitions/ext-kentik_default/ping-dashboard.json
@@ -22,7 +22,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "FROM Metric SELECT latest(device_name) AS 'Device Name', latest(src_addr) AS 'Device IP', latest(timestamp) AS 'Last Update', latest(src_as) AS 'AS Number', latest(src_as_name) AS 'AS Name', latest(src_geo) AS 'Country Code' WHERE provider = 'kentik-ping'"
+                "query": "FROM Metric SELECT latest(device_name) AS 'Device Name', latest(src_addr) AS 'Device IP', latest(timestamp) AS 'Last Update', latest(src_as) AS 'AS Number', latest(src_as_name) AS 'AS Name', latest(src_geo) AS 'Country Code' WHERE instrumentation.name = 'ping'"
               }
             ],
             "thresholds": []
@@ -46,7 +46,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "FROM Metric SELECT max(kentik.ping.AvgRttMs) AS 'Average', max(kentik.ping.MinRttMs) AS 'Min', max(kentik.ping.MaxRttMs) AS 'Max' WHERE provider = 'kentik-ping' TIMESERIES 5 MINUTES"
+                "query": "FROM Metric SELECT max(kentik.ping.AvgRttMs) AS 'Average', max(kentik.ping.MinRttMs) AS 'Min', max(kentik.ping.MaxRttMs) AS 'Max' WHERE instrumentation.name = 'ping' TIMESERIES 5 MINUTES"
               }
             ],
             "yAxisLeft": {
@@ -73,7 +73,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "FROM Metric SELECT count(*) AS 'Failed Pings' WHERE provider = 'kentik-ping' AND kentik.ping.AvgRttMs[latest] = 0"
+                "query": "FROM Metric SELECT count(*) AS 'Failed Pings' WHERE instrumentation.name = 'ping' AND kentik.ping.AvgRttMs[latest] = 0"
               }
             ],
             "thresholds": [
@@ -105,7 +105,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "FROM Metric SELECT count(*) AS 'Failed Pings' WHERE provider = 'kentik-ping' AND kentik.ping.AvgRttMs[latest] = 0 FACET device_name TIMESERIES 5 MINUTES"
+                "query": "FROM Metric SELECT count(*) AS 'Failed Pings' WHERE instrumentation.name = 'ping' AND kentik.ping.AvgRttMs[latest] = 0 FACET device_name TIMESERIES 5 MINUTES"
               }
             ]
           }


### PR DESCRIPTION
### Relevant information

Based on customer feedback swapped out the where condition so that it matched up with devices being pinged by kentik\ktranslate

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
