### PR TITLE
NEWRELIC-5915: Ensure that off-cluster Pixie entities are properly captured

### DIFF
--- a/definitions/ext-pixie_amqp/definition.yml
+++ b/definitions/ext-pixie_amqp/definition.yml
@@ -2,11 +2,27 @@ domain: EXT
 type: PIXIE_AMQP
 synthesis:
   rules:
+  # Matches the services that exist inside a cluster (namespace is not null).
   - compositeIdentifier:
       separator: "/"
       attributes:
         - amqp.service.name
         - amqp.namespace.name
+        - px.cluster.id
+    name: amqp.service.name
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: amqp.frame_name
+      present: true
+    - attribute: instrumentation.provider
+      value: pixie
+    tags:
+      k8s.cluster.name:
+  # Matches the services that exist outside of a cluster (namespace is null).
+  - compositeIdentifier:
+      separator: "/"
+      attributes:
+        - amqp.service.name
         - px.cluster.id
     name: amqp.service.name
     encodeIdentifierInGUID: true

--- a/definitions/ext-pixie_cassandra/definition.yml
+++ b/definitions/ext-pixie_cassandra/definition.yml
@@ -2,11 +2,27 @@ domain: EXT
 type: PIXIE_CASSANDRA
 synthesis:
   rules:
+  # Matches the services that exist inside a cluster (namespace is not null).
   - compositeIdentifier:
       separator: "/"
       attributes:
         - cassandra.service.name
         - cassandra.namespace.name
+        - px.cluster.id
+    name: cassandra.service.name
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: cassandra.req_cmd
+      present: true
+    - attribute: instrumentation.provider
+      value: pixie
+    tags:
+      k8s.cluster.name:
+  # Matches the services that exist outside of a cluster (namespace is null).
+  - compositeIdentifier:
+      separator: "/"
+      attributes:
+        - cassandra.service.name
         - px.cluster.id
     name: cassandra.service.name
     encodeIdentifierInGUID: true

--- a/definitions/ext-pixie_dns/definition.yml
+++ b/definitions/ext-pixie_dns/definition.yml
@@ -2,11 +2,27 @@ domain: EXT
 type: PIXIE_DNS
 synthesis:
   rules:
+  # Matches the services that exist inside a cluster (namespace is not null).
   - compositeIdentifier:
       separator: "/"
       attributes:
         - dns.server.cluster_id
         - dns.server.namespace
+        - dns.server.name
+    name: dns.server.name
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: dns.query_type
+      present: true
+    - attribute: instrumentation.provider
+      value: pixie
+    tags:
+      k8s.cluster.name:
+  # Matches the services that exist outside of a cluster (namespace is null).
+  - compositeIdentifier:
+      separator: "/"
+      attributes:
+        - dns.server.cluster_id
         - dns.server.name
     name: dns.server.name
     encodeIdentifierInGUID: true

--- a/definitions/ext-pixie_kafkabroker/definition.yml
+++ b/definitions/ext-pixie_kafkabroker/definition.yml
@@ -2,6 +2,7 @@ domain: EXT
 type: PIXIE_KAFKABROKER
 synthesis:
   rules:
+  # Matches the services that exist inside a cluster (namespace is not null).
   - compositeIdentifier:
       separator: "/"
       attributes:
@@ -18,6 +19,23 @@ synthesis:
     tags:
       k8s.cluster.name:
       k8s.namespace.name:
+      k8s.pod.name:
+      service.name:
+  # Matches the services that exist outside of a cluster (namespace is null).
+  - compositeIdentifier:
+      separator: "/"
+      attributes:
+        - kafka.service.name
+        - px.cluster.id
+    name: kafka.service.name
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: kafka.req_cmd
+      present: true
+    - attribute: instrumentation.provider
+      value: pixie
+    tags:
+      k8s.cluster.name:
       k8s.pod.name:
       service.name:
 dashboardTemplates:

--- a/definitions/ext-pixie_mysql/definition.yml
+++ b/definitions/ext-pixie_mysql/definition.yml
@@ -2,11 +2,27 @@ domain: EXT
 type: PIXIE_MYSQL
 synthesis:
   rules:
+  # Matches the services that exist inside a cluster (namespace is not null).
   - compositeIdentifier:
       separator: "/"
       attributes:
         - mysql.service.name
         - mysql.namespace.name
+        - px.cluster.id
+    name: mysql.service.name
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: mysql.req_cmd
+      present: true
+    - attribute: instrumentation.provider
+      value: pixie
+    tags:
+      k8s.cluster.name:
+  # Matches the services that exist outside of a cluster (namespace is null).
+  - compositeIdentifier:
+      separator: "/"
+      attributes:
+        - mysql.service.name
         - px.cluster.id
     name: mysql.service.name
     encodeIdentifierInGUID: true

--- a/definitions/ext-pixie_postgres/definition.yml
+++ b/definitions/ext-pixie_postgres/definition.yml
@@ -2,11 +2,27 @@ domain: EXT
 type: PIXIE_POSTGRES
 synthesis:
   rules:
+  # Matches the services that exist inside a cluster (namespace is not null).
   - compositeIdentifier:
       separator: "/"
       attributes:
         - postgres.service.name
         - postgres.namespace.name
+        - px.cluster.id
+    name: postgres.service.name
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: postgres.req_cmd
+      present: true
+    - attribute: instrumentation.provider
+      value: pixie
+    tags:
+      k8s.cluster.name:
+  # Matches the services that exist outside of a cluster (namespace is null).
+  - compositeIdentifier:
+      separator: "/"
+      attributes:
+        - postgres.service.name
         - px.cluster.id
     name: postgres.service.name
     encodeIdentifierInGUID: true

--- a/definitions/ext-pixie_redis/definition.yml
+++ b/definitions/ext-pixie_redis/definition.yml
@@ -2,11 +2,27 @@ domain: EXT
 type: PIXIE_REDIS
 synthesis:
   rules:
+  # Matches the services that exist inside a cluster (namespace is not null).
   - compositeIdentifier:
       separator: "/"
       attributes:
         - redis.service.name
         - redis.namespace.name
+        - px.cluster.id
+    name: redis.service.name
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: redis.req_cmd
+      present: true
+    - attribute: instrumentation.provider
+      value: pixie
+    tags:
+      k8s.cluster.name:
+  # Matches the services that exist outside of a cluster (namespace is null).
+  - compositeIdentifier:
+      separator: "/"
+      attributes:
+        - redis.service.name
         - px.cluster.id
     name: redis.service.name
     encodeIdentifierInGUID: true


### PR DESCRIPTION
## Relevant information
Pixie entities required a namespace to exist, this relaxes that restriction while still keeping namespace around to distinguish between different entities.

Checklist
- [x] I've read the guidelines and understand the acceptance criteria.
- [x] The value of the attribute marked as identifier will be unique and valid.
- [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.