### PR TITLE
Fix Kubernetes Cronjob, Job entity definitions

### DIFF
--- a/definitions/infra-kubernetes_cronjob/definition.yml
+++ b/definitions/infra-kubernetes_cronjob/definition.yml
@@ -8,13 +8,14 @@ goldenTags:
 - k8s.clusterName
 - k8s.namespaceName
 synthesis:
-  identifier: entityId
-  name: k8s.cronjobName
-  legacyFeatures:
-      overrideGuidType: true
-  encodeIdentifierInGUID: true
-  conditions:
-  - attribute:  k8s.cronjob.createdAt
+  rules:
+    - identifier: entityId
+      name: k8s.cronjobName
+      legacyFeatures:
+        overrideGuidType: true
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute:  k8s.cronjob.createdAt
   tags:
     k8s.clusterName:
     k8s.namespaceName:

--- a/definitions/infra-kubernetes_cronjob/definition.yml
+++ b/definitions/infra-kubernetes_cronjob/definition.yml
@@ -8,9 +8,11 @@ goldenTags:
 - k8s.clusterName
 - k8s.namespaceName
 synthesis:
-  identifier: entity.id
+  identifier: entityId
   name: k8s.cronjobName
-  encodeIdentifierInGUID: false
+  legacyFeatures:
+      overrideGuidType: true
+  encodeIdentifierInGUID: true
   conditions:
   - attribute:  k8s.cronjob.createdAt
   tags:

--- a/definitions/infra-kubernetes_cronjob/tests/MetricRaw.json
+++ b/definitions/infra-kubernetes_cronjob/tests/MetricRaw.json
@@ -4,7 +4,7 @@
         "k8s.cronjobName": "e2e-resources-cronjob",
         "k8s.namespaceName": "default",
         "k8s.cronjob.createdAt": 1675983384,
-        "entity.id": "4878011584894256254",
+        "entityId": "4878011584894256254",
         "k8s.cronjob.isActive": 0,
         "k8s.cronjob.isSuspended": 0,
         "k8s.cronjob.lastScheduledTime": 1676609580,

--- a/definitions/infra-kubernetes_job/definition.yml
+++ b/definitions/infra-kubernetes_job/definition.yml
@@ -8,9 +8,11 @@ goldenTags:
 - k8s.clusterName
 - k8s.namespaceName
 synthesis:
-  identifier: entity.id
+  identifier: entityId
   name: k8s.jobName
-  encodeIdentifierInGUID: false
+  legacyFeatures:
+      overrideGuidType: true
+  encodeIdentifierInGUID: true
   conditions:
   - attribute:  k8s.job.createdAt
   tags:

--- a/definitions/infra-kubernetes_job/definition.yml
+++ b/definitions/infra-kubernetes_job/definition.yml
@@ -8,13 +8,14 @@ goldenTags:
 - k8s.clusterName
 - k8s.namespaceName
 synthesis:
-  identifier: entityId
-  name: k8s.jobName
-  legacyFeatures:
-      overrideGuidType: true
-  encodeIdentifierInGUID: true
-  conditions:
-  - attribute:  k8s.job.createdAt
+  rules:
+    - identifier: entityId
+      name: k8s.jobName
+      legacyFeatures:
+        overrideGuidType: true
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute:  k8s.job.createdAt
   tags:
     k8s.clusterName:
     k8s.namespaceName:

--- a/definitions/infra-kubernetes_job/tests/MetricRaw.json
+++ b/definitions/infra-kubernetes_job/tests/MetricRaw.json
@@ -3,7 +3,7 @@
         "k8s.clusterName": "dev-cluster",
         "k8s.jobName": "e2e-resources-cronjob-27943496",
         "k8s.namespaceName": "default",
-        "entity.id": "4878011584894256254",
+        "entityId": "4878011584894256254",
         "k8s.job.activePods": 0,
         "k8s.job.completedAt": 1676609764,
         "k8s.job.createdAt": 1676609760,


### PR DESCRIPTION
### Relevant information

The `CronJob` and `Job` entities are not currently synthesizing. This PR:
- uses `EntityId` instead of `entity.id` for synthesis
- enables legacy feature `overrideGuidType`

### Checklist

* [X] I've read the guidelines and understand the acceptance criteria.
* [X] The value of the attribute marked as `identifier` will be unique and valid. 
* [X] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
