### PR TITLE
AWSLambda: add metric-streams rule

### DIFF
--- a/definitions/infra-awslambdafunction/definition.yml
+++ b/definitions/infra-awslambdafunction/definition.yml
@@ -16,3 +16,14 @@ goldenTags:
 configuration:
   entityExpirationTime: DAILY
   alertable: true
+synthesis:
+  rules:
+  # aws metric-streams
+  - identifier: aws.Arn
+    name: displayName
+    legacyFeatures:
+      overrideGuidType: true
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: aws.Namespace
+      value: AWS/Lambda


### PR DESCRIPTION
### Relevant information

Added synthesis rule for AWSLambda entities ingesting metrics and using ARN as identifier (DMs)

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
