### PR TITLE
Validate that sanitize dashboards was run

### DIFF
--- a/.github/workflows/validate-definition.yml
+++ b/.github/workflows/validate-definition.yml
@@ -14,3 +14,5 @@ jobs:
         run: npm --prefix validator install
       - name: Validate definition
         run: npm --prefix validator run check
+      - name: Ensure sanitize was run
+        run: npm --prefix validator run sanitize-dashboards && git status --porcelain

--- a/.github/workflows/validate-definition.yml
+++ b/.github/workflows/validate-definition.yml
@@ -15,4 +15,5 @@ jobs:
       - name: Validate definition
         run: npm --prefix validator run check
       - name: Ensure sanitize was run
-        run: npm --prefix validator run sanitize-dashboards && git status --porcelain
+        # Runs the sanitize script and checks errors if the dashboards were not sanitized.
+        run: npm --prefix validator run sanitize-dashboards &&  git diff-index --quiet HEAD --

--- a/.github/workflows/validate-definition.yml
+++ b/.github/workflows/validate-definition.yml
@@ -16,4 +16,4 @@ jobs:
         run: npm --prefix validator run check
       - name: Ensure sanitize was run
         # Runs the sanitize script and checks errors if the dashboards were not sanitized.
-        run: npm --prefix validator run sanitize-dashboards &&  git diff-index --quiet HEAD --
+        run: npm --prefix validator run sanitize-dashboards &&  git diff-index HEAD --

--- a/.github/workflows/validate-definition.yml
+++ b/.github/workflows/validate-definition.yml
@@ -16,4 +16,5 @@ jobs:
         run: npm --prefix validator run check
       - name: Ensure sanitize was run
         # Runs the sanitize script and checks errors if the dashboards were not sanitized.
-        run: npm --prefix validator run sanitize-dashboards &&  git diff-index HEAD --
+        # If the dashboards were sanitized, the git command will return 0 and the step will pass.
+        run: npm --prefix validator run sanitize-dashboards &&  git diff-index --quiet HEAD -- definitions/

--- a/definitions/ext-dell_datadomain/dashboard.json
+++ b/definitions/ext-dell_datadomain/dashboard.json
@@ -1,7 +1,6 @@
 {
   "name": "Backup - Dell DataDomain",
   "description": null,
-  "permissions": "PUBLIC_READ_WRITE",
   "pages": [
     {
       "name": "Backup - Dell DataDomain",
@@ -15,7 +14,6 @@
             "width": 2,
             "height": 2
           },
-          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.billboard"
           },
@@ -42,7 +40,6 @@
             "width": 12,
             "height": 3
           },
-          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.table"
           },
@@ -69,7 +66,6 @@
             "width": 8,
             "height": 3
           },
-          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.table"
           },
@@ -96,7 +92,6 @@
             "width": 4,
             "height": 3
           },
-          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.line"
           },
@@ -129,7 +124,6 @@
             "width": 8,
             "height": 3
           },
-          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.table"
           },
@@ -156,7 +150,6 @@
             "width": 4,
             "height": 3
           },
-          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.line"
           },
@@ -189,7 +182,6 @@
             "width": 8,
             "height": 3
           },
-          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.table"
           },
@@ -216,7 +208,6 @@
             "width": 4,
             "height": 3
           },
-          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.line"
           },
@@ -249,7 +240,6 @@
             "width": 8,
             "height": 3
           },
-          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.table"
           },
@@ -276,7 +266,6 @@
             "width": 4,
             "height": 3
           },
-          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.line"
           },

--- a/definitions/ext-dell_datadomain/dashboard.json
+++ b/definitions/ext-dell_datadomain/dashboard.json
@@ -1,6 +1,7 @@
 {
   "name": "Backup - Dell DataDomain",
   "description": null,
+  "permissions": "PUBLIC_READ_WRITE",
   "pages": [
     {
       "name": "Backup - Dell DataDomain",
@@ -14,6 +15,7 @@
             "width": 2,
             "height": 2
           },
+          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.billboard"
           },
@@ -40,6 +42,7 @@
             "width": 12,
             "height": 3
           },
+          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.table"
           },
@@ -66,6 +69,7 @@
             "width": 8,
             "height": 3
           },
+          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.table"
           },
@@ -92,6 +96,7 @@
             "width": 4,
             "height": 3
           },
+          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.line"
           },
@@ -124,6 +129,7 @@
             "width": 8,
             "height": 3
           },
+          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.table"
           },
@@ -150,6 +156,7 @@
             "width": 4,
             "height": 3
           },
+          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.line"
           },
@@ -182,6 +189,7 @@
             "width": 8,
             "height": 3
           },
+          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.table"
           },
@@ -208,6 +216,7 @@
             "width": 4,
             "height": 3
           },
+          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.line"
           },
@@ -240,6 +249,7 @@
             "width": 8,
             "height": 3
           },
+          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.table"
           },
@@ -266,6 +276,7 @@
             "width": 4,
             "height": 3
           },
+          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.line"
           },

--- a/definitions/ext-influxdb/dashboard.json
+++ b/definitions/ext-influxdb/dashboard.json
@@ -14,7 +14,6 @@
             "width": 4,
             "height": 3
           },
-          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.line"
           },
@@ -47,7 +46,6 @@
             "width": 4,
             "height": 3
           },
-          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.line"
           },
@@ -80,7 +78,6 @@
             "width": 4,
             "height": 3
           },
-          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.line"
           },

--- a/definitions/ext-influxdb/dashboard.json
+++ b/definitions/ext-influxdb/dashboard.json
@@ -14,6 +14,7 @@
             "width": 4,
             "height": 3
           },
+          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.line"
           },
@@ -46,6 +47,7 @@
             "width": 4,
             "height": 3
           },
+          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.line"
           },
@@ -78,6 +80,7 @@
             "width": 4,
             "height": 3
           },
+          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.line"
           },

--- a/definitions/ext-rubrik/dashboard.json
+++ b/definitions/ext-rubrik/dashboard.json
@@ -1,7 +1,6 @@
 {
   "name": "Rubrik",
   "description": null,
-  "permissions": "PUBLIC_READ_WRITE",
   "pages": [
     {
       "name": "Rubrik",
@@ -15,7 +14,6 @@
             "width": 1,
             "height": 2
           },
-          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.billboard"
           },
@@ -52,7 +50,6 @@
             "width": 1,
             "height": 2
           },
-          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.billboard"
           },
@@ -85,7 +82,6 @@
             "width": 1,
             "height": 2
           },
-          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.billboard"
           },
@@ -123,7 +119,6 @@
             "width": 1,
             "height": 2
           },
-          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.billboard"
           },
@@ -160,7 +155,6 @@
             "width": 2,
             "height": 2
           },
-          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.line"
           },
@@ -193,7 +187,6 @@
             "width": 3,
             "height": 2
           },
-          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.line"
           },
@@ -226,7 +219,6 @@
             "width": 3,
             "height": 2
           },
-          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.line"
           },
@@ -259,7 +251,6 @@
             "width": 12,
             "height": 3
           },
-          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.table"
           },
@@ -286,7 +277,6 @@
             "width": 3,
             "height": 2
           },
-          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.line"
           },
@@ -319,7 +309,6 @@
             "width": 3,
             "height": 2
           },
-          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.line"
           },
@@ -352,7 +341,6 @@
             "width": 6,
             "height": 3
           },
-          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.table"
           },
@@ -379,7 +367,6 @@
             "width": 6,
             "height": 3
           },
-          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.table"
           },
@@ -406,7 +393,6 @@
             "width": 12,
             "height": 2
           },
-          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.table"
           },
@@ -433,7 +419,6 @@
             "width": 6,
             "height": 2
           },
-          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.table"
           },

--- a/definitions/ext-rubrik/dashboard.json
+++ b/definitions/ext-rubrik/dashboard.json
@@ -1,6 +1,7 @@
 {
   "name": "Rubrik",
   "description": null,
+  "permissions": "PUBLIC_READ_WRITE",
   "pages": [
     {
       "name": "Rubrik",
@@ -14,6 +15,7 @@
             "width": 1,
             "height": 2
           },
+          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.billboard"
           },
@@ -50,6 +52,7 @@
             "width": 1,
             "height": 2
           },
+          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.billboard"
           },
@@ -82,6 +85,7 @@
             "width": 1,
             "height": 2
           },
+          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.billboard"
           },
@@ -119,6 +123,7 @@
             "width": 1,
             "height": 2
           },
+          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.billboard"
           },
@@ -155,6 +160,7 @@
             "width": 2,
             "height": 2
           },
+          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.line"
           },
@@ -187,6 +193,7 @@
             "width": 3,
             "height": 2
           },
+          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.line"
           },
@@ -219,6 +226,7 @@
             "width": 3,
             "height": 2
           },
+          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.line"
           },
@@ -251,6 +259,7 @@
             "width": 12,
             "height": 3
           },
+          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.table"
           },
@@ -277,6 +286,7 @@
             "width": 3,
             "height": 2
           },
+          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.line"
           },
@@ -309,6 +319,7 @@
             "width": 3,
             "height": 2
           },
+          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.line"
           },
@@ -341,6 +352,7 @@
             "width": 6,
             "height": 3
           },
+          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.table"
           },
@@ -367,6 +379,7 @@
             "width": 6,
             "height": 3
           },
+          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.table"
           },
@@ -393,6 +406,7 @@
             "width": 12,
             "height": 2
           },
+          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.table"
           },
@@ -419,6 +433,7 @@
             "width": 6,
             "height": 2
           },
+          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.table"
           },

--- a/definitions/ext-shelled_spa/dashboard.json
+++ b/definitions/ext-shelled_spa/dashboard.json
@@ -1,6 +1,5 @@
 {
   "name": "Shelled Browser Status",
-  "permissions": "PUBLIC_READ_WRITE",
   "pages": [
     {
       "name": "Shelled Browser Status",

--- a/definitions/ext-shelled_spa/dashboard.json
+++ b/definitions/ext-shelled_spa/dashboard.json
@@ -1,5 +1,6 @@
 {
   "name": "Shelled Browser Status",
+  "permissions": "PUBLIC_READ_WRITE",
   "pages": [
     {
       "name": "Shelled Browser Status",

--- a/definitions/ext-zerto/dashboard.json
+++ b/definitions/ext-zerto/dashboard.json
@@ -1,7 +1,6 @@
 {
   "name": "Backup - Zerto synthesis template",
   "description": null,
-  "permissions": "PUBLIC_READ_WRITE",
   "pages": [
     {
       "name": "Backup - Zerto",
@@ -15,7 +14,6 @@
             "width": 1,
             "height": 3
           },
-          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.billboard"
           },
@@ -42,7 +40,6 @@
             "width": 1,
             "height": 3
           },
-          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.billboard"
           },
@@ -69,7 +66,6 @@
             "width": 2,
             "height": 3
           },
-          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.line"
           },
@@ -102,7 +98,6 @@
             "width": 2,
             "height": 3
           },
-          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.line"
           },
@@ -135,7 +130,6 @@
             "width": 3,
             "height": 3
           },
-          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.line"
           },
@@ -168,7 +162,6 @@
             "width": 3,
             "height": 3
           },
-          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.line"
           },
@@ -201,7 +194,6 @@
             "width": 12,
             "height": 5
           },
-          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.table"
           },
@@ -228,7 +220,6 @@
             "width": 12,
             "height": 4
           },
-          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.table"
           },
@@ -255,7 +246,6 @@
             "width": 12,
             "height": 4
           },
-          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.table"
           },
@@ -282,7 +272,6 @@
             "width": 4,
             "height": 3
           },
-          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.line"
           },

--- a/definitions/ext-zerto/dashboard.json
+++ b/definitions/ext-zerto/dashboard.json
@@ -1,6 +1,7 @@
 {
   "name": "Backup - Zerto synthesis template",
   "description": null,
+  "permissions": "PUBLIC_READ_WRITE",
   "pages": [
     {
       "name": "Backup - Zerto",
@@ -14,6 +15,7 @@
             "width": 1,
             "height": 3
           },
+          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.billboard"
           },
@@ -40,6 +42,7 @@
             "width": 1,
             "height": 3
           },
+          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.billboard"
           },
@@ -66,6 +69,7 @@
             "width": 2,
             "height": 3
           },
+          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.line"
           },
@@ -98,6 +102,7 @@
             "width": 2,
             "height": 3
           },
+          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.line"
           },
@@ -130,6 +135,7 @@
             "width": 3,
             "height": 3
           },
+          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.line"
           },
@@ -162,6 +168,7 @@
             "width": 3,
             "height": 3
           },
+          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.line"
           },
@@ -194,6 +201,7 @@
             "width": 12,
             "height": 5
           },
+          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.table"
           },
@@ -220,6 +228,7 @@
             "width": 12,
             "height": 4
           },
+          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.table"
           },
@@ -246,6 +255,7 @@
             "width": 12,
             "height": 4
           },
+          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.table"
           },
@@ -272,6 +282,7 @@
             "width": 4,
             "height": 3
           },
+          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.line"
           },


### PR DESCRIPTION
### Relevant information
I keep finding that contributors fail to sanitize their dashboards. It's very annoying to run the sanitize dashboard commands and find other users' dashboards show up. This diff adds the sanitize command and a git repo dirty check to the workflows that must be run before a PR is accepted. 

I tested this on this PR with a few commits. Ran it first with the dashboards not sanitized: https://github.com/newrelic/entity-definitions/actions/runs/3842474241
Then ran it with the dashboards sanitized:
https://github.com/newrelic/entity-definitions/actions/runs/3842481940
### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
