### PR TITLE
Avoid Cloud metrics showing empty agent Hosts

### DIFF
--- a/definitions/infra-host/definition.yml
+++ b/definitions/infra-host/definition.yml
@@ -119,15 +119,6 @@ synthesis:
       tags:
         host.name:
         instrumentation.provider:
-    # Azure host from Microsoft.Compute/virtualMachines
-    - identifier: azure.compute.virtualmachines.vmId
-      name: displayName
-      encodeIdentifierInGUID: true
-      legacyFeatures:
-        overrideGuidType: true
-      conditions:
-        - attribute: azure.resourceType
-          value: microsoft.compute/virtualmachines
 configuration:
   entityExpirationTime: DAILY
   alertable: true


### PR DESCRIPTION
### Relevant information

All the dashboards are defined using metrics from the Agent, if we allow cloud metrics to register and index an entity, it won't have any metrics unless the agent is also installed.


### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
