### PR TITLE
Fix golden metrics for azureappserviceplan

### DIFF
--- a/definitions/infra-azureappserviceplan/golden_metrics.yml
+++ b/definitions/infra-azureappserviceplan/golden_metrics.yml
@@ -1,14 +1,26 @@
 cpuUsage:
-  query:
-    eventId: entityGuid
-    select: average(`cpuPercent.Average`)
-    from: AzureAppServicePlanSample
   unit: PERCENTAGE
   title: CPU usage
+  queries:
+    aws:   
+      eventId: entity.guid
+      select: average(`azure.web.serverfarms.CpuPercentage`)
+      from: Metric
+      eventName: entity.name
+    awsSample:
+      eventId: entityGuid
+      select: average(`cpuPercent.Average`)
+      from: AzureAppServicePlanSample
 memoryUsage:
-  query:
-    eventId: entityGuid
-    select: average(`memoryPercent.Average`)
-    from: AzureAppServicePlanSample
   unit: PERCENTAGE
   title: Memory usage
+  queries:
+    aws:
+      eventId: entity.guid
+      select: average(`azure.web.serverfarms.MemoryPercentage`)
+      from: Metric
+      eventName: entity.name
+    awsSample:
+      eventId: entityGuid
+      select: average(`memoryPercent.Average`)
+      from: AzureAppServicePlanSample


### PR DESCRIPTION
https://issues.newrelic.com/browse/NR-81315

Fix golden metrics for `azure app service plan`

### Relevant information

The awsSample metric is not able to be captured internally by our golden metric synthetizer.