### PR TITLE
Add the agent uid as a separate attribute

### DIFF
--- a/definitions/ext-otelcol/definition.yml
+++ b/definitions/ext-otelcol/definition.yml
@@ -16,6 +16,8 @@ synthesis:
     tags:
       service.namespace:
       service.version:
+      service.instance.id:
+        entityTagName: opamp.agent.uid
       os.type:
       os.version:
       cloud.provider:


### PR DESCRIPTION
### Relevant information

This is a small modification of the existing Opentelemetry Collector definition. Right now, the uid of an agent is implicitly defined as the entity name. This could cause some confusion in the future, so I'd like to add a separate tag for the agent uid instead.

Note: this rule is still protected by a dummy condition (nr.entity_type), so it's not used by anyone in practice.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
