### PR TITLE
fix: update synthesis name and identifier

### DIFF
--- a/definitions/ext-meraki_controller/definition.yml
+++ b/definitions/ext-meraki_controller/definition.yml
@@ -3,8 +3,8 @@
 domain: EXT
 type: MERAKI_CONTROLLER
 synthesis:
-  name: device_name
-  identifier: device_name
+  name: objectIdentifier
+  identifier: objectIdentifier
   encodeIdentifierInGUID: true
 
   conditions:


### PR DESCRIPTION
### Relevant information

updating the `synthesis.name` and `synthesis.identifier` attributes on the `EXT-MERAKI_CONTROLLER` definition to isolate the entity at the controller level. The current `device_name` attribute is used for multiple items below the controller and is causing `n+1` entities when we only want 1 created. 

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
