### PR TITLE
Fix: typo in gigamon definition

### DIFF
--- a/definitions/ext-gigamon_dns/definition.yml
+++ b/definitions/ext-gigamon_dns/definition.yml
@@ -10,7 +10,7 @@ synthesis:
     - attribute: dns_query
       present: true
     tags:
-      porsrc_portt:
+      src_port:
         entityTagName: port
         multiValue: false
 


### PR DESCRIPTION
### Relevant information

Fix a typo

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
