### PR TITLE
Add GMs for TLS version info by app

### DIFF
--- a/definitions/apm-application/golden_metrics.yml
+++ b/definitions/apm-application/golden_metrics.yml
@@ -19,3 +19,19 @@ errorRate:
     select: filter(count(newrelic.timeslice.value), where metricTimesliceName = 'Errors/all') / (filter(count(newrelic.timeslice.value),
       where metricTimesliceName in ('HttpDispatcher', 'OtherTransaction/all'))) * 100 AS 'Error %'
     eventName: appName
+
+deprecatedTlsInstances:
+  title: Instances using deprecated TLS versions
+  unit: COUNT
+  query:
+    select: uniqueCount(realAgentId)
+    where: metricTimesliceName in ('HttpDispatcher', 'OtherTransaction/all')
+    eventName: appName
+    
+supportedTlsInstances:
+  title: Instances using supported TLS versions
+  unit: COUNT
+  query:
+    select: uniqueCount(realAgentId)
+    where: metricTimesliceName in ('HttpDispatcher', 'OtherTransaction/all')
+    eventName: appName


### PR DESCRIPTION
Add golden metrics to report on how many instances are reporting supported vs deprecated versions of TLS. The definition of supported and deprecated versions will change over time, but providing this as a golden metric allows customers to plot their progress. This golden metric will be particularly useful as New Relic moves to deprecate a TLS version (as we're intending to do soon with TLS v1.0 and v1.1).

For example, a query like:
```
FROM Metric SELECT uniqueCount(newrelic.goldenmetrics.apm.application.deprecatedTlsInstances) TIMESERIES
```
will plot, across all applications in an account, the number of reporting instances using a deprecated version of TLS to talk to New Relic. Replacing `newrelic.goldenmetrics.apm.application.deprecatedTlsInstances` with `newrelic.goldenmetrics.apm.application.deprecatedTlsInstances` shows the number of reporting instances using a supported TLS version.

### Relevant information

Describe what you have done and any details that you think are relevant or that you might want to discuss with us. 

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
