### PR TITLE
Fix: Use rcode name instead of rcode for Pixie DNS

### DIFF
--- a/definitions/ext-pixie_dns/dashboard.json
+++ b/definitions/ext-pixie_dns/dashboard.json
@@ -138,7 +138,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT rate(count(`dns.latency`), 1 minute) FROM Metric facet dns.rcode \nSINCE 30 MINUTES AGO TIMESERIES"
+                "query": "SELECT rate(count(`dns.latency`), 1 minute) FROM Metric facet dns.rcode_name SINCE 30 MINUTES AGO TIMESERIES"
               }
             ],
             "platformOptions": {


### PR DESCRIPTION
### Relevant information
Switch to use `rcode_name` instead of `rcode for Pixie DNS dashboard. rcode_name is more readable after our conversions.
After: 
![image](https://user-images.githubusercontent.com/5456019/201447465-909b1f0c-9d35-4fce-a6a9-6770db40722f.png)

Before:
![image](https://user-images.githubusercontent.com/5456019/201447457-fa4ddb4e-4986-49c1-9a60-ce502b30f7d8.png)


### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
