### PR TITLE
Create NOT_INSTRUMENTED entity type

### DIFF
--- a/definitions/ext-not_instrumented/definition.yml
+++ b/definitions/ext-not_instrumented/definition.yml
@@ -1,0 +1,6 @@
+domain: EXT
+type: NOT_INSTRUMENTED
+
+configuration:
+  entityExpirationTime: DAILY
+  alertable: false


### PR DESCRIPTION
### Relevant information

This new type will hold entities that are not yet  instrumented but detected by an internal system in NR.

For now this is on experimental so we are not providing an overview.

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
