### PR TITLE
Revert "Revert "Add Kubernetes Job, CronJob entities""

### DIFF
--- a/definitions/infra-kubernetes_cronjob/definition.yml
+++ b/definitions/infra-kubernetes_cronjob/definition.yml
@@ -1,0 +1,31 @@
+domain: INFRA
+type: KUBERNETES_CRONJOB
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+goldenTags:
+- k8s.cronjobName
+- k8s.clusterName
+- k8s.namespaceName
+synthesis:
+  identifier: entity.id
+  name: k8s.cronjobName
+  encodeIdentifierInGUID: false
+  conditions:
+  - attribute:  k8s.cronjob.createdAt
+  tags:
+    k8s.clusterName:
+    k8s.namespaceName:
+    k8s.cronjobName:
+    label.topology.kubernetes.io/region:
+    label.topology.kubernetes.io/zone:
+    label.eks.amazonaws.com/compute-type:
+    label.kubernetes.io/arch:
+    label.kubernetes.io/hostname:
+    label.kubernetes.io/os:
+    newrelic.integrationName:
+    newrelic.integrationVersion:
+      multiValue: false
+    newrelic.agentVersion:
+      multiValue: false
+

--- a/definitions/infra-kubernetes_cronjob/summary_metrics.yml
+++ b/definitions/infra-kubernetes_cronjob/summary_metrics.yml
@@ -1,0 +1,10 @@
+cluster:
+  title: Cluster
+  unit: STRING
+  tag:
+    key: k8s.clusterName
+namespace:
+  title: Namespace
+  unit: STRING
+  tag:
+    key: k8s.namespaceName

--- a/definitions/infra-kubernetes_cronjob/tests/MetricRaw.json
+++ b/definitions/infra-kubernetes_cronjob/tests/MetricRaw.json
@@ -1,0 +1,15 @@
+[
+    {
+        "k8s.clusterName": "dev-cluster",
+        "k8s.cronjobName": "e2e-resources-cronjob",
+        "k8s.namespaceName": "default",
+        "k8s.cronjob.createdAt": 1675983384,
+        "entity.id": "4878011584894256254",
+        "k8s.cronjob.isActive": 0,
+        "k8s.cronjob.isSuspended": 0,
+        "k8s.cronjob.lastScheduledTime": 1676609580,
+        "k8s.cronjob.metadataResourceVersion": 17779225,
+        "k8s.cronjob.nextScheduledTime": 1676609640,
+        "k8s.cronjob.specStartingDeadlineSeconds": 200
+    }
+  ]

--- a/definitions/infra-kubernetes_job/definition.yml
+++ b/definitions/infra-kubernetes_job/definition.yml
@@ -1,0 +1,31 @@
+domain: INFRA
+type: KUBERNETES_JOB
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+goldenTags:
+- k8s.jobName
+- k8s.clusterName
+- k8s.namespaceName
+synthesis:
+  identifier: entity.id
+  name: k8s.jobName
+  encodeIdentifierInGUID: false
+  conditions:
+  - attribute:  k8s.job.createdAt
+  tags:
+    k8s.clusterName:
+    k8s.namespaceName:
+    k8s.jobName:
+    label.topology.kubernetes.io/region:
+    label.topology.kubernetes.io/zone:
+    label.eks.amazonaws.com/compute-type:
+    label.kubernetes.io/arch:
+    label.kubernetes.io/hostname:
+    label.kubernetes.io/os:
+    newrelic.integrationName:
+    newrelic.integrationVersion:
+      multiValue: false
+    newrelic.agentVersion:
+      multiValue: false
+

--- a/definitions/infra-kubernetes_job/summary_metrics.yml
+++ b/definitions/infra-kubernetes_job/summary_metrics.yml
@@ -1,0 +1,10 @@
+cluster:
+  title: Cluster
+  unit: STRING
+  tag:
+    key: k8s.clusterName
+namespace:
+  title: Namespace
+  unit: STRING
+  tag:
+    key: k8s.namespaceName

--- a/definitions/infra-kubernetes_job/tests/MetricRaw.json
+++ b/definitions/infra-kubernetes_job/tests/MetricRaw.json
@@ -1,0 +1,16 @@
+[
+    {
+        "k8s.clusterName": "dev-cluster",
+        "k8s.jobName": "e2e-resources-cronjob-27943496",
+        "k8s.namespaceName": "default",
+        "entity.id": "4878011584894256254",
+        "k8s.job.activePods": 0,
+        "k8s.job.completedAt": 1676609764,
+        "k8s.job.createdAt": 1676609760,
+        "k8s.job.specActiveDeadlineSeconds": 200,
+        "k8s.job.specCompletions": 1,
+        "k8s.job.specParallelism": 1,
+        "k8s.job.startedAt": 1676609760,
+        "k8s.job.succeededPods": 1
+    }
+  ]


### PR DESCRIPTION
Reverts newrelic/entity-definitions#924

Reverting the revert so the changes that were accidentally deployed are back in the BETA channel.