### PR TITLE
Azure host overrideGuidType

### DIFF
--- a/definitions/infra-host/definition.yml
+++ b/definitions/infra-host/definition.yml
@@ -128,7 +128,6 @@ synthesis:
       conditions:
         - attribute: azure.resourceType
           value: Microsoft.Compute/virtualMachines
-
 configuration:
   entityExpirationTime: DAILY
   alertable: true

--- a/definitions/infra-host/definition.yml
+++ b/definitions/infra-host/definition.yml
@@ -123,9 +123,12 @@ synthesis:
     - identifier: azure.resourceId
       name: displayName
       encodeIdentifierInGUID: true
+      legacyFeatures:
+        overrideGuidType: true
       conditions:
         - attribute: azure.resourceType
           value: Microsoft.Compute/virtualMachines
+
 configuration:
   entityExpirationTime: DAILY
   alertable: true


### PR DESCRIPTION
### Relevant information

Adding the overrideGuidType = false to the Azure host to keep backwards compatibility with old integrations hosts. 

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
