### PR TITLE
Fix: Pixie Golden Metrics order of operations

### DIFF
--- a/definitions/ext-pixie_dns/golden_metrics.yml
+++ b/definitions/ext-pixie_dns/golden_metrics.yml
@@ -14,5 +14,5 @@ errorRate:
   title: Error rate (%)
   unit: PERCENTAGE
   query:
-    select: filter(count(dns.latency), WHERE dns.rcode!=3 and dns.rcode!= 0) / count(dns.latency) * 100
+    select: 100 * filter(count(dns.latency), WHERE dns.rcode !=3 and dns.rcode != 0) / count(dns.latency)
     from: Metric

--- a/definitions/ext-pixie_kafkabroker/golden_metrics.yml
+++ b/definitions/ext-pixie_kafkabroker/golden_metrics.yml
@@ -14,7 +14,7 @@ errorRate:
   title: Error rate (%)
   unit: PERCENTAGE
   query:
-    select: filter(count(kafka.latency), WHERE kafka.has_error) / count(kafka.latency) * 100
+    select: 100 * filter(count(kafka.latency), WHERE kafka.has_error is TRUE) / count(kafka.latency)
     from: Metric
 dataTransferRate:
   title: Throughput (bps)

--- a/definitions/ext-pixie_mysql/golden_metrics.yml
+++ b/definitions/ext-pixie_mysql/golden_metrics.yml
@@ -14,7 +14,7 @@ errorRate:
   title: Error rate (%)
   unit: PERCENTAGE
   query:
-    select: filter(count(mysql.latency), WHERE mysql.resp_status>2) / count(mysql.latency) * 100
+    select: 100 * filter(count(mysql.latency), WHERE mysql.resp_status > 2) / count(mysql.latency)
     from: Metric
 dataTransferRate:
   title: Throughput (bps)


### PR DESCRIPTION
### Relevant information
There's a bug in the golden metrics platform right now that we ran into with the Pixie Golden Metrics: https://issues.newrelic.com/browse/NEWRELIC-5496

This diff is a work-around that fixes the issue where error % metrics didn't show up for Pixie entities that had this golden metric. 

To prevent further churn: I worked with the golden metrics team to test each metric using the ephemeral golden metric service on staging. Each of these metrics should work to the best of my knowledge.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
