### PR TITLE
Fix Pixie Kafka entity name

### DIFF
--- a/definitions/ext-pixie_kafkabroker/dashboard.json
+++ b/definitions/ext-pixie_kafkabroker/dashboard.json
@@ -161,7 +161,7 @@
           }
         },
         {
-          "title": "Kafka Spans",
+          "title": "Sample of Kafka Requests",
           "layout": {
             "column": 1,
             "row": 10,

--- a/definitions/ext-pixie_kafkabroker/definition.yml
+++ b/definitions/ext-pixie_kafkabroker/definition.yml
@@ -7,7 +7,7 @@ synthesis:
       attributes:
         - kafka.service.name
         - kafka.namespace.name
-        - pixie.cluster.id
+        - px.cluster.id
     name: kafka.service.name
     encodeIdentifierInGUID: true
     # Matching kafka metrics
@@ -26,7 +26,7 @@ synthesis:
       attributes:
         - kafka.service.name
         - kafka.namespace.name
-        - pixie.cluster.id
+        - px.cluster.id
     name: kafka.service.name
     encodeIdentifierInGUID: true
     conditions:

--- a/definitions/ext-pixie_kafkabroker/tests/MetricRaw.json
+++ b/definitions/ext-pixie_kafkabroker/tests/MetricRaw.json
@@ -2,7 +2,7 @@
   {
     "kafka.service.name": "kafka-broker",
     "kafka.namespace.name": "px-kafka",
-    "pixie.cluster.id": "test_cluster",
+    "px.cluster.id": "test_cluster",
     "metricName": "kafka.latency",
     "instrumentation.provider": "pixie",
     "k8s.cluster.name": "test_cluster",

--- a/definitions/ext-pixie_kafkabroker/tests/Span.json
+++ b/definitions/ext-pixie_kafkabroker/tests/Span.json
@@ -2,7 +2,7 @@
   {
     "kafka.service.name": "kafka-broker",
     "kafka.namespace.name": "px-kafka",
-    "pixie.cluster.id": "test_cluster",
+    "px.cluster.id": "test_cluster",
     "metricName": "kafka.latency",
     "instrumentation.provider": "pixie",
     "k8s.cluster.name": "staging_cluster",


### PR DESCRIPTION
### Relevant information
The Pixie Kafka entity name uses the wrong field at the moment. It should be `px.cluster.id` not `pixie.cluster.id`. Discovered this during testing.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
