### PR TITLE
we hash de identifier not encode

### DIFF
--- a/docs/synthesis.md
+++ b/docs/synthesis.md
@@ -21,7 +21,7 @@ synthesis:
 | name    | String | Yes | The attribute to use for the entity name. |
 | identifier| String| Yes | Telemetry attribute to use as the entity identifier.|
 | compositeIdentifier| String| No | Set of attributes that will identify the telemetry. When this one is used identifier is not required.|
-| encodeIdentifierInGUID | Boolean | No | If true, the identifier value will be encoded to respect the [GUID limits][guid_spec]. Defaults to `false`. |
+| encodeIdentifierInGUID | Boolean | No | If true, the identifier value will be hashed to respect the [GUID limits][guid_spec]. Defaults to `false`. |
 | conditions | List | No | The list of conditions to apply in the data point to match the rule. Defaults to an empty list. |
 | tags     | List   | No | The list of attributes to copy as entity tags if the rule matches. Defaults to an empty list. |
 


### PR DESCRIPTION
### Relevant information

change the doc to reflect that we hash the identifier not necode.

Hash is not reversible while encoding is

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
