### PR TITLE
NEWRELIC-5898 Pixie MySQL split by requesting pod and split by responding pod

### DIFF
--- a/definitions/ext-pixie_mysql/dashboard.json
+++ b/definitions/ext-pixie_mysql/dashboard.json
@@ -3,7 +3,7 @@
   "description": null,
   "pages": [
     {
-      "name": "pixie_mysql",
+      "name": "Overview",
       "description": null,
       "widgets": [
         {
@@ -11,7 +11,7 @@
           "layout": {
             "column": 1,
             "row": 1,
-            "width": 6,
+            "width": 12,
             "height": 3
           },
           "visualization": {
@@ -41,9 +41,9 @@
         {
           "title": "% of Errors over time",
           "layout": {
-            "column": 7,
-            "row": 1,
-            "width": 6,
+            "column": 5,
+            "row": 4,
+            "width": 4,
             "height": 3
           },
           "visualization": {
@@ -75,7 +75,7 @@
           "layout": {
             "column": 1,
             "row": 4,
-            "width": 6,
+            "width": 4,
             "height": 3
           },
           "visualization": {
@@ -105,9 +105,9 @@
         {
           "title": "Throughput (rpm)",
           "layout": {
-            "column": 7,
+            "column": 9,
             "row": 4,
-            "width": 6,
+            "width": 4,
             "height": 3
           },
           "visualization": {
@@ -135,7 +135,7 @@
           }
         },
         {
-          "title": "Sampled mysql Requests",
+          "title": "Sample of MySQL Requests",
           "layout": {
             "column": 1,
             "row": 7,
@@ -183,6 +183,344 @@
             ],
             "platformOptions": {
               "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "",
+          "layout": {
+            "column": 1,
+            "row": 13,
+            "width": 12,
+            "height": 1
+          },
+          "visualization": {
+            "id": "viz.markdown"
+          },
+          "rawConfiguration": {
+            "text": "# Breakdown by Servicing Pod\nThis section breaks down metrics based on which pod handles the work for the service. \nIf the service is located off the cluster, then everything will be grouped under \"Outside Cluster\"."
+          }
+        },
+        {
+          "title": "Servicing Pods",
+          "layout": {
+            "column": 1,
+            "row": 14,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.table"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(count(`mysql.latency`), 1 minute) as requests_per_minute from Metric FACET cases(WHERE mysql.pod.name IS NULL as 'Outside Cluster', WHERE mysql.pod.name is NOT NULL as 'Inside Cluster') as outside_cluster, `mysql.pod.name` SINCE 30 MINUTES AGO"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "Distribution of response times (ms)",
+          "layout": {
+            "column": 7,
+            "row": 14,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`mysql.latency`), max(`mysql.latency`), min(`mysql.latency`) FROM Metric FACET cases(WHERE mysql.pod.name IS NULL as 'Outside Cluster', WHERE mysql.pod.name is NOT NULL as 'Inside Cluster') as outside_cluster, `mysql.pod.name` SINCE 30 MINUTES AGO TIMESERIES"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Data Transfer Rate (bps)",
+          "layout": {
+            "column": 1,
+            "row": 17,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(sum(`mysql.req_bytes`), 1 second) as req_bps, rate(sum(`mysql.resp_bytes`), 1 second) as resp_bps FROM Metric FACET cases(WHERE mysql.pod.name IS NULL as 'Outside Cluster', WHERE mysql.pod.name is NOT NULL as 'Inside Cluster') as outside_cluster, `mysql.pod.name` SINCE 30 MINUTES AGO TIMESERIES"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "% of Errors over time",
+          "layout": {
+            "column": 5,
+            "row": 17,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT percentage(count(mysql.latency), where mysql.resp_status>2) FROM Metric FACET cases(WHERE mysql.pod.name IS NULL as 'Outside Cluster', WHERE mysql.pod.name is NOT NULL as 'Inside Cluster') as outside_cluster, `mysql.pod.name` SINCE 30 MINUTES AGO TIMESERIES"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Throughput (rpm)",
+          "layout": {
+            "column": 9,
+            "row": 17,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(count(`mysql.latency`), 1 minute) as requests_per_m FROM Metric FACET cases(WHERE mysql.pod.name IS NULL as 'Outside Cluster', WHERE mysql.pod.name is NOT NULL as 'Inside Cluster') as outside_cluster, `mysql.pod.name` SINCE 30 MINUTES AGO TIMESERIES"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "",
+          "layout": {
+            "column": 1,
+            "row": 20,
+            "width": 12,
+            "height": 1
+          },
+          "visualization": {
+            "id": "viz.markdown"
+          },
+          "rawConfiguration": {
+            "text": "# Breakdown by Requesting Pod\nThis section breaks the metrics down based on the internal pod that makes requests to the service. Clients that are located off cluster are grouped under \"Outside Cluster\"."
+          }
+        },
+        {
+          "title": "Requesting Pods",
+          "layout": {
+            "column": 1,
+            "row": 21,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.table"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(count(`mysql.latency`), 1 minute) as requests_per_minute from Metric FACET cases(WHERE k8s.namespace.name IS NULL as 'Outside Cluster', WHERE k8s.namespace.name is NOT NULL as 'Inside Cluster') as outside_cluster, `k8s.namespace.name`, `service.instance.id` as pod_name SINCE 30 MINUTES AGO"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "Distribution of response times (ms)",
+          "layout": {
+            "column": 7,
+            "row": 21,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`mysql.latency`), max(`mysql.latency`), min(`mysql.latency`) FROM Metric FACET cases(WHERE k8s.namespace.name IS NULL as 'Outside Cluster', WHERE k8s.namespace.name is NOT NULL as 'Inside Cluster') as outside_cluster, `k8s.namespace.name`, `service.instance.id` as pod_name SINCE 30 MINUTES AGO TIMESERIES"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Data Transfer Rate (bps)",
+          "layout": {
+            "column": 1,
+            "row": 24,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(sum(`mysql.req_bytes`), 1 second) as req_bps, rate(sum(`mysql.resp_bytes`), 1 second) as resp_bps FROM Metric FACET cases(WHERE k8s.namespace.name IS NULL as 'Outside Cluster', WHERE k8s.namespace.name is NOT NULL as 'Inside Cluster') as outside_cluster, `k8s.namespace.name`, `service.instance.id` as pod_name SINCE 30 MINUTES AGO TIMESERIES"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "% of Errors over time",
+          "layout": {
+            "column": 5,
+            "row": 24,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT percentage(count(mysql.latency), where mysql.resp_status>2) FROM Metric FACET cases(WHERE k8s.namespace.name IS NULL as 'Outside Cluster', WHERE k8s.namespace.name is NOT NULL as 'Inside Cluster') as outside_cluster, `k8s.namespace.name`, `service.instance.id` as pod_name SINCE 30 MINUTES AGO TIMESERIES"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Throughput (rpm)",
+          "layout": {
+            "column": 9,
+            "row": 24,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(count(`mysql.latency`), 1 minute) as requests_per_m FROM Metric FACET cases(WHERE k8s.namespace.name IS NULL as 'Outside Cluster', WHERE k8s.namespace.name is NOT NULL as 'Inside Cluster') as outside_cluster, `k8s.namespace.name`, `service.instance.id` as pod_name SINCE 30 MINUTES AGO TIMESERIES"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
             }
           }
         }


### PR DESCRIPTION
Signed-off-by: Phillip Kuznetsov <pkuznetsov@pixielabs.ai>

### Relevant information
Users have requested that we breakdown these metrics by the pods that service them as well as the pods that request them. Fortunately this is a simple addition to the dashboard.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
