### PR TITLE
Add new generic elastic cache entities

### DIFF
--- a/definitions/infra-awselasticachecluster/definition.yml
+++ b/definitions/infra-awselasticachecluster/definition.yml
@@ -1,0 +1,11 @@
+domain: INFRA
+type: AWSELASTICACHECLUSTER
+goldenTags:
+- aws.accountId
+- aws.awsRegion
+- aws.region
+- aws.customerAvailabilityZone
+- aws.numCacheNodes
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awselasticachecluster/golden_metrics.yml
+++ b/definitions/infra-awselasticachecluster/golden_metrics.yml
@@ -1,0 +1,45 @@
+cpuUtilization:
+  title: CPU utilization (%)
+  unit: PERCENTAGE
+  queries:
+    aws:
+      select: average(aws.elasticache.CPUUtilization)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+swapUsageBytes:
+  title: Swap usage (bytes)
+  unit: BYTES
+  queries:
+    aws:
+      select: average(aws.elasticache.SwapUsage)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+freeableMemory:
+  title: Free memory (bytes)
+  unit: BYTES
+  queries:
+    aws:
+      select: average(aws.elasticache.FreeableMemory)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+networkBytesIn:
+  title: Bytes in per sec
+  unit: BYTES_PER_SECOND
+  queries:
+    aws:
+      select: rate(sum(aws.elasticache.NetworkBytesIn), 1 second)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+networkBytesOut:
+  title: Bytes out per sec
+  unit: BYTES_PER_SECOND
+  queries:
+    aws:
+      select: rate(sum(aws.elasticache.NetworkBytesOut), 1 second)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/definitions/infra-awselasticachecluster/summary_metrics.yml
+++ b/definitions/infra-awselasticachecluster/summary_metrics.yml
@@ -1,0 +1,29 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: AWS account
+  unit: STRING
+cpuUtilization:
+  goldenMetric: cpuUtilization
+  query:
+    eventId: entity.guid
+    select: average(aws.elasticache.CPUUtilization)
+    from: Metric
+  unit: PERCENTAGE
+  title: CPU utilization
+freeableMemory:
+  goldenMetric: freeableMemory
+  query:
+    eventId: entity.guid
+    select: average(aws.elasticache.FreeableMemory)
+    from: Metric
+  unit: BYTES
+  title: Free memory
+swapUsageBytes:
+  goldenMetric: swapUsageBytes
+  query:
+    eventId: entity.guid
+    select: average(aws.elasticache.SwapUsage)
+    from: Metric
+  unit: BYTES
+  title: Swap usage

--- a/definitions/infra-awselasticachememcachedcluster/golden_metrics.yml
+++ b/definitions/infra-awselasticachememcachedcluster/golden_metrics.yml
@@ -3,7 +3,7 @@ cpuUtilization:
   unit: PERCENTAGE
   queries:
     aws:
-      select: average(aws.rds.CPUUtilization)
+      select: average(aws.elasticache.CPUUtilization)
       from: Metric
       eventId: entity.guid
       eventName: entity.name

--- a/definitions/infra-awselasticachenode/definition.yml
+++ b/definitions/infra-awselasticachenode/definition.yml
@@ -1,0 +1,12 @@
+domain: INFRA
+type: AWSELASTICACHENODE
+goldenTags:
+- aws.accountId
+- aws.awsRegion
+- aws.region
+- aws.customerAvailabilityZone
+- aws.cacheClusterId
+- aws.parameterGroupStatus
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-awselasticachenode/golden_metrics.yml
+++ b/definitions/infra-awselasticachenode/golden_metrics.yml
@@ -1,0 +1,54 @@
+getThroughput:
+  title: Gets per sec
+  unit: REQUESTS_PER_MINUTE
+  queries:
+    aws:
+      select: rate(sum(aws.elasticache.CacheHits) + sum(aws.elasticache.CacheMisses), 1 minute)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+getMisses:
+  title: Get hit rate (%)
+  unit: PERCENTAGE
+  queries:
+    aws:
+      select: 100 * sum(aws.elasticache.CacheHits) / (sum(aws.elasticache.CacheMisses) + sum(aws.elasticache.CacheMisses))
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+evictedItems:
+  title: Evicted items per sec
+  unit: OPERATIONS_PER_SECOND
+  queries:
+    aws:
+      select: rate(sum(aws.elasticache.Evictions), 1 second)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+swapUsage:
+  title: Swap usage
+  unit: BYTES
+  queries:
+    aws:
+      select: average(aws.elasticache.SwapUsage)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+cpuUtilization:
+  title: CPU utilization (%)
+  unit: PERCENTAGE
+  queries:
+    aws:
+      select: average(aws.rds.CPUUtilization)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+currentConnections:
+  title: Current connections
+  unit: PERCENTAGE
+  queries:
+    aws:
+      select: average(aws.elasticache.CurrConnections)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/definitions/infra-awselasticachenode/summary_metrics.yml
+++ b/definitions/infra-awselasticachenode/summary_metrics.yml
@@ -1,0 +1,29 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: AWS account
+  unit: STRING
+getThroughput:
+  goldenMetric: getThroughput
+  query:
+    eventId: entity.guid
+    select: rate(sum(aws.elasticache.CacheHits) + sum(aws.elasticache.CacheMisses), 1 minute)
+    from: Metric
+  unit: REQUESTS_PER_MINUTE
+  title: Get throughput
+getHitRatio:
+  goldenMetric: getMisses
+  query:
+    eventId: entity.guid
+    select: sum(aws.elasticache.CacheHits) / (sum(aws.elasticache.CacheHits) + sum(aws.elasticache.CacheMisses)) * 100
+    from: Metric
+  unit: PERCENTAGE
+  title: Get hit rate
+swapUsage:
+  goldenMetric: swapUsage
+  query:
+    eventId: entity.guid
+    select: average(aws.elasticache.SwapUsage)
+    from: Metric
+  unit: BYTES
+  title: Swap usage


### PR DESCRIPTION
### Relevant information

Create 2 new entities that englobes the elasticache (redis | memcached) cluster and node. 
This is needed because in some scenarios (Metric Streams) there is no way to distinguish between redis or memcached, then we need a way to somehow assign an entity to those metrics

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
