### PR TITLE
Remove not_instrumented type

### DIFF
--- a/definitions/ext-not_instrumented/definition.yml
+++ b/definitions/ext-not_instrumented/definition.yml
@@ -1,7 +1,0 @@
-# Entity for testing will be deleted soon
-domain: EXT
-type: NOT_INSTRUMENTED
-
-configuration:
-  entityExpirationTime: DAILY
-  alertable: false


### PR DESCRIPTION
### Relevant information

We have decided on using the UNINSTRUMENTED domain.

So we need to cleanup this ext-not_instrumented

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
