### PR TITLE
Allow specifying only the goldenMetric pointer in summary metric definitions

### DIFF
--- a/definitions/infra-container/summary_metrics.yml
+++ b/definitions/infra-container/summary_metrics.yml
@@ -3,108 +3,23 @@ containerState:
   unit: STRING
   tag:
     key: container.state
-cpuUsageContainer:
-  title: Container CPU Core usage
-  query:
-    eventId: entityGuid
-    from: ContainerSample
-    select: max(cpuUsedCores)
-  unit: COUNT
-  hidden: true
-cpuUsageK8s:
-  title: K8s CPU Core usage
-  query:
-    eventId: entityGuid
-    from: K8sContainerSample
-    select: max(cpuUsedCores)
-  unit: COUNT
-  hidden: true
 cpuUsage:
   goldenMetric: cpuUsage
   title: CPU usage (cores)
-  derive: '@cpuUsageContainer || @cpuUsageK8s'
   unit: COUNT
-cpuUtilizationContainer:
-  title: Container CPU utilization percent
-  query:
-    eventId: entityGuid
-    from: ContainerSample
-    select: max(cpuPercent)
-  unit: PERCENTAGE
-  hidden: true
-cpuUtilizationK8s:
-  title: K8s CPU utilization percent
-  query:
-    eventId: entityGuid
-    from: K8sContainerSample
-    select: max(cpuCoresUtilization)
-  unit: PERCENTAGE
-  hidden: true
 cpuUtilization:
   goldenMetric: cpuUtilization
-  derive: '@cpuUtilizationContainer || @cpuUtilizationK8s'
   unit: PERCENTAGE
   title: CPU utilization (%)
-storageUsageContainer:
-  title: container storage usage
-  query:
-    eventId: entityGuid
-    from: ContainerSample
-    select: max(ioTotalBytes)
-  unit: BYTES
-  hidden: true
-storageUsageK8s:
-  title: K8s storage usage
-  query:
-    eventId: entityGuid
-    from: K8sContainerSample
-    select: max(fsUsedBytes)
-  unit: BYTES
-  hidden: true
 storageUsage:
   goldenMetric: storageUsage
   title: Storage usage (bytes)
   unit: BYTES
-  derive: '@storageUsageContainer || @storageUsageK8s'
-memoryUsageContainer:
-  title: Container memory usage
-  query:
-    eventId: entityGuid
-    from: ContainerSample
-    select: max(memoryUsageBytes)
-  unit: BYTES
-  hidden: true
-memoryUsageK8s:
-  title: K8s memory usage
-  query:
-    eventId: entityGuid
-    from: K8sContainerSample
-    select: max(memoryWorkingSetBytes)
-  unit: BYTES
-  hidden: true
 memoryUsage:
   goldenMetric: memoryUsage
-  derive: '@memoryUsageContainer || @memoryUsageK8s'
   title: Memory usage (bytes)
   unit: BYTES
-networkTrafficRx:
-  title: Network traffic RX
-  query:
-    eventId: entityGuid
-    from: ContainerSample
-    select: max(networkRxBytesPerSecond)
-  unit: BYTES_PER_SECOND
-  hidden: true
-networkTrafficTx:
-  title: Network traffic TX
-  query:
-    eventId: entityGuid
-    from: ContainerSample
-    select: max(networkTxBytesPerSecond)
-  unit: BYTES_PER_SECOND
-  hidden: true
 networkTrafficTotal:
   goldenMetric: networkTrafficTotal
-  derive: '@networkTrafficRx + @networkTrafficTx'
   title: Network traffic (bytes per second)
   unit: BYTES_PER_SECOND

--- a/definitions/infra-host/summary_metrics.yml
+++ b/definitions/infra-host/summary_metrics.yml
@@ -3,130 +3,23 @@ agentVersion:
   unit: STRING
   tag:
     key: agentVersion
-cpuUsageHost:
-  title: "CPU Usage Host"
-  unit: PERCENTAGE
-  query:
-    from: Metric
-    select: average(host.cpuPercent)
-    eventId: entity.guid
-  hidden: true
-cpuUsageEc2:
-  title: "CPU Usage Ec2"
-  unit: PERCENTAGE
-  query:
-    from: Metric
-    select: average(aws.ec2.CPUUtilization)
-    eventId: entity.guid
-  hidden: true
-cpuUsageAzure:
-  title: "CPU Usage Azure"
-  unit: PERCENTAGE
-  query:
-    from: Metric
-    select: average(azure.compute.virtualmachines.PercentageCPU)
-    eventId: entity.guid
-  hidden: true
-cpuUsageGcp:
-  title: "CPU Usage GCP"
-  unit: PERCENTAGE
-  query:
-    from: Metric
-    select: average(gcp.compute.instance.cpu.utilization)
-    eventId: entity.guid
-  hidden: true
-networkInHost:
-  title: "Network In Host"
-  unit: BYTES_PER_SECOND
-  query:
-    from: Metric
-    select: average(host.net.receiveBytesPerSecond)
-    eventId: entity.guid
-  hidden: true
-networkInEc2:
-  title: "Network In EC2"
-  unit: BYTES_PER_SECOND
-  query:
-    from: Metric
-    select: average(aws.ec2.NetworkIn)
-    eventId: entity.guid
-  hidden: true
-networkInAzure:
-  title: "Network In Azure"
-  unit: BYTES_PER_SECOND
-  query:
-    from: Metric
-    select: average(azure.compute.virtualmachines.NetworkIn)
-    eventId: entity.guid
-  hidden: true
-networkInGcp:
-  title: "Network In GCP"
-  unit: BYTES_PER_SECOND
-  query:
-    from: Metric
-    select: average(gcp.compute.instance.network.received_bytes_count)
-    eventId: entity.guid
-  hidden: true
-networkOutHost:
-  title: Network out host
-  unit: BYTES_PER_SECOND
-  query:
-    from: Metric
-    select: average(host.net.transmitBytesPerSecond)
-    eventId: entity.guid
-  hidden: true
-networkOutEc2:
-  title: "Network Out Ec2"
-  unit: BYTES_PER_SECOND
-  query:
-    from: Metric
-    select: average(aws.ec2.NetworkOut)
-    eventId: entity.guid
-  hidden: true
-networkOutAzure:
-  title: "Network Out Azure"
-  unit: BYTES_PER_SECOND
-  query:
-    from: Metric
-    select: average(azure.compute.virtualmachines.NetworkOut)
-    eventId: entity.guid
-  hidden: true
-networkOutGcp:
-  title: "Network Out GCP"
-  unit: BYTES_PER_SECOND
-  query:
-    from: Metric
-    select: average(gcp.compute.instance.network.sent_bytes_count)
-    eventId: entity.guid
-  hidden: true
 cpuUsage:
   goldenMetric: cpuUsage
   title: CPU usage (%)
   unit: PERCENTAGE
-  derive: '@cpuUsageHost || @cpuUsageEc2 || @cpuUsageAzure || @cpuUsageGcp'
 memoryUsage:
   goldenMetric: memoryUsage
   title: Memory usage (%)
   unit: PERCENTAGE
-  query:
-    from: Metric
-    select: average(host.memoryUsedPercent)
-    eventId: entity.guid
 storageUsage:
   goldenMetric: storageUsage
   title: Storage usage (%)
   unit: PERCENTAGE
-  query:
-    from: Metric
-    select: average(host.diskUsedPercent)
-    eventId: entity.guid
 networkTrafficTx:
   goldenMetric: networkTrafficTx
   title: Network transmit traffic (bytes/s)
   unit: BYTES_PER_SECOND
-  derive: '@networkOutHost || @networkOutEc2 || @networkOutAzure || @networkOutGcp'
 networkTrafficRx:
   goldenMetric: networkTrafficRx
   title: Network receive traffic (bytes/s)
   unit: BYTES_PER_SECOND
-  derive: '@networkInHost || @networkInEc2 || @networkInAzure || @networkInGcp'

--- a/validator/schemas/summary-metrics-schema-v1.json
+++ b/validator/schemas/summary-metrics-schema-v1.json
@@ -23,24 +23,14 @@
       "unit",
       "title"
     ],
-    "oneOf": [{
+    "oneOf": [      {
         "required": [
-          "query"
-        ]
-      },
-      {
-        "required": [
-          "queries"
+          "goldenMetric"
         ]
       },
       {
         "required": [
           "tag"
-        ]
-      },
-      {
-        "required": [
-          "derive"
         ]
       }
     ],
@@ -61,11 +51,6 @@
         "examples": [
           "COUNT"
         ]
-      },
-      "hidden": {
-        "$id": "#/properties/hidden",
-        "type": "boolean",
-        "title": "Whether the metric shows up on the UI or not"
       },
       "query": {
         "$ref": "#/definitions/query"
@@ -99,15 +84,6 @@
           }
         },
         "additionalProperties": false
-      },
-      "derive": {
-        "$id": "#/properties/derive",
-        "type": "string",
-        "title": "The derive string",
-        "description": "The derive string can be used to derive metric out of other metrics",
-        "examples": [
-          "(@metricA * 100) / (@metricB + @metricC)"
-        ]
       },
       "goldenMetric": {
         "$id": "#/properties/goldenMetric",


### PR DESCRIPTION
### Relevant information

The validation was failing when no query was provided. SMs can just contain pointers to GMs to be valid. 

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
