### PR TITLE
make workflows non-alertable

### DIFF
--- a/definitions/aiops-workflow/definition.yml
+++ b/definitions/aiops-workflow/definition.yml
@@ -2,4 +2,4 @@ domain: AIOPS
 type: WORKFLOW
 configuration:
   entityExpirationTime: MANUAL
-  alertable: true
+  alertable: false


### PR DESCRIPTION
### Relevant information

Until we are fully ready with workflow entity UI, we want to make sure that workflows are invisible on all-entities page

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
