### PR TITLE
Change Azure host identifier

### DIFF
--- a/definitions/infra-host/definition.yml
+++ b/definitions/infra-host/definition.yml
@@ -120,7 +120,7 @@ synthesis:
         host.name:
         instrumentation.provider:
     # Azure host from Microsoft.Compute/virtualMachines
-    - identifier: azure.resourceId
+    - identifier: azure.compute.virtualmachines.vmId
       name: displayName
       encodeIdentifierInGUID: true
       legacyFeatures:


### PR DESCRIPTION
### Relevant information
The NR agent uses `vmId` this change is to preserve intercompatibility between both sources of data. 

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
