### PR TITLE
NEWRELIC-4198 : Update OTEL Host golden metrics (network.io)

### DIFF
--- a/definitions/infra-host/golden_metrics.yml
+++ b/definitions/infra-host/golden_metrics.yml
@@ -75,8 +75,8 @@ networkTrafficTx:
       eventName: entityName
     opentelemetry:
       # emulate a rate of 1 second in order to get bytes/second
-      select: sum(system.network.io) / sum((endTimestamp - timestamp) / 1000)
-      where: device != 'lo' AND direction='transmit'
+      select: sum(system.network.io.transmit) / sum((endTimestamp - timestamp) / 1000)
+      where: device != 'lo'
       from: Metric
       eventId: entity.guid
       eventName: entity.name
@@ -96,8 +96,8 @@ networkTrafficRx:
       eventName: entityName
     opentelemetry:
       # emulate a rate of 1 second in order to get bytes/second
-      select: sum(system.network.io) / sum((endTimestamp - timestamp) / 1000)
-      where: device != 'lo' AND direction='receive'
+      select: sum(system.network.io.receive) / sum((endTimestamp - timestamp) / 1000)
+      where: device != 'lo'
       from: Metric
       eventId: entity.guid
       eventName: entity.name


### PR DESCRIPTION
### Relevant information

```
Following this change in the specs, direction will disappear as an attribute and be part of the metric name. For instance system.network.io will be replaced by system.network.io.transmit and system.network.io.receive. This directly impacts the golden metric definitions, which should be updated.
```

### Checklist

* [X] I've read the guidelines and understand the acceptance criteria.
* [X] The value of the attribute marked as `identifier` will be unique and valid. 
* [X] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
