### PR TITLE
Use `NA` instead of `entity.type` for Azure entities

### DIFF
--- a/definitions/infra-azureapimanagementservice/definition.yml
+++ b/definitions/infra-azureapimanagementservice/definition.yml
@@ -12,6 +12,8 @@ synthesis:
   rules:
   - identifier: azure.resourceId
     name: displayName
+    legacyFeatures:
+      overrideGuidType: true
     encodeIdentifierInGUID: true
     conditions:
     - attribute: azure.resourceType

--- a/definitions/infra-azureapplicationgateway/definition.yml
+++ b/definitions/infra-azureapplicationgateway/definition.yml
@@ -10,6 +10,8 @@ synthesis:
   rules:
   - identifier: azure.resourceId
     name: displayName
+    legacyFeatures:
+      overrideGuidType: true
     encodeIdentifierInGUID: true
     conditions:
     - attribute: azure.resourceType

--- a/definitions/infra-azureappserviceplan/definition.yml
+++ b/definitions/infra-azureappserviceplan/definition.yml
@@ -7,6 +7,8 @@ synthesis:
   rules:
     - identifier: azure.resourceId
       name: displayName
+      legacyFeatures:
+        overrideGuidType: true
       encodeIdentifierInGUID: true
       conditions:
         - attribute: azure.resourceType

--- a/definitions/infra-azurecontainersinstancegroup/definition.yml
+++ b/definitions/infra-azurecontainersinstancegroup/definition.yml
@@ -10,6 +10,8 @@ synthesis:
   rules:
   - identifier: azure.resourceId
     name: displayName
+    legacyFeatures:
+      overrideGuidType: true
     encodeIdentifierInGUID: true
     conditions:
     - attribute: azure.resourceType

--- a/definitions/infra-azurecontainersmanagedcluster/definition.yml
+++ b/definitions/infra-azurecontainersmanagedcluster/definition.yml
@@ -10,6 +10,8 @@ synthesis:
   rules:
   - identifier: azure.resourceId
     name: displayName
+    legacyFeatures:
+      overrideGuidType: true
     encodeIdentifierInGUID: true
     conditions:
     - attribute: azure.resourceType

--- a/definitions/infra-azurecontainersregistry/definition.yml
+++ b/definitions/infra-azurecontainersregistry/definition.yml
@@ -10,6 +10,8 @@ synthesis:
   rules:
   - identifier: azure.resourceId
     name: displayName
+    legacyFeatures:
+      overrideGuidType: true
     encodeIdentifierInGUID: true
     conditions:
     - attribute: azure.resourceType

--- a/definitions/infra-azurecosmosdbaccount/definition.yml
+++ b/definitions/infra-azurecosmosdbaccount/definition.yml
@@ -12,6 +12,8 @@ synthesis:
   rules:
     - identifier: azure.resourceId
       name: displayName
+      legacyFeatures:
+        overrideGuidType: true
       encodeIdentifierInGUID: true
       conditions:
         - attribute: azure.resourceType

--- a/definitions/infra-azuredatafactorydatafactory/definition.yml
+++ b/definitions/infra-azuredatafactorydatafactory/definition.yml
@@ -10,6 +10,8 @@ synthesis:
   rules:
   - identifier: azure.resourceId
     name: displayName
+    legacyFeatures:
+      overrideGuidType: true
     encodeIdentifierInGUID: true
     conditions:
     - attribute: azure.resourceType

--- a/definitions/infra-azuredatafactoryfactory/definition.yml
+++ b/definitions/infra-azuredatafactoryfactory/definition.yml
@@ -7,6 +7,8 @@ synthesis:
   rules:
   - identifier: azure.resourceId
     name: displayName
+    legacyFeatures:
+      overrideGuidType: true
     encodeIdentifierInGUID: true
     conditions:
     - attribute: azure.resourceType

--- a/definitions/infra-azureeventhubcluster/definition.yml
+++ b/definitions/infra-azureeventhubcluster/definition.yml
@@ -10,6 +10,8 @@ synthesis:
   rules:
   - identifier: azure.resourceId
     name: displayName
+    legacyFeatures:
+      overrideGuidType: true
     encodeIdentifierInGUID: true
     conditions:
     - attribute: azure.resourceType

--- a/definitions/infra-azureeventhubnamespace/definition.yml
+++ b/definitions/infra-azureeventhubnamespace/definition.yml
@@ -10,6 +10,8 @@ synthesis:
   rules:
   - identifier: azure.resourceId
     name: displayName
+    legacyFeatures:
+      overrideGuidType: true
     encodeIdentifierInGUID: true
     conditions:
     - attribute: azure.resourceType

--- a/definitions/infra-azureexpressroutecircuit/definition.yml
+++ b/definitions/infra-azureexpressroutecircuit/definition.yml
@@ -7,6 +7,8 @@ synthesis:
   rules:
   - identifier: azure.resourceId
     name: displayName
+    legacyFeatures:
+      overrideGuidType: true
     encodeIdentifierInGUID: true
     conditions:
     - attribute: azure.resourceType

--- a/definitions/infra-azureexpressrouteconnection/definition.yml
+++ b/definitions/infra-azureexpressrouteconnection/definition.yml
@@ -7,6 +7,8 @@ synthesis:
   rules:
   - identifier: azure.resourceId
     name: displayName
+    legacyFeatures:
+      overrideGuidType: true
     encodeIdentifierInGUID: true
     conditions:
     - attribute: azure.resourceType

--- a/definitions/infra-azureexpressroutegateway/definition.yml
+++ b/definitions/infra-azureexpressroutegateway/definition.yml
@@ -7,6 +7,8 @@ synthesis:
   rules:
   - identifier: azure.resourceId
     name: displayName
+    legacyFeatures:
+      overrideGuidType: true
     encodeIdentifierInGUID: true
     conditions:
     - attribute: azure.resourceType

--- a/definitions/infra-azurefirewall/definition.yml
+++ b/definitions/infra-azurefirewall/definition.yml
@@ -10,6 +10,8 @@ synthesis:
   rules:
   - identifier: azure.resourceId
     name: displayName
+    legacyFeatures:
+      overrideGuidType: true
     encodeIdentifierInGUID: true
     conditions:
     - attribute: azure.resourceType

--- a/definitions/infra-azurefrontdoorfrontdoor/definition.yml
+++ b/definitions/infra-azurefrontdoorfrontdoor/definition.yml
@@ -10,6 +10,8 @@ synthesis:
   rules:
   - identifier: azure.resourceId
     name: displayName
+    legacyFeatures:
+      overrideGuidType: true
     encodeIdentifierInGUID: true
     conditions:
     - attribute: azure.resourceType

--- a/definitions/infra-azurekeyvaultvault/definition.yml
+++ b/definitions/infra-azurekeyvaultvault/definition.yml
@@ -10,6 +10,8 @@ synthesis:
   rules:
   - identifier: azure.resourceId
     name: displayName
+    legacyFeatures:
+      overrideGuidType: true
     encodeIdentifierInGUID: true
     conditions:
     - attribute: azure.resourceType

--- a/definitions/infra-azureloadbalancer/definition.yml
+++ b/definitions/infra-azureloadbalancer/definition.yml
@@ -12,6 +12,8 @@ synthesis:
   rules:
     - identifier: azure.resourceId
       name: displayName
+      legacyFeatures:
+        overrideGuidType: true
       encodeIdentifierInGUID: true
       conditions:
         - attribute: azure.resourceType

--- a/definitions/infra-azurelogicappsintegrationserviceenvironment/definition.yml
+++ b/definitions/infra-azurelogicappsintegrationserviceenvironment/definition.yml
@@ -10,6 +10,8 @@ synthesis:
   rules:
   - identifier: azure.resourceId
     name: displayName
+    legacyFeatures:
+      overrideGuidType: true
     encodeIdentifierInGUID: true
     conditions:
     - attribute: azure.resourceType

--- a/definitions/infra-azurelogicappsworkflow/definition.yml
+++ b/definitions/infra-azurelogicappsworkflow/definition.yml
@@ -10,6 +10,8 @@ synthesis:
   rules:
   - identifier: azure.resourceId
     name: displayName
+    legacyFeatures:
+      overrideGuidType: true
     encodeIdentifierInGUID: true
     conditions:
     - attribute: azure.resourceType

--- a/definitions/infra-azuremachinelearningworkspace/definition.yml
+++ b/definitions/infra-azuremachinelearningworkspace/definition.yml
@@ -7,6 +7,8 @@ synthesis:
   rules:
   - identifier: azure.resourceId
     name: displayName
+    legacyFeatures:
+      overrideGuidType: true
     encodeIdentifierInGUID: true
     conditions:
     - attribute: azure.resourceType

--- a/definitions/infra-azuremariadbserver/definition.yml
+++ b/definitions/infra-azuremariadbserver/definition.yml
@@ -14,6 +14,8 @@ synthesis:
   rules:
     - identifier: azure.resourceId
       name: displayName
+      legacyFeatures:
+        overrideGuidType: true
       encodeIdentifierInGUID: true
       conditions:
         - attribute: azure.resourceType

--- a/definitions/infra-azuremysqlflexibleserver/definition.yml
+++ b/definitions/infra-azuremysqlflexibleserver/definition.yml
@@ -10,6 +10,8 @@ synthesis:
   rules:
   - identifier: azure.resourceId
     name: displayName
+    legacyFeatures:
+      overrideGuidType: true
     encodeIdentifierInGUID: true
     conditions:
     - attribute: azure.resourceType

--- a/definitions/infra-azuremysqlserver/definition.yml
+++ b/definitions/infra-azuremysqlserver/definition.yml
@@ -14,6 +14,8 @@ synthesis:
   rules:
     - identifier: azure.resourceId
       name: displayName
+      legacyFeatures:
+        overrideGuidType: true
       encodeIdentifierInGUID: true
       conditions:
         - attribute: azure.resourceType

--- a/definitions/infra-azurepostgresqlflexibleserver/definition.yml
+++ b/definitions/infra-azurepostgresqlflexibleserver/definition.yml
@@ -10,6 +10,8 @@ synthesis:
   rules:
   - identifier: azure.resourceId
     name: displayName
+    legacyFeatures:
+      overrideGuidType: true
     encodeIdentifierInGUID: true
     conditions:
     - attribute: azure.resourceType

--- a/definitions/infra-azurepostgresqlserver/definition.yml
+++ b/definitions/infra-azurepostgresqlserver/definition.yml
@@ -14,6 +14,8 @@ synthesis:
   rules:
     - identifier: azure.resourceId
       name: displayName
+      legacyFeatures:
+        overrideGuidType: true
       encodeIdentifierInGUID: true
       conditions:
         - attribute: azure.resourceType

--- a/definitions/infra-azurepowerbidedicatedcapacity/definition.yml
+++ b/definitions/infra-azurepowerbidedicatedcapacity/definition.yml
@@ -10,6 +10,8 @@ synthesis:
   rules:
   - identifier: azure.resourceId
     name: displayName
+    legacyFeatures:
+      overrideGuidType: true
     encodeIdentifierInGUID: true
     conditions:
     - attribute: azure.resourceType

--- a/definitions/infra-azurerediscache/definition.yml
+++ b/definitions/infra-azurerediscache/definition.yml
@@ -7,6 +7,8 @@ synthesis:
   rules:
     - identifier: azure.resourceId
       name: displayName
+      legacyFeatures:
+        overrideGuidType: true
       encodeIdentifierInGUID: true
       conditions:
         - attribute: azure.resourceType

--- a/definitions/infra-azureservicebusnamespace/definition.yml
+++ b/definitions/infra-azureservicebusnamespace/definition.yml
@@ -13,6 +13,8 @@ synthesis:
   rules:
     - identifier: azure.resourceId
       name: displayName
+      legacyFeatures:
+        overrideGuidType: true
       encodeIdentifierInGUID: true
       conditions:
         - attribute: azure.resourceType

--- a/definitions/infra-azuresqldatabase/definition.yml
+++ b/definitions/infra-azuresqldatabase/definition.yml
@@ -16,6 +16,8 @@ synthesis:
   rules:
   - identifier: azure.resourceId
     name: displayName
+    legacyFeatures:
+      overrideGuidType: true
     encodeIdentifierInGUID: true
     conditions:
       - attribute: azure.resourceType

--- a/definitions/infra-azuresqlelasticpool/definition.yml
+++ b/definitions/infra-azuresqlelasticpool/definition.yml
@@ -7,6 +7,8 @@ synthesis:
   rules:
     - identifier: azure.resourceId
       name: displayName
+      legacyFeatures:
+        overrideGuidType: true
       encodeIdentifierInGUID: true
       conditions:
         - attribute: azure.resourceType

--- a/definitions/infra-azuresqlmanagedinstance/definition.yml
+++ b/definitions/infra-azuresqlmanagedinstance/definition.yml
@@ -10,6 +10,8 @@ synthesis:
   rules:
   - identifier: azure.resourceId
     name: displayName
+    legacyFeatures:
+      overrideGuidType: true
     encodeIdentifierInGUID: true
     conditions:
     - attribute: azure.resourceType

--- a/definitions/infra-azurestorageaccount/definition.yml
+++ b/definitions/infra-azurestorageaccount/definition.yml
@@ -14,6 +14,8 @@ synthesis:
   rules:
     - identifier: azure.resourceId
       name: displayName
+      legacyFeatures:
+        overrideGuidType: true
       encodeIdentifierInGUID: true
       conditions:
         - attribute: azure.resourceType

--- a/definitions/infra-azurevirtualmachinescaleset/definition.yml
+++ b/definitions/infra-azurevirtualmachinescaleset/definition.yml
@@ -12,6 +12,8 @@ synthesis:
   rules:
   - identifier: azure.resourceId
     name: displayName
+    legacyFeatures:
+      overrideGuidType: true
     encodeIdentifierInGUID: true
     conditions:
     - attribute: azure.resourceType

--- a/definitions/infra-azurevirtualnetworks/definition.yml
+++ b/definitions/infra-azurevirtualnetworks/definition.yml
@@ -7,6 +7,8 @@ synthesis:
   rules:
     - identifier: azure.resourceId
       name: displayName
+      legacyFeatures:
+        overrideGuidType: true
       encodeIdentifierInGUID: true
       conditions:
         - attribute: azure.resourceType

--- a/definitions/infra-azurevirtualnetworksnetworkinterface/definition.yml
+++ b/definitions/infra-azurevirtualnetworksnetworkinterface/definition.yml
@@ -7,6 +7,8 @@ synthesis:
   rules:
     - identifier: azure.resourceId
       name: displayName
+      legacyFeatures:
+        overrideGuidType: true
       encodeIdentifierInGUID: true
       conditions:
         - attribute: azure.resourceType

--- a/definitions/infra-azurevirtualnetworkspublicipaddress/definition.yml
+++ b/definitions/infra-azurevirtualnetworkspublicipaddress/definition.yml
@@ -7,6 +7,8 @@ synthesis:
   rules:
     - identifier: azure.resourceId
       name: displayName
+      legacyFeatures:
+        overrideGuidType: true
       encodeIdentifierInGUID: true
       conditions:
         - attribute: azure.resourceType

--- a/definitions/infra-azurevpngatewaysvpngateway/definition.yml
+++ b/definitions/infra-azurevpngatewaysvpngateway/definition.yml
@@ -7,6 +7,8 @@ synthesis:
   rules:
   - identifier: azure.resourceId
     name: displayName
+    legacyFeatures:
+      overrideGuidType: true
     encodeIdentifierInGUID: true
     conditions:
     - attribute: azure.resourceType


### PR DESCRIPTION
### Relevant information

The GUID for azure entities is generated using `NA` instead of `entity.type`.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
