### PR TITLE
Add SSL Certifcate Entity Definition

### DIFF
--- a/definitions/ext-ssl_certificate/dashboard.json
+++ b/definitions/ext-ssl_certificate/dashboard.json
@@ -1,7 +1,6 @@
 {
   "name": "SSL - Certificate Expiration Dashboard",
   "description": null,
-  "permissions": "PUBLIC_READ_WRITE",
   "pages": [
     {
       "name": "SSL - Certificate Expiration Dashboard",
@@ -15,7 +14,6 @@
             "width": 3,
             "height": 3
           },
-          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.billboard"
           },
@@ -42,7 +40,6 @@
             "width": 3,
             "height": 3
           },
-          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.billboard"
           },
@@ -69,7 +66,6 @@
             "width": 6,
             "height": 3
           },
-          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.billboard"
           },

--- a/definitions/ext-ssl_certificate/dashboard.json
+++ b/definitions/ext-ssl_certificate/dashboard.json
@@ -26,7 +26,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "FROM Metric SELECT min(days.remaining)"
+                "query": "FROM Metric SELECT min(days.remaining) SINCE 1 day ago"
               }
             ],
             "platformOptions": {
@@ -53,7 +53,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "FROM Metric SELECT latest(ssl.cert.issuer)"
+                "query": "FROM Metric SELECT latest(ssl.cert.issuer) SINCE 1 day ago"
               }
             ],
             "platformOptions": {
@@ -80,7 +80,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "FROM Metric SELECT latest(ssl.cert.serial_number)"
+                "query": "FROM Metric SELECT latest(ssl.cert.serial_number) SINCE 1 day ago"
               }
             ],
             "platformOptions": {

--- a/definitions/ext-ssl_certificate/dashboard.json
+++ b/definitions/ext-ssl_certificate/dashboard.json
@@ -1,0 +1,94 @@
+{
+  "name": "SSL - Certificate Expiration Dashboard",
+  "description": null,
+  "permissions": "PUBLIC_READ_WRITE",
+  "pages": [
+    {
+      "name": "SSL - Certificate Expiration Dashboard",
+      "description": null,
+      "widgets": [
+        {
+          "title": "Certificate Days Remaining",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 3,
+            "height": 3
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT min(days.remaining)"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "Certificate Issuer",
+          "layout": {
+            "column": 4,
+            "row": 1,
+            "width": 3,
+            "height": 3
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT latest(ssl.cert.issuer)"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "Certificate Serial Number",
+          "layout": {
+            "column": 7,
+            "row": 1,
+            "width": 6,
+            "height": 3
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT latest(ssl.cert.serial_number)"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/definitions/ext-ssl_certificate/definition.yml
+++ b/definitions/ext-ssl_certificate/definition.yml
@@ -10,11 +10,17 @@ synthesis:
       value: ext-ssl
     tags:
       ssl.cert.serial_number:
-      ssl.cert.expiration_date:
+      ssl.cert.issuer:
 
 goldenTags:
+- ssl.cert.issuer
 - ssl.cert.common_name
-- ssl.cert.expiration_date
+- ssl.cert.serial_number
+
+dashboardTemplates:
+  newRelic:
+    template: dashboard.json
 
 configuration:
   entityExpirationTime: EIGHT_DAYS
+

--- a/definitions/ext-ssl_certificate/definition.yml
+++ b/definitions/ext-ssl_certificate/definition.yml
@@ -8,8 +8,6 @@ synthesis:
     conditions:
     - attribute: provider
       value: ext-ssl
-    - attribute: metricName
-      prefix: ssl
     tags:
       ssl.cert.serial_number:
       ssl.cert.expiration_date:

--- a/definitions/ext-ssl_certificate/definition.yml
+++ b/definitions/ext-ssl_certificate/definition.yml
@@ -1,0 +1,22 @@
+domain: EXT
+type: SSL_CERTIFICATE
+synthesis:
+  rules:
+  - identifier: ssl.cert.serial_number
+    name: ssl.cert.common_name
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: provider
+      value: ext-ssl
+    - attribute: metricName
+      prefix: ssl
+    tags:
+      ssl.cert.serial_number:
+      ssl.cert.expiration_date:
+
+goldenTags:
+- ssl.cert.common_name
+- ssl.cert.expiration_date
+
+configuration:
+  entityExpirationTime: EIGHT_DAYS

--- a/definitions/ext-ssl_certificate/golden_metrics.yml
+++ b/definitions/ext-ssl_certificate/golden_metrics.yml
@@ -2,6 +2,6 @@ expirationDays:
   title: "Days Until Expiration"
   unit: COUNT
   query:
-    select: latest(ssl.cert.days_remaining)
+    select: min(ssl.cert.days_remaining)
     from: Metric
     where: "provider = 'ext-ssl'"

--- a/definitions/ext-ssl_certificate/golden_metrics.yml
+++ b/definitions/ext-ssl_certificate/golden_metrics.yml
@@ -1,8 +1,7 @@
-ssl_days_to_expire:
-  title: Days Until Expiration
+expirationDays:
+  title: "Days Until Expiration"
   unit: COUNT
   query:
-    select: max(ssl.cert.days_remaining)
+    select: latest(ssl.cert.days_remaining)
     from: Metric
     where: "provider = 'ext-ssl'"
-

--- a/definitions/ext-ssl_certificate/golden_metrics.yml
+++ b/definitions/ext-ssl_certificate/golden_metrics.yml
@@ -1,0 +1,8 @@
+ssl_days_to_expire:
+  title: Days Until Expiration
+  unit: COUNT
+  query:
+    select: max(ssl.cert.days_remaining)
+    from: Metric
+    where: "provider = 'ext-ssl'"
+

--- a/definitions/ext-ssl_certificate/summary_metrics.yml
+++ b/definitions/ext-ssl_certificate/summary_metrics.yml
@@ -2,9 +2,3 @@ expirationDays:
   goldenMetric: expirationDays
   title: Days Until Expiration
   unit: COUNT
-
-expirationDate:
-  title: Expiration Date
-  unit: STRING
-  tag:
-    key: ssl.cert.expiration_date

--- a/definitions/ext-ssl_certificate/summary_metrics.yml
+++ b/definitions/ext-ssl_certificate/summary_metrics.yml
@@ -1,5 +1,5 @@
 expirationDays:
-  goldenMetric: ssl.cert.days_remaining
+  goldenMetric: expirationDays
   title: Days Until Expiration
   unit: COUNT
 

--- a/definitions/ext-ssl_certificate/summary_metrics.yml
+++ b/definitions/ext-ssl_certificate/summary_metrics.yml
@@ -1,0 +1,10 @@
+expirationDays:
+  goldenMetric: ssl.cert.days_remaining
+  title: Days Until Expiration
+  unit: COUNT
+
+expirationDate:
+  title: Expiration Date
+  unit: STRING
+  tag:
+    key: ssl.cert.expiration_date

--- a/definitions/ext-ssl_certificate/tests/Log.json
+++ b/definitions/ext-ssl_certificate/tests/Log.json
@@ -1,0 +1,12 @@
+[
+    {
+        "ssl.cert.common_name": "1.my.example.com",
+        "ssl.cert.expiration_date": "02-14-2023",
+        "provider": "ext-ssl"
+    },
+    {
+        "ssl.cert.common_name": "1.my.example.com",
+        "ssl.cert.expiration_date": "02-14-2023",
+        "provider": "ext-ssl"
+    }
+]

--- a/definitions/ext-ssl_certificate/tests/Log.json
+++ b/definitions/ext-ssl_certificate/tests/Log.json
@@ -2,11 +2,13 @@
     {
         "ssl.cert.common_name": "1.my.example.com",
         "ssl.cert.expiration_date": "02-14-2023",
+        "ssl.cert.serial_number": "03:2F:E5:F0:34:8C:21:15:7F:32:CB:ED:90:63:A8:51:41:A6",
         "provider": "ext-ssl"
     },
     {
         "ssl.cert.common_name": "1.my.example.com",
         "ssl.cert.expiration_date": "02-14-2023",
+        "ssl.cert.serial_number": "FB:2F:E5:F0:34:8C:21:15:7F:32:CB:ED:90:63:A8:51:41:D9",
         "provider": "ext-ssl"
     }
 ]

--- a/definitions/ext-ssl_certificate/tests/Log.json
+++ b/definitions/ext-ssl_certificate/tests/Log.json
@@ -1,13 +1,13 @@
 [
     {
         "ssl.cert.common_name": "1.my.example.com",
-        "ssl.cert.expiration_date": "02-14-2023",
+        "ssl.cert.issuer": "amazon",
         "ssl.cert.serial_number": "03:2F:E5:F0:34:8C:21:15:7F:32:CB:ED:90:63:A8:51:41:A6",
         "provider": "ext-ssl"
     },
     {
-        "ssl.cert.common_name": "1.my.example.com",
-        "ssl.cert.expiration_date": "02-14-2023",
+        "ssl.cert.common_name": "2.my.example.com",
+        "ssl.cert.issuer": "digicert",
         "ssl.cert.serial_number": "FB:2F:E5:F0:34:8C:21:15:7F:32:CB:ED:90:63:A8:51:41:D9",
         "provider": "ext-ssl"
     }


### PR DESCRIPTION
### Relevant information
Adding an Entity Definition for SSL Certificates. The goal is to provide an entity that will show the common name for a certificate as the entity where entity uniqueness is based on the certificate serial number. The summary dashboard should include the expiration date and the number of days left until a certificate expires.

### Example Python SDK code that should work with this entity type
```
import os
from datetime import datetime
from newrelic_telemetry_sdk import GaugeMetric, MetricClient

metric_client = MetricClient(os.environ["NEW_RELIC_INSERT_KEY"])

TODAY = "01-20-2023"

tags = {
    "ssl.cert.common_name": "www.epochalypse.today",
    "ssl.cert.serial_number": "03:2F:E5:F0:34:8C:21:15:7F:32:CB:ED:90:63:A8:51:41:A6",
    "ssl.cert.expiration_date": "01-19-2038",
    "provider": "ext-ssl"
}

a = datetime.strptime(TODAY, "%m-%d-%Y")
b = datetime.strptime(tags['ssl.cert.expiration_date'], "%m-%d-%Y")

days_remaining = GaugeMetric("ssl.cert.days_remaining", int(b - a), tags)

batch = [days_remaining]
response = metric_client.send_batch(batch)
response.raise_for_status()
print("Sent metrics successfully!")

```


### Checklist

* [ x ] I've read the guidelines and understand the acceptance criteria.
* [ x ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ x ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
