### PR TITLE
Fix the condition for capturing traces inside of the Pixie DNS dashboard

### DIFF
--- a/definitions/ext-pixie_dns/dashboard.json
+++ b/definitions/ext-pixie_dns/dashboard.json
@@ -167,7 +167,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT * from Span WHERE dns.dns_server IS NOT NULL and instrumentation.provider = 'pixie' since 30 minutes ago"
+                "query": "SELECT * from Span WHERE dns.server.name IS NOT NULL and instrumentation.provider = 'pixie' since 30 minutes ago"
               }
             ],
             "platformOptions": {


### PR DESCRIPTION
### Relevant information
Discovered that I didn't change the DNS dashboard span filter. I was filtering on an old field that doesn't show up in the data anymore. This diff points to a new filter that actually shows up in the data.
### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
