### PR TITLE
Remove opamp.agent.uid tag taken from instance.id

### DIFF
--- a/definitions/ext-otelcol/definition.yml
+++ b/definitions/ext-otelcol/definition.yml
@@ -17,7 +17,6 @@ synthesis:
       service.namespace:
       service.version:
       service.instance.id:
-        entityTagName: opamp.agent.uid
       os.type:
       os.version:
       cloud.provider:


### PR DESCRIPTION
We discovered that this is not the best place to populate the `opamp.agent.uid`, as it can fall back to a value that doesn't always correspond to an agent in our OpAMP agents database.

Instead, it will be better to populate this tag more intentionally with a resource processor in the pipeline that exports the collector's o11y data.

### Relevant information

Describe what you have done and any details that you think are relevant or that you might want to discuss with us. 

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
