### PR TITLE
NEWRELIC-5898 Postgres split by requesting pod and split by responding pod

### DIFF
--- a/definitions/ext-pixie_postgres/dashboard.json
+++ b/definitions/ext-pixie_postgres/dashboard.json
@@ -146,7 +146,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT max(`postgres.latency`), min(`postgres.latency`), average(`postgres.latency`), count(`postgres.latency`) as num_requests, sum(postgres.req_bytes), sum(postgres.resp_bytes) FROM Metric FACET `postgres.req_cmd`, `service.name`, `service.instance.id`, `k8s.namespace.name`, `postgres.pod.name` SINCE 30 MINUTES ago"
+                "query": "SELECT max(`postgres.latency`), min(`postgres.latency`), average(`postgres.latency`), count(`postgres.latency`) as num_requests, sum(postgres.req_bytes), sum(postgres.resp_bytes) FROM Metric FACET `postgres.req_cmd`, `service.name`, `service.instance.id` as pod_name, `k8s.namespace.name`, `postgres.pod.name` SINCE 30 MINUTES ago"
               }
             ],
             "platformOptions": {
@@ -187,7 +187,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT rate(count(*), 1 minute) as requests_per_minute from Metric FACET cases(WHERE postgres.pod.name IS NULL as 'Outside Cluster', WHERE postgres.pod.name is NOT NULL as 'Inside Cluster') as outside_cluster, postgres.pod.name where postgres.req_cmd is not null SINCE 30 MINUTES AGO"
+                "query": "SELECT rate(count(`postgres.latency`), 1 minute) as requests_per_minute from Metric FACET cases(WHERE postgres.pod.name IS NULL as 'Outside Cluster', WHERE postgres.pod.name is NOT NULL as 'Inside Cluster') as outside_cluster, postgres.pod.name SINCE 30 MINUTES AGO"
               }
             ],
             "platformOptions": {
@@ -324,7 +324,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT rate(count(*), 1 minute) as requests_per_minute from Metric FACET cases(WHERE k8s.namespace.name IS NULL as 'Outside Cluster', WHERE k8s.namespace.name IS NOT NULL as 'Inside Cluster') as outside_cluster, k8s.namespace.name, service.instance.id where postgres.pod.name is NOT NULL SINCE 30 MINUTES AGO "
+                "query": "SELECT rate(count(`postgres.latency`), 1 minute) as requests_per_minute from Metric FACET cases(WHERE k8s.namespace.name IS NULL as 'Outside Cluster', WHERE k8s.namespace.name IS NOT NULL as 'Inside Cluster') as outside_cluster, `k8s.namespace.name`, `service.instance.id` as pod_name SINCE 30 MINUTES AGO "
               }
             ],
             "platformOptions": {
@@ -353,7 +353,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT average(`postgres.latency`), max(`postgres.latency`), min(`postgres.latency`) FROM Metric FACET  cases(WHERE k8s.namespace.name IS NULL as 'Outside Cluster', WHERE k8s.namespace.name IS NOT NULL as 'Inside Cluster') as outside_cluster, `k8s.namespace.name`, `service.instance.id` SINCE 30 MINUTES AGO TIMESERIES"
+                "query": "SELECT average(`postgres.latency`), max(`postgres.latency`), min(`postgres.latency`) FROM Metric FACET  cases(WHERE k8s.namespace.name IS NULL as 'Outside Cluster', WHERE k8s.namespace.name IS NOT NULL as 'Inside Cluster') as outside_cluster, `k8s.namespace.name`, `service.instance.id` as pod_name SINCE 30 MINUTES AGO TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -385,7 +385,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT rate(sum(`postgres.req_bytes`), 1 second) as req_bps, rate(sum(`postgres.resp_bytes`), 1 second) as resp_bps FROM Metric FACET cases(WHERE k8s.namespace.name IS NULL as 'Outside Cluster', WHERE k8s.namespace.name IS NOT NULL as 'Inside Cluster') as outside_cluster, `k8s.namespace.name`, `service.instance.id` SINCE 30 MINUTES AGO TIMESERIES"
+                "query": "SELECT rate(sum(`postgres.req_bytes`), 1 second) as req_bps, rate(sum(`postgres.resp_bytes`), 1 second) as resp_bps FROM Metric FACET cases(WHERE k8s.namespace.name IS NULL as 'Outside Cluster', WHERE k8s.namespace.name IS NOT NULL as 'Inside Cluster') as outside_cluster, `k8s.namespace.name`, `service.instance.id` as pod_name SINCE 30 MINUTES AGO TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -417,7 +417,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT rate(count(`postgres.latency`), 1 minute) as requests_per_m FROM Metric FACET cases(WHERE k8s.namespace.name IS NULL as 'Outside Cluster', WHERE k8s.namespace.name IS NOT NULL as 'Inside Cluster') as outside_cluster,`k8s.namespace.name`, `service.instance.id` SINCE 30 MINUTES AGO TIMESERIES"
+                "query": "SELECT rate(count(`postgres.latency`), 1 minute) as requests_per_m FROM Metric FACET cases(WHERE k8s.namespace.name IS NULL as 'Outside Cluster', WHERE k8s.namespace.name IS NOT NULL as 'Inside Cluster') as outside_cluster,`k8s.namespace.name`, `service.instance.id` as pod_name SINCE 30 MINUTES AGO TIMESERIES"
               }
             ],
             "platformOptions": {

--- a/definitions/ext-pixie_postgres/dashboard.json
+++ b/definitions/ext-pixie_postgres/dashboard.json
@@ -3,7 +3,7 @@
   "description": null,
   "pages": [
     {
-      "name": "pixie_postgres",
+      "name": "Overview",
       "description": null,
       "widgets": [
         {
@@ -151,6 +151,280 @@
             ],
             "platformOptions": {
               "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "",
+          "layout": {
+            "column": 1,
+            "row": 13,
+            "width": 12,
+            "height": 1
+          },
+          "visualization": {
+            "id": "viz.markdown"
+          },
+          "rawConfiguration": {
+            "text": "# Breakdown by Servicing Pod\nThis section breaks down metrics based on which pod handles the work for the service. \nIf the service is located off the cluster, then everything will be grouped under \"Outside Cluster\"."
+          }
+        },
+        {
+          "title": "Servicing Pods",
+          "layout": {
+            "column": 1,
+            "row": 14,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.table"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(count(*), 1 minute) as requests_per_minute from Metric FACET cases(WHERE postgres.pod.name IS NULL as 'Outside Cluster', WHERE postgres.pod.name is NOT NULL as 'Inside Cluster') as outside_cluster, postgres.pod.name where postgres.req_cmd is not null SINCE 30 MINUTES AGO"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "Distribution of response times (ms)",
+          "layout": {
+            "column": 7,
+            "row": 14,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`postgres.latency`), max(`postgres.latency`), min(`postgres.latency`) FROM Metric FACET cases(WHERE postgres.pod.name IS NULL as 'Outside Cluster', WHERE postgres.pod.name is NOT NULL as 'Inside Cluster') as outside_cluster, `postgres.pod.name` SINCE 30 MINUTES AGO TIMESERIES"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Data Transfer Rate (bps)",
+          "layout": {
+            "column": 1,
+            "row": 17,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(sum(`postgres.req_bytes`), 1 second) as req_bps, rate(sum(`postgres.resp_bytes`), 1 second) as resp_bps FROM Metric FACET cases(WHERE postgres.pod.name IS NULL as 'Outside Cluster', WHERE postgres.pod.name is NOT NULL as 'Inside Cluster') as outside_cluster, `postgres.pod.name` SINCE 30 MINUTES AGO TIMESERIES"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Throughput (rpm)",
+          "layout": {
+            "column": 7,
+            "row": 17,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(count(`postgres.latency`), 1 minute) as requests_per_m FROM Metric FACET cases(WHERE postgres.pod.name IS NULL as 'Outside Cluster', WHERE postgres.pod.name is NOT NULL as 'Inside Cluster') as outside_cluster, `postgres.pod.name` SINCE 30 MINUTES AGO TIMESERIES"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "",
+          "layout": {
+            "column": 1,
+            "row": 20,
+            "width": 12,
+            "height": 1
+          },
+          "visualization": {
+            "id": "viz.markdown"
+          },
+          "rawConfiguration": {
+            "text": "# Breakdown by Requesting Pod\nThis section breaks the metrics down based on the internal pod that makes requests to the service. Clients that are located off cluster are grouped under \"Outside Cluster\"."
+          }
+        },
+        {
+          "title": "Requesting Pods",
+          "layout": {
+            "column": 1,
+            "row": 21,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.table"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(count(*), 1 minute) as requests_per_minute from Metric FACET cases(WHERE k8s.namespace.name IS NULL as 'Outside Cluster', WHERE k8s.namespace.name IS NOT NULL as 'Inside Cluster') as outside_cluster, k8s.namespace.name, service.instance.id where postgres.pod.name is NOT NULL SINCE 30 MINUTES AGO "
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "Distribution of response times (ms)",
+          "layout": {
+            "column": 7,
+            "row": 21,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`postgres.latency`), max(`postgres.latency`), min(`postgres.latency`) FROM Metric FACET  cases(WHERE k8s.namespace.name IS NULL as 'Outside Cluster', WHERE k8s.namespace.name IS NOT NULL as 'Inside Cluster') as outside_cluster, `k8s.namespace.name`, `service.instance.id` SINCE 30 MINUTES AGO TIMESERIES"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Data Transfer Rate (bps)",
+          "layout": {
+            "column": 1,
+            "row": 24,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(sum(`postgres.req_bytes`), 1 second) as req_bps, rate(sum(`postgres.resp_bytes`), 1 second) as resp_bps FROM Metric FACET cases(WHERE k8s.namespace.name IS NULL as 'Outside Cluster', WHERE k8s.namespace.name IS NOT NULL as 'Inside Cluster') as outside_cluster, `k8s.namespace.name`, `service.instance.id` SINCE 30 MINUTES AGO TIMESERIES"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Throughput (rpm)",
+          "layout": {
+            "column": 7,
+            "row": 24,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(count(`postgres.latency`), 1 minute) as requests_per_m FROM Metric FACET cases(WHERE k8s.namespace.name IS NULL as 'Outside Cluster', WHERE k8s.namespace.name IS NOT NULL as 'Inside Cluster') as outside_cluster,`k8s.namespace.name`, `service.instance.id` SINCE 30 MINUTES AGO TIMESERIES"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
             }
           }
         }


### PR DESCRIPTION
## Relevant information
Users have requested that we breakdown these metrics by the pods that service them as well as the pods that request them. Fortunately this is a simple addition to the dashboard.

Checklist
- [x] I've read the guidelines and understand the acceptance criteria.
- [x] The value of the attribute marked as identifier will be unique and valid.
- [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.