### PR TITLE
Convert unit of 2 golden metrics from ms to second to match real data

### DIFF
--- a/definitions/ext-sap_maxdb/golden_metrics.yml
+++ b/definitions/ext-sap_maxdb/golden_metrics.yml
@@ -18,7 +18,7 @@ responseTime:
   title: Response time
   unit: SECONDS
   query:
-    select: average(NR.SAP.SYSTEM.PROCESS)
+    select: average(NR.SAP.SYSTEM.PROCESS) / 1000
     from: Metric
     where: KEY_FIGURE = 'DB Time'
     eventId: entity.guid

--- a/definitions/ext-sap_mssql/golden_metrics.yml
+++ b/definitions/ext-sap_mssql/golden_metrics.yml
@@ -16,7 +16,7 @@ spaceUsed:
 
 size:
   title: Cache hit ratio
-  unit: BYTES
+  unit: PERCENTAGE
   query:
     select: average(NR.SAP.DB.SQLSvr.Cache)
     from: Metric
@@ -27,7 +27,7 @@ responseTime:
   title: Response time
   unit: SECONDS
   query:
-    select: average(NR.SAP.SYSTEM.PROCESS)
+    select: average(NR.SAP.SYSTEM.PROCESS) / 1000
     from: Metric
     where: KEY_FIGURE = 'DB Time'
     eventId: entity.guid


### PR DESCRIPTION
	modified:   ext-sap_maxdb/golden_metrics.yml
	modified:   ext-sap_mssql/golden_metrics.yml

### Relevant information

The golden matrix are showing data in seconds, while the raw metrics data are in ms. Add conversion for ms to second in NRQL statements to make data consistent with unit displayed.

Also, change hit-ratio unit to Percentage

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
