### PR TITLE
fix: change PERCENTAGE to STRING in SL

### DIFF
--- a/definitions/ext-service_level/summary_metrics.yml
+++ b/definitions/ext-service_level/summary_metrics.yml
@@ -1,6 +1,6 @@
 sloTarget:
   title: SLO target
-  unit: PERCENTAGE
+  unit: STRING
   tag:
     key: nr.sloTarget
 


### PR DESCRIPTION
### Relevant information

Switching sloTarget from PERCENTAGE to STRING, since the field is a configuration and not a calculated value, we want to show to the costumers the exact value they configured and not a rounded one, for cases like 99.99X% the rounding to 100% loose the sense of the SLI.

### Checklist

* [X] I've read the guidelines and understand the acceptance criteria.
* [X] The value of the attribute marked as `identifier` will be unique and valid. 
* [X] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
