### PR TITLE
fix: add datetime format to widget

### DIFF
--- a/definitions/ext-kentik_default/ping-dashboard.json
+++ b/definitions/ext-kentik_default/ping-dashboard.json
@@ -18,7 +18,12 @@
           },
           "title": "Summary",
           "rawConfiguration": {
-            "dataFormatters": [],
+            "dataFormatters": [
+              {
+                "name": "Last Update",
+                "type": "date"
+              }
+            ],
             "nrqlQueries": [
               {
                 "accountId": 0,


### PR DESCRIPTION
### Relevant information

fixing dashboard widget that was missing a data formatter option

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
