### PR TITLE
NEWRELIC-5898 Pixie Kafka split by requesting pod and split by responding pod

### DIFF
--- a/definitions/ext-pixie_kafkabroker/dashboard.json
+++ b/definitions/ext-pixie_kafkabroker/dashboard.json
@@ -1,9 +1,9 @@
 {
-  "name": "pixie_kafka_filtered",
+  "name": "pixie_kafka",
   "description": null,
   "pages": [
     {
-      "name": "pixie_kafka",
+      "name": "Overview",
       "description": null,
       "widgets": [
         {
@@ -39,7 +39,7 @@
           }
         },
         {
-          "title": "Throughput (bps)",
+          "title": "Data Transfer Rate (bps)",
           "layout": {
             "column": 1,
             "row": 4,
@@ -183,6 +183,344 @@
             ],
             "platformOptions": {
               "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "",
+          "layout": {
+            "column": 1,
+            "row": 13,
+            "width": 12,
+            "height": 1
+          },
+          "visualization": {
+            "id": "viz.markdown"
+          },
+          "rawConfiguration": {
+            "text": "# Breakdown by Servicing Pod\nThis section breaks down metrics based on which pod handles the work for the service. \nIf the service is located off the cluster, then everything will be grouped under \"Outside Cluster\"."
+          }
+        },
+        {
+          "title": "Servicing Pods",
+          "layout": {
+            "column": 1,
+            "row": 14,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.table"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(count(`kafka.latency`), 1 minute) as requests_per_minute from Metric FACET cases(WHERE kafka.broker.pod IS NULL as 'Outside Cluster', WHERE kafka.broker.pod is NOT NULL as 'Inside Cluster') as outside_cluster, `kafka.broker.pod` SINCE 30 MINUTES AGO"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "Distribution of response times (ms)",
+          "layout": {
+            "column": 7,
+            "row": 14,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`kafka.latency`), max(`kafka.latency`), min(`kafka.latency`) FROM Metric FACET cases(WHERE kafka.broker.pod IS NULL as 'Outside Cluster', WHERE kafka.broker.pod is NOT NULL as 'Inside Cluster') as outside_cluster, `kafka.broker.pod` SINCE 30 MINUTES AGO TIMESERIES"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Data Transfer Rate (bps)",
+          "layout": {
+            "column": 1,
+            "row": 17,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(sum(`kafka.bytes`), 1 second ) as bytes_per_s FROM Metric FACET cases(WHERE kafka.broker.pod IS NULL as 'Outside Cluster', WHERE kafka.broker.pod is NOT NULL as 'Inside Cluster') as outside_cluster, `kafka.broker.pod` SINCE 30 MINUTES AGO TIMESERIES"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "% of Errors over time",
+          "layout": {
+            "column": 5,
+            "row": 17,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT percentage(count(`kafka.latency`), where `kafka.has_error`=true) FROM Metric FACET cases(WHERE kafka.broker.pod IS NULL as 'Outside Cluster', WHERE kafka.broker.pod is NOT NULL as 'Inside Cluster') as outside_cluster, `kafka.broker.pod`SINCE 30 MINUTES AGO TIMESERIES"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Throughput (rpm)",
+          "layout": {
+            "column": 9,
+            "row": 17,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(count(`kafka.latency`), 1 minute) as requests_per_m FROM Metric FACET cases(WHERE kafka.broker.pod IS NULL as 'Outside Cluster', WHERE kafka.broker.pod is NOT NULL as 'Inside Cluster') as outside_cluster, `kafka.broker.pod` SINCE 30 MINUTES AGO TIMESERIES"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "",
+          "layout": {
+            "column": 1,
+            "row": 20,
+            "width": 12,
+            "height": 1
+          },
+          "visualization": {
+            "id": "viz.markdown"
+          },
+          "rawConfiguration": {
+            "text": "# Breakdown by Requesting Pod\nThis section breaks the metrics down based on the internal pod that makes requests to the service. Clients that are located off cluster are grouped under \"Outside Cluster\"."
+          }
+        },
+        {
+          "title": "Requesting Pods",
+          "layout": {
+            "column": 1,
+            "row": 21,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.table"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(count(`kafka.latency`), 1 minute) as requests_per_minute from Metric FACET cases(WHERE k8s.namespace.name IS NULL as 'Outside Cluster', WHERE k8s.namespace.name is NOT NULL as 'Inside Cluster') as outside_cluster, `k8s.namespace.name`, `service.instance.id` as pod_name SINCE 30 MINUTES AGO"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "Distribution of response times (ms)",
+          "layout": {
+            "column": 7,
+            "row": 21,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`kafka.latency`), max(`kafka.latency`), min(`kafka.latency`) FROM Metric FACET cases(WHERE k8s.namespace.name IS NULL as 'Outside Cluster', WHERE k8s.namespace.name is NOT NULL as 'Inside Cluster') as outside_cluster, `k8s.namespace.name`, `service.instance.id` as pod_name SINCE 30 MINUTES AGO TIMESERIES"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Data Transfer Rate (bps)",
+          "layout": {
+            "column": 1,
+            "row": 24,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(sum(`kafka.bytes`), 1 second ) as bytes_per_s FROM Metric FACET cases(WHERE k8s.namespace.name IS NULL as 'Outside Cluster', WHERE k8s.namespace.name is NOT NULL as 'Inside Cluster') as outside_cluster, `k8s.namespace.name`, `service.instance.id` as pod_name SINCE 30 MINUTES AGO TIMESERIES"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "% of Errors over time",
+          "layout": {
+            "column": 5,
+            "row": 24,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT percentage(count(`kafka.latency`), where `kafka.has_error`=true) FROM Metric FACET cases(WHERE k8s.namespace.name IS NULL as 'Outside Cluster', WHERE k8s.namespace.name is NOT NULL as 'Inside Cluster') as outside_cluster, `k8s.namespace.name`, `service.instance.id` as pod_name SINCE 30 MINUTES AGO TIMESERIES"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Throughput (rpm)",
+          "layout": {
+            "column": 9,
+            "row": 24,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(count(`kafka.latency`), 1 minute) as requests_per_m FROM Metric FACET cases(WHERE k8s.namespace.name IS NULL as 'Outside Cluster', WHERE k8s.namespace.name is NOT NULL as 'Inside Cluster') as outside_cluster, `k8s.namespace.name`, `service.instance.id` as pod_name SINCE 30 MINUTES AGO TIMESERIES"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
             }
           }
         }


### PR DESCRIPTION
## Relevant information
Users have requested that we breakdown these metrics by the pods that service them as well as the pods that request them. Fortunately this is a simple addition to the dashboard.

Checklist
- [x] I've read the guidelines and understand the acceptance criteria.
- [x] The value of the attribute marked as identifier will be unique and valid.
- [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
