### PR TITLE
Introduce uninstrumented entities domain

### DIFF
--- a/definitions/ext-not_instrumented/definition.yml
+++ b/definitions/ext-not_instrumented/definition.yml
@@ -1,3 +1,4 @@
+# Entity for testing will be deleted soon
 domain: EXT
 type: NOT_INSTRUMENTED
 

--- a/definitions/uninstrumented-database/definition.yml
+++ b/definitions/uninstrumented-database/definition.yml
@@ -1,0 +1,6 @@
+domain: UNINSTRUMENTED
+type: DATABASE
+
+configuration:
+  entityExpirationTime: DAILY
+  alertable: false


### PR DESCRIPTION
### Relevant information

This new type will replace EXT-NOT_INSTRUMENTED

We will have a type under this domain for each generic type of entity.

So for DB's we have database instead of mysqldb, psqldb, awspsqldb etc

We also move to UNINSTRUMENTED to be inside the domain length limits.

A follow-up PR will delete the not-instrumented type once we shutdown the poc.

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
