### PR TITLE
Add support for filterNRQLByEntityID in definition.yml

### DIFF
--- a/docs/entity_summary.md
+++ b/docs/entity_summary.md
@@ -83,7 +83,7 @@ Tags are assigned to all entities based on the tags defined in an entity's defin
 `k8s.cluster.name` as a tag.
 https://github.com/newrelic/entity-definitions/blob/42b7a5a1780d897312f231aac3271898f8c87ff5/definitions/ext-pixie_postgres/definition.yml#L34-L35
 
-In a NRQL query, you can reference the value of a tag using the `tags.k8s.cluster.name` like so:
+In a NRQL query, you can reference the value of a tag using `tags.k8s.cluster.name` like so:
 ```sql
-FROM Metric SELECT latest(k8s.clusterName) as 'Cluster Name' WHERE metricName = 'k8s.pod.startTime' AND tags.k8s.cluster.name = '{{tags.k8s.cluster.name}}'
+FROM Metric SELECT latest(k8s.clusterName) as 'Cluster Name' WHERE k8s.cluster.name = '{{tags.k8s.cluster.name}}'
 ```

--- a/docs/entity_summary.md
+++ b/docs/entity_summary.md
@@ -4,11 +4,13 @@ The entity summary is the entity's main page, and contains all the information a
 
 * Dashboards should be listed in the `definition.yml` file, under the `dashboardTemplates` section.
 * If the entity type only has one source of data, use `newRelic` as the default source.
+* By default, each NRQL query will be filtered by the entity GUID. If you want to disable this behavior, set `filterNRQLByEntityID` to `false`. When you disable this behavior, you must manually specify the filter for all NRQL queries in the dashboard. See [Filtering by Entity GUID](#filtering-by-entity-guid) for more details.
 
 ```yaml
 dashboardTemplates:
   newRelic:
     template: dashboard.json
+    filterNRQLByEntityID: true
 ```
 
 In order to get a dashboard in JSON format, [create a dashboard](https://docs.newrelic.com/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards/) in New Relic and [export it as json](https://docs.newrelic.com/docs/query-your-data/explore-query-data/dashboards/dashboards-charts-import-export-data/#dashboards).
@@ -17,7 +19,7 @@ In order to get a dashboard in JSON format, [create a dashboard](https://docs.ne
 
 Copy the JSON content to the `dashboard.json` file.
 
-Make sure your dashboard is valid running our sanitizer: 
+Make sure your dashboard is valid running our sanitizer:
 
 `docker-compose run sanitize-dashboards`
 
@@ -39,7 +41,7 @@ dashboardTemplates:
     template: prometheus_dashboard.json
 ```
 
-We recommend prefixing dashboard names with the source name. 
+We recommend prefixing dashboard names with the source name.
 
 You can also specify both provider and name in the form of `{provider}/{name}`.
 
@@ -52,4 +54,36 @@ Note that query semantics (such as average vs counts, units, etc.) should match 
 dashboardTemplates:
   kentik/netflow-events:
     template: kentik_netflow-evens_dashboard.json
+```
+
+## Filtering by Entity GUID
+```yaml
+dashboardTemplates:
+  newRelic:
+    template: dashboard.json
+    filterNRQLByEntityID: true
+```
+
+By default the NRQL query will be filtered by the entity GUID. If you want to disable this behavior, set `filterNRQLByEntityID` to `false`. When you disable this
+behavior, you must manually specify the filter for all NRQL queries in the dashboard. You can use mustache syntax to reference [available variables](#available-variables).
+
+For example, if you want to filter by the entity GUID, you can use the following NRQL query:
+```sql
+FROM Metric SELECT latest(k8s.clusterName) as 'Cluster Name' WHERE metricName = 'k8s.pod.startTime' AND `entity.guid` = '{{entity.id}}'
+```
+
+### Available variables
+| Variable | Description |
+| --- | --- |
+| `entity.id` | The entity GUID |
+| `tags.*` | Any tag value, see below for more details on how to find the tag name |
+
+### Finding the tag name
+Tags are assigned to all entities based on the tags defined in an entity's definition file. For example, the `ext-pixie_postgres` entity type defines
+`k8s.cluster.name` as a tag.
+https://github.com/newrelic/entity-definitions/blob/42b7a5a1780d897312f231aac3271898f8c87ff5/definitions/ext-pixie_postgres/definition.yml#L34-L35
+
+In a NRQL query, you can reference the value of a tag using the `tags.k8s.cluster.name` like so:
+```sql
+FROM Metric SELECT latest(k8s.clusterName) as 'Cluster Name' WHERE metricName = 'k8s.pod.startTime' AND tags.k8s.cluster.name = '{{tags.k8s.cluster.name}}'
 ```

--- a/validator/schemas/entity-schema-v1.json
+++ b/validator/schemas/entity-schema-v1.json
@@ -343,6 +343,12 @@
                 "prometheus_dashboard.json"
               ]
             ]
+          },
+          "filterNRQLByEntityID": {
+            "$id": "#/properties/query/dashboardTemplates/filterNRQLByEntityID",
+            "type": "boolean",
+            "default": false,
+            "description": "The dashboard will be filtered by the entity ID. Defaults to false if not provided."
           }
         },
         "additionalProperties": false


### PR DESCRIPTION
### Relevant information
We want to support more powerful entity dashboards. In the backend, we've gone ahead and supported `filterNRQLByEntityID` as an optional parameter. This change propagates that upwards and adds the documentation here.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
