### PR TITLE
Update Pixie-Cassandra entity definition.

### DIFF
--- a/definitions/ext-pixie_cassandra/definition.yml
+++ b/definitions/ext-pixie_cassandra/definition.yml
@@ -11,7 +11,7 @@ synthesis:
     name: cassandra.service.name
     encodeIdentifierInGUID: true
     conditions:
-    - attribute: cassandra.req_body
+    - attribute: cassandra.req_cmd
       present: true
     - attribute: instrumentation.provider
       value: pixie

--- a/definitions/ext-pixie_cassandra/tests/MetricRaw.json
+++ b/definitions/ext-pixie_cassandra/tests/MetricRaw.json
@@ -6,6 +6,6 @@
     "instrumentation.provider": "pixie",
     "k8s.cluster.name": "test_cluster",
     "metricName": "cassandra.latency",
-    "cassandra.req_body": "select * from users;"
+    "cassandra.req_cmd": "Query"
   }
 ]

--- a/definitions/ext-pixie_cassandra/tests/Span.json
+++ b/definitions/ext-pixie_cassandra/tests/Span.json
@@ -5,6 +5,6 @@
     "px.cluster.id": "abcdef",
     "instrumentation.provider": "pixie",
     "k8s.cluster.name": "test_cluster",
-    "cassandra.req_body": "select * from users;"
+    "cassandra.req_cmd": "Query"
   }
 ]


### PR DESCRIPTION
### Relevant information

Not all Cassandra requests have a req_body, which means that those requests won't show up under the Pixie Cassandra entity. This PR updates the entity definition to use a column that is always present in CQL requests. cc @philkuz 

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
