### PR TITLE
Add cluster name to Pixie entities list view

### DIFF
--- a/definitions/ext-pixie_amqp/summary_metrics.yml
+++ b/definitions/ext-pixie_amqp/summary_metrics.yml
@@ -1,3 +1,8 @@
+cluster:
+  title: Cluster
+  unit: STRING
+  tag:
+    key: k8s.cluster.name
 throughput:
   goldenMetric: throughput
   title: Throughput (rpm)

--- a/definitions/ext-pixie_cassandra/summary_metrics.yml
+++ b/definitions/ext-pixie_cassandra/summary_metrics.yml
@@ -1,3 +1,8 @@
+cluster:
+  title: Cluster
+  unit: STRING
+  tag:
+    key: k8s.cluster.name
 throughput:
   goldenMetric: throughput
   title: Throughput (rpm)

--- a/definitions/ext-pixie_dns/summary_metrics.yml
+++ b/definitions/ext-pixie_dns/summary_metrics.yml
@@ -1,3 +1,8 @@
+cluster:
+  title: Cluster
+  unit: STRING
+  tag:
+    key: k8s.cluster.name
 throughput:
   goldenMetric: throughput
   title: Throughput (rpm)

--- a/definitions/ext-pixie_kafkabroker/summary_metrics.yml
+++ b/definitions/ext-pixie_kafkabroker/summary_metrics.yml
@@ -1,3 +1,8 @@
+cluster:
+  title: Cluster
+  unit: STRING
+  tag:
+    key: k8s.cluster.name
 throughput:
   goldenMetric: throughput
   title: Throughput (rpm)

--- a/definitions/ext-pixie_mysql/summary_metrics.yml
+++ b/definitions/ext-pixie_mysql/summary_metrics.yml
@@ -1,3 +1,8 @@
+cluster:
+  title: Cluster
+  unit: STRING
+  tag:
+    key: k8s.cluster.name
 throughput:
   goldenMetric: throughput
   title: Throughput (rpm)

--- a/definitions/ext-pixie_postgres/summary_metrics.yml
+++ b/definitions/ext-pixie_postgres/summary_metrics.yml
@@ -1,3 +1,8 @@
+cluster:
+  title: Cluster
+  unit: STRING
+  tag:
+    key: k8s.cluster.name
 throughput:
   goldenMetric: throughput
   title: Throughput (rpm)

--- a/definitions/ext-pixie_redis/summary_metrics.yml
+++ b/definitions/ext-pixie_redis/summary_metrics.yml
@@ -1,3 +1,8 @@
+cluster:
+  title: Cluster
+  unit: STRING
+  tag:
+    key: k8s.cluster.name
 throughput:
   goldenMetric: throughput
   title: Throughput (rpm)


### PR DESCRIPTION
## Motivation

It can sometimes be difficult to know which Kubernetes cluster Pixie entities are coming from. For example, in the `DNS - Pixie` entity list view, we have many `kube-dns` entities:

<img width="1235" alt="image" src="https://user-images.githubusercontent.com/66266496/206809175-761bf95a-76ad-4dd1-909c-ea9cdfa3cb73.png">

## Fix

Our goal is to add the cluster name as a column to the (above) entity list view. It appears that the `summary_metrics.yml` file controls this view, so we've added the cluster name there. Cluster name is already part of the tags for each Pixie entity. 

### Checklist

* [X] I've read the guidelines and understand the acceptance criteria.
* [X] The value of the attribute marked as `identifier` will be unique and valid. 
* [X] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
