### PR TITLE
fix: NR-10056 modified the query for summary metrics for KT throguput

### DIFF
--- a/definitions/ext-key_transaction/golden_metrics.yml
+++ b/definitions/ext-key_transaction/golden_metrics.yml
@@ -9,7 +9,7 @@ throughput:
   title: Throughput
   unit: REQUESTS_PER_MINUTE
   query:
-    select: count(newrelic.goldenmetrics.ext.key_transaction.throughput) AS 'Throughput'
+    select: rate(count(newrelic.goldenmetrics.ext.key_transaction.throughput), 1 minute) AS 'Throughput'
     from: Metric
     eventId: entity.guid  
 errorRate:

--- a/definitions/ext-key_transaction/golden_metrics.yml
+++ b/definitions/ext-key_transaction/golden_metrics.yml
@@ -9,7 +9,7 @@ throughput:
   title: Throughput
   unit: REQUESTS_PER_MINUTE
   query:
-    select: average(newrelic.goldenmetrics.ext.key_transaction.throughput) AS 'Throughput'
+    select: count(newrelic.goldenmetrics.ext.key_transaction.throughput) AS 'Throughput'
     from: Metric
     eventId: entity.guid  
 errorRate:


### PR DESCRIPTION
### Relevant information

https://issues.newrelic.com/browse/NR-70592

changed summary metrics query  to display throughput value.

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
