### PR TITLE
fix(firewall): Use single dimensional metric for GM rule

### DIFF
--- a/definitions/ext-firewall/golden_metrics.yml
+++ b/definitions/ext-firewall/golden_metrics.yml
@@ -54,7 +54,7 @@ sessionsTotal:
       where: "provider = 'kentik-firewall'"
     # Fortinet Fortigate firewalls
     kentik/fortinet-fortigate:
-      select: max(kentik.snmp.fgSysSesCount) + max(kentik.snmp.fgSysSes6Count)
+      select: max(kentik.snmp.fgSysSesCount)
       from: Metric
       where: "provider = 'kentik-firewall'"
     # Cisco Firepower firewalls

--- a/definitions/ext-firewall/palo-alto-dashboard.json
+++ b/definitions/ext-firewall/palo-alto-dashboard.json
@@ -134,7 +134,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "FROM Metric SELECT min(kentik.snmp.MemoryUtilization) AS 'Min Memory', max(kentik.snmp.MemoryUtilization) AS 'Max Memory', average(kentik.snmp.MemoryUtilization) AS 'Average Memory' WHERE provider = 'kentik-firewall' TIMESERIES 5 MINUTES"
+                "query": "FROM Metric SELECT (max(kentik.snmp.hrStorageUsed)/max(kentik.snmp.hrStorageSize)) * 100 AS 'Memory Utilization %' FACET storage_description TIMESERIES 5 MINUTES"
               }
             ],
             "yAxisLeft": {


### PR DESCRIPTION
### Relevant information

* Updates the fortigate GM definition to only use a single dimensional metric (old query had issues in golden signals pipeline)
* Also reverts the memoryUtilization query for palo alto devices back to a previous working state

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
