### PR TITLE
remove indexation of HOSTs from Cloud monitoring

### DIFF
--- a/definitions/infra-host/definition.yml
+++ b/definitions/infra-host/definition.yml
@@ -119,15 +119,6 @@ synthesis:
       tags:
         host.name:
         instrumentation.provider:
-    # Azure host from Microsoft.Compute/virtualMachines
-    - identifier: azure.compute.virtualmachines.vmId
-      name: displayName
-      encodeIdentifierInGUID: true
-      legacyFeatures:
-        overrideGuidType: true
-      conditions:
-        - attribute: azure.resourceType
-          value: microsoft.compute/virtualmachines
 configuration:
   entityExpirationTime: DAILY
   alertable: true


### PR DESCRIPTION
### Relevant information

remove indexation of HOSTs from Cloud monitoring.
This is required because we're indexing hosts without agent installed and UI is not prepared for this.
This is used in non GA product and won't break anything.

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
