### PR TITLE
NEWRELIC-5898: Add breakdown of Redis metrics based on responding pods and requesting pods

### DIFF
--- a/definitions/ext-pixie_redis/dashboard.json
+++ b/definitions/ext-pixie_redis/dashboard.json
@@ -146,7 +146,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT max(`redis.latency`), min(`redis.latency`), average(`redis.latency`), count(`redis.latency`) as num_requests, sum(redis.req_bytes), sum(redis.resp_bytes) FROM Metric FACET `redis.req_cmd`, `service.name`, `service.instance.id`, `k8s.namespace.name`, `redis.pod.name` SINCE 30 MINUTES ago"
+                "query": "SELECT max(`redis.latency`), min(`redis.latency`), average(`redis.latency`), count(`redis.latency`) as num_requests, sum(redis.req_bytes), sum(redis.resp_bytes) FROM Metric FACET `redis.req_cmd`, `service.name`, `service.instance.id` as pod_name, `k8s.namespace.name`, `redis.pod.name` SINCE 30 MINUTES ago"
               }
             ],
             "platformOptions": {
@@ -187,7 +187,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT rate(count(*), 1 minute) as requests_per_minute from Metric FACET cases(WHERE redis.pod.name IS NULL as 'Outside Cluster', WHERE redis.pod.name is NOT NULL as 'Inside Cluster') as outside_cluster, redis.pod.name where redis.req_cmd is not null SINCE 30 MINUTES AGO"
+                "query": "SELECT rate(count(`redis.latency`), 1 minute) as requests_per_minute from Metric FACET cases(WHERE redis.pod.name IS NULL as 'Outside Cluster', WHERE redis.pod.name is NOT NULL as 'Inside Cluster') as outside_cluster, `redis.pod.name` SINCE 30 MINUTES AGO"
               }
             ],
             "platformOptions": {
@@ -324,7 +324,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT rate(count(*), 1 minute) as requests_per_minute from Metric FACET cases(WHERE service.instance.id IS NULL as 'Outside Cluster', WHERE service.instance.id is NOT NULL as 'Inside Cluster') as outside_cluster, k8s.namespace.name, service.instance.id where redis.pod.name is NOT NULL SINCE 30 MINUTES AGO "
+                "query": "SELECT rate(count(`redis.latency`), 1 minute) as requests_per_minute from Metric FACET cases(WHERE k8s.namespace.name IS NULL as 'Outside Cluster', WHERE k8s.namespace.name IS NOT NULL as 'Inside Cluster') as outside_cluster, `k8s.namespace.name`, `service.instance.id` as pod_name SINCE 30 MINUTES AGO "
               }
             ],
             "platformOptions": {
@@ -353,7 +353,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT average(`redis.latency`), max(`redis.latency`), min(`redis.latency`) FROM Metric FACET  cases(WHERE service.instance.id IS NULL as 'Outside Cluster', WHERE service.instance.id IS NOT NULL as 'Inside Cluster') as outside_cluster, `k8s.namespace.name`, `service.instance.id` SINCE 30 MINUTES AGO TIMESERIES"
+                "query": "SELECT average(`redis.latency`), max(`redis.latency`), min(`redis.latency`) FROM Metric FACET  cases(WHERE k8s.namespace.name IS NULL as 'Outside Cluster', WHERE k8s.namespace.name IS NOT NULL as 'Inside Cluster') as outside_cluster, `k8s.namespace.name`, `service.instance.id` as pod_name SINCE 30 MINUTES AGO TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -385,7 +385,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT rate(sum(`redis.req_bytes`), 1 second) as req_bps, rate(sum(`redis.resp_bytes`), 1 second) as resp_bps FROM Metric FACET cases(WHERE service.instance.id IS NULL as 'Outside Cluster', WHERE service.instance.id IS NOT NULL as 'Inside Cluster') as outside_cluster, `k8s.namespace.name`, `service.instance.id` SINCE 30 MINUTES AGO TIMESERIES"
+                "query": "SELECT rate(sum(`redis.req_bytes`), 1 second) as req_bps, rate(sum(`redis.resp_bytes`), 1 second) as resp_bps FROM Metric FACET cases(WHERE k8s.namespace.name IS NULL as 'Outside Cluster', WHERE k8s.namespace.name IS NOT NULL as 'Inside Cluster') as outside_cluster, `k8s.namespace.name`, `service.instance.id` as pod_name SINCE 30 MINUTES AGO TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -417,7 +417,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT rate(count(`redis.latency`), 1 minute) as requests_per_m FROM Metric FACET cases(WHERE service.instance.id IS NULL as 'Outside Cluster', WHERE service.instance.id IS NOT NULL as 'Inside Cluster') as outside_cluster,`k8s.namespace.name`, `service.instance.id` SINCE 30 MINUTES AGO TIMESERIES"
+                "query": "SELECT rate(count(`redis.latency`), 1 minute) as requests_per_m FROM Metric FACET cases(WHERE k8s.namespace.name IS NULL as 'Outside Cluster', WHERE k8s.namespace.name IS NOT NULL as 'Inside Cluster') as outside_cluster,`k8s.namespace.name`, `service.instance.id` as pod_name SINCE 30 MINUTES AGO TIMESERIES"
               }
             ],
             "platformOptions": {

--- a/definitions/ext-pixie_redis/dashboard.json
+++ b/definitions/ext-pixie_redis/dashboard.json
@@ -3,7 +3,7 @@
   "description": null,
   "pages": [
     {
-      "name": "pixie_redis",
+      "name": "Overview",
       "description": null,
       "widgets": [
         {
@@ -155,6 +155,263 @@
           }
         }
       ]
+    },
+    {
+      "name": "By Servicing pod",
+      "description": null,
+      "widgets": [
+        {
+          "title": "Servicing Pods",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 3,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.table"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(count(*), 1 minute) as requests_per_minute from Metric FACET redis.pod.name SINCE 30 MINUTES AGO"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "Distribution of response times (ms)",
+          "layout": {
+            "column": 4,
+            "row": 1,
+            "width": 9,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`redis.latency`), max(`redis.latency`), min(`redis.latency`) FROM Metric FACET `redis.pod.name` SINCE 30 MINUTES AGO TIMESERIES"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Data Transfer Rate (bps)",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(sum(`redis.req_bytes`), 1 second) as req_bps, rate(sum(`redis.resp_bytes`), 1 second) as resp_bps FROM Metric FACET `redis.pod.name` SINCE 30 MINUTES AGO TIMESERIES"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Throughput (rpm)",
+          "layout": {
+            "column": 7,
+            "row": 4,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(count(`redis.latency`), 1 minute) as requests_per_m FROM Metric FACET `redis.pod.name` SINCE 30 MINUTES AGO TIMESERIES"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "By requesting pod",
+      "description": null,
+      "widgets": [
+        {
+          "title": "Requesting Pods",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 3,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.table"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(count(*), 1 minute) as requests_per_minute from Metric FACET service.instance.id where redis.pod.name is NOT NULL SINCE 30 MINUTES AGO "
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "Distribution of response times (ms)",
+          "layout": {
+            "column": 4,
+            "row": 1,
+            "width": 9,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`redis.latency`), max(`redis.latency`), min(`redis.latency`) FROM Metric FACET `k8s.namespace.name`, `service.instance.id` SINCE 30 MINUTES AGO TIMESERIES"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Data Transfer Rate (bps)",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(sum(`redis.req_bytes`), 1 second) as req_bps, rate(sum(`redis.resp_bytes`), 1 second) as resp_bps FROM Metric FACET `k8s.namespace.name`, `service.instance.id` SINCE 30 MINUTES AGO TIMESERIES"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Throughput (rpm)",
+          "layout": {
+            "column": 7,
+            "row": 4,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(count(`redis.latency`), 1 minute) as requests_per_m FROM Metric FACET `k8s.namespace.name`, `service.instance.id` SINCE 30 MINUTES AGO TIMESERIES"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
     }
-  ]
+  ],
+  "variables": []
 }

--- a/definitions/ext-pixie_redis/dashboard.json
+++ b/definitions/ext-pixie_redis/dashboard.json
@@ -153,18 +153,27 @@
               "ignoreTimeRange": false
             }
           }
-        }
-      ]
-    },
-    {
-      "name": "By Servicing pod",
-      "description": null,
-      "widgets": [
+        },
+        {
+          "title": "",
+          "layout": {
+            "column": 1,
+            "row": 13,
+            "width": 12,
+            "height": 1
+          },
+          "visualization": {
+            "id": "viz.markdown"
+          },
+          "rawConfiguration": {
+            "text": "# Breakdown by Servicing Pod\nThis section breaks down metrics based on which pod handles the work for the service."
+          }
+        },
         {
           "title": "Servicing Pods",
           "layout": {
             "column": 1,
-            "row": 1,
+            "row": 14,
             "width": 3,
             "height": 3
           },
@@ -190,7 +199,7 @@
           "title": "Distribution of response times (ms)",
           "layout": {
             "column": 4,
-            "row": 1,
+            "row": 14,
             "width": 9,
             "height": 3
           },
@@ -222,7 +231,7 @@
           "title": "Data Transfer Rate (bps)",
           "layout": {
             "column": 1,
-            "row": 4,
+            "row": 17,
             "width": 6,
             "height": 3
           },
@@ -254,7 +263,7 @@
           "title": "Throughput (rpm)",
           "layout": {
             "column": 7,
-            "row": 4,
+            "row": 17,
             "width": 6,
             "height": 3
           },
@@ -281,18 +290,27 @@
               "zero": true
             }
           }
-        }
-      ]
-    },
-    {
-      "name": "By requesting pod",
-      "description": null,
-      "widgets": [
+        },
+        {
+          "title": "",
+          "layout": {
+            "column": 1,
+            "row": 20,
+            "width": 12,
+            "height": 1
+          },
+          "visualization": {
+            "id": "viz.markdown"
+          },
+          "rawConfiguration": {
+            "text": "# Breakdown by Requesting Pod\nThis section breaks the metrics down based on the internal pod that makes requests to the service."
+          }
+        },
         {
           "title": "Requesting Pods",
           "layout": {
             "column": 1,
-            "row": 1,
+            "row": 21,
             "width": 3,
             "height": 3
           },
@@ -306,7 +324,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT rate(count(*), 1 minute) as requests_per_minute from Metric FACET service.instance.id where redis.pod.name is NOT NULL SINCE 30 MINUTES AGO "
+                "query": "SELECT rate(count(*), 1 minute) as requests_per_minute from Metric FACET k8s.namespace.name, service.instance.id where redis.pod.name is NOT NULL SINCE 30 MINUTES AGO "
               }
             ],
             "platformOptions": {
@@ -318,7 +336,7 @@
           "title": "Distribution of response times (ms)",
           "layout": {
             "column": 4,
-            "row": 1,
+            "row": 21,
             "width": 9,
             "height": 3
           },
@@ -350,7 +368,7 @@
           "title": "Data Transfer Rate (bps)",
           "layout": {
             "column": 1,
-            "row": 4,
+            "row": 24,
             "width": 6,
             "height": 3
           },
@@ -382,7 +400,7 @@
           "title": "Throughput (rpm)",
           "layout": {
             "column": 7,
-            "row": 4,
+            "row": 24,
             "width": 6,
             "height": 3
           },
@@ -412,6 +430,5 @@
         }
       ]
     }
-  ],
-  "variables": []
+  ]
 }

--- a/definitions/ext-pixie_redis/dashboard.json
+++ b/definitions/ext-pixie_redis/dashboard.json
@@ -166,7 +166,7 @@
             "id": "viz.markdown"
           },
           "rawConfiguration": {
-            "text": "# Breakdown by Servicing Pod\nThis section breaks down metrics based on which pod handles the work for the service."
+            "text": "# Breakdown by Servicing Pod\nThis section breaks down metrics based on which pod handles the work for the service. \nIf the service is located off the cluster, then everything will be grouped under \"Outside Cluster\"."
           }
         },
         {
@@ -174,7 +174,7 @@
           "layout": {
             "column": 1,
             "row": 14,
-            "width": 3,
+            "width": 6,
             "height": 3
           },
           "visualization": {
@@ -187,7 +187,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT rate(count(*), 1 minute) as requests_per_minute from Metric FACET redis.pod.name SINCE 30 MINUTES AGO"
+                "query": "SELECT rate(count(*), 1 minute) as requests_per_minute from Metric FACET cases(WHERE redis.pod.name IS NULL as 'Outside Cluster', WHERE redis.pod.name is NOT NULL as 'Inside Cluster') as outside_cluster, redis.pod.name where redis.req_cmd is not null SINCE 30 MINUTES AGO"
               }
             ],
             "platformOptions": {
@@ -198,9 +198,9 @@
         {
           "title": "Distribution of response times (ms)",
           "layout": {
-            "column": 4,
+            "column": 7,
             "row": 14,
-            "width": 9,
+            "width": 6,
             "height": 3
           },
           "visualization": {
@@ -216,7 +216,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT average(`redis.latency`), max(`redis.latency`), min(`redis.latency`) FROM Metric FACET `redis.pod.name` SINCE 30 MINUTES AGO TIMESERIES"
+                "query": "SELECT average(`redis.latency`), max(`redis.latency`), min(`redis.latency`) FROM Metric FACET cases(WHERE redis.pod.name IS NULL as 'Outside Cluster', WHERE redis.pod.name is NOT NULL as 'Inside Cluster') as outside_cluster, `redis.pod.name` SINCE 30 MINUTES AGO TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -248,7 +248,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT rate(sum(`redis.req_bytes`), 1 second) as req_bps, rate(sum(`redis.resp_bytes`), 1 second) as resp_bps FROM Metric FACET `redis.pod.name` SINCE 30 MINUTES AGO TIMESERIES"
+                "query": "SELECT rate(sum(`redis.req_bytes`), 1 second) as req_bps, rate(sum(`redis.resp_bytes`), 1 second) as resp_bps FROM Metric FACET cases(WHERE redis.pod.name IS NULL as 'Outside Cluster', WHERE redis.pod.name is NOT NULL as 'Inside Cluster') as outside_cluster, `redis.pod.name` SINCE 30 MINUTES AGO TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -280,7 +280,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT rate(count(`redis.latency`), 1 minute) as requests_per_m FROM Metric FACET `redis.pod.name` SINCE 30 MINUTES AGO TIMESERIES"
+                "query": "SELECT rate(count(`redis.latency`), 1 minute) as requests_per_m FROM Metric FACET cases(WHERE redis.pod.name IS NULL as 'Outside Cluster', WHERE redis.pod.name is NOT NULL as 'Inside Cluster') as outside_cluster, `redis.pod.name` SINCE 30 MINUTES AGO TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -303,7 +303,7 @@
             "id": "viz.markdown"
           },
           "rawConfiguration": {
-            "text": "# Breakdown by Requesting Pod\nThis section breaks the metrics down based on the internal pod that makes requests to the service."
+            "text": "# Breakdown by Requesting Pod\nThis section breaks the metrics down based on the internal pod that makes requests to the service. Clients that are located off cluster are grouped under \"Outside Cluster\"."
           }
         },
         {
@@ -311,7 +311,7 @@
           "layout": {
             "column": 1,
             "row": 21,
-            "width": 3,
+            "width": 6,
             "height": 3
           },
           "visualization": {
@@ -324,7 +324,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT rate(count(*), 1 minute) as requests_per_minute from Metric FACET k8s.namespace.name, service.instance.id where redis.pod.name is NOT NULL SINCE 30 MINUTES AGO "
+                "query": "SELECT rate(count(*), 1 minute) as requests_per_minute from Metric FACET cases(WHERE service.instance.id IS NULL as 'Outside Cluster', WHERE service.instance.id is NOT NULL as 'Inside Cluster') as outside_cluster, k8s.namespace.name, service.instance.id where redis.pod.name is NOT NULL SINCE 30 MINUTES AGO "
               }
             ],
             "platformOptions": {
@@ -335,9 +335,9 @@
         {
           "title": "Distribution of response times (ms)",
           "layout": {
-            "column": 4,
+            "column": 7,
             "row": 21,
-            "width": 9,
+            "width": 6,
             "height": 3
           },
           "visualization": {
@@ -353,7 +353,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT average(`redis.latency`), max(`redis.latency`), min(`redis.latency`) FROM Metric FACET `k8s.namespace.name`, `service.instance.id` SINCE 30 MINUTES AGO TIMESERIES"
+                "query": "SELECT average(`redis.latency`), max(`redis.latency`), min(`redis.latency`) FROM Metric FACET  cases(WHERE service.instance.id IS NULL as 'Outside Cluster', WHERE service.instance.id IS NOT NULL as 'Inside Cluster') as outside_cluster, `k8s.namespace.name`, `service.instance.id` SINCE 30 MINUTES AGO TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -385,7 +385,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT rate(sum(`redis.req_bytes`), 1 second) as req_bps, rate(sum(`redis.resp_bytes`), 1 second) as resp_bps FROM Metric FACET `k8s.namespace.name`, `service.instance.id` SINCE 30 MINUTES AGO TIMESERIES"
+                "query": "SELECT rate(sum(`redis.req_bytes`), 1 second) as req_bps, rate(sum(`redis.resp_bytes`), 1 second) as resp_bps FROM Metric FACET cases(WHERE service.instance.id IS NULL as 'Outside Cluster', WHERE service.instance.id IS NOT NULL as 'Inside Cluster') as outside_cluster, `k8s.namespace.name`, `service.instance.id` SINCE 30 MINUTES AGO TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -417,7 +417,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT rate(count(`redis.latency`), 1 minute) as requests_per_m FROM Metric FACET `k8s.namespace.name`, `service.instance.id` SINCE 30 MINUTES AGO TIMESERIES"
+                "query": "SELECT rate(count(`redis.latency`), 1 minute) as requests_per_m FROM Metric FACET cases(WHERE service.instance.id IS NULL as 'Outside Cluster', WHERE service.instance.id IS NOT NULL as 'Inside Cluster') as outside_cluster,`k8s.namespace.name`, `service.instance.id` SINCE 30 MINUTES AGO TIMESERIES"
               }
             ],
             "platformOptions": {


### PR DESCRIPTION
## Relevant information
Users have requested that we breakdown these metrics by the pods that service them as well as the pods that request them. Fortunately this is a simple addition to the dashboard.

Checklist
- [x] I've read the guidelines and understand the acceptance criteria.
- [x] The value of the attribute marked as identifier will be unique and valid.
- [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
