### PR TITLE
fix: Replace pixie golden metrics percentage aggregate

### DIFF
--- a/definitions/ext-pixie_dns/golden_metrics.yml
+++ b/definitions/ext-pixie_dns/golden_metrics.yml
@@ -14,5 +14,5 @@ errorRate:
   title: Error rate (%)
   unit: PERCENTAGE
   query:
-    select: percentage(count(dns.latency), WHERE dns.rcode!=3 and dns.rcode!= 0)
+    select: filter(count(dns.latency), WHERE dns.rcode!=3 and dns.rcode!= 0) / count(dns.latency)
     from: Metric

--- a/definitions/ext-pixie_dns/golden_metrics.yml
+++ b/definitions/ext-pixie_dns/golden_metrics.yml
@@ -14,5 +14,5 @@ errorRate:
   title: Error rate (%)
   unit: PERCENTAGE
   query:
-    select: filter(count(dns.latency), WHERE dns.rcode!=3 and dns.rcode!= 0) / count(dns.latency)
+    select: filter(count(dns.latency), WHERE dns.rcode!=3 and dns.rcode!= 0) / count(dns.latency) * 100
     from: Metric

--- a/definitions/ext-pixie_kafkabroker/golden_metrics.yml
+++ b/definitions/ext-pixie_kafkabroker/golden_metrics.yml
@@ -14,7 +14,7 @@ errorRate:
   title: Error rate (%)
   unit: PERCENTAGE
   query:
-    select: filter(count(kafka.latency), WHERE kafka.has_error) / count(kafka.latency)
+    select: filter(count(kafka.latency), WHERE kafka.has_error) / count(kafka.latency) * 100
     from: Metric
 dataTransferRate:
   title: Throughput (bps)

--- a/definitions/ext-pixie_kafkabroker/golden_metrics.yml
+++ b/definitions/ext-pixie_kafkabroker/golden_metrics.yml
@@ -14,7 +14,7 @@ errorRate:
   title: Error rate (%)
   unit: PERCENTAGE
   query:
-    select: percentage(count(kafka.latency), WHERE kafka.has_error)
+    select: filter(count(kafka.latency), WHERE kafka.has_error) / count(kafka.latency)
     from: Metric
 dataTransferRate:
   title: Throughput (bps)

--- a/definitions/ext-pixie_mysql/golden_metrics.yml
+++ b/definitions/ext-pixie_mysql/golden_metrics.yml
@@ -14,7 +14,7 @@ errorRate:
   title: Error rate (%)
   unit: PERCENTAGE
   query:
-    select: percentage(count(mysql.latency), where mysql.resp_status>2)
+    select: filter(count(mysql.latency), WHERE mysql.resp_status>2) / count(mysql.latency)
     from: Metric
 dataTransferRate:
   title: Throughput (bps)

--- a/definitions/ext-pixie_mysql/golden_metrics.yml
+++ b/definitions/ext-pixie_mysql/golden_metrics.yml
@@ -14,7 +14,7 @@ errorRate:
   title: Error rate (%)
   unit: PERCENTAGE
   query:
-    select: filter(count(mysql.latency), WHERE mysql.resp_status>2) / count(mysql.latency)
+    select: filter(count(mysql.latency), WHERE mysql.resp_status>2) / count(mysql.latency) * 100
     from: Metric
 dataTransferRate:
   title: Throughput (bps)


### PR DESCRIPTION
### Relevant information
Discovered after the entity update that `percentage()` did not render properly inside of the golden metrics view. The golden metrics platform does not support percentage at the moment. This diff makes a work around:  we're "manually" calculating the percentage by replacing the aggregate with the following:
```
s/percentage\(count\((.*?)\), WHERE (.*)\)/filter(count($1), WHERE $2) \/ count($1)_)/g
```
`percentage(count(mysql.latency), WHERE mysql.resp_status>2)` became
`filter(count(mysql.latency), WHERE mysql.resp_status>2) / count(mysql.latency)`

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
