### PR TITLE
feat: create synthetics runtime upgrade validation entity

### DIFF
--- a/definitions/synth-runtime_validation/definition.yml
+++ b/definitions/synth-runtime_validation/definition.yml
@@ -1,0 +1,5 @@
+domain: SYNTH
+type: RUNTIME_VALIDATION
+configuration:
+  entityExpirationTime: EIGHT_DAYS
+  alertable: false

--- a/definitions/synth-runtime_validation/summary_metrics.yml
+++ b/definitions/synth-runtime_validation/summary_metrics.yml
@@ -1,0 +1,20 @@
+monitorName:
+  title: Monitor Name
+  unit: STRING
+  tag:
+    key: monitorName
+monitorType:
+  title: Monitor Type
+  unit: STRING
+  tag:
+    key: monitorType
+validationStatus:
+  title: Validation Status
+  unit: STRING
+  tag:
+    key: validationStatus
+lastValidated:
+  title: Last Validated
+  unit: TIMESTAMP
+  tag:
+    key: lastValidated

--- a/definitions/synth-runtime_validation/summary_metrics.yml
+++ b/definitions/synth-runtime_validation/summary_metrics.yml
@@ -1,8 +1,8 @@
-monitorName:
+name:
   title: Monitor Name
   unit: STRING
   tag:
-    key: monitorName
+    key: name
 monitorType:
   title: Monitor Type
   unit: STRING

--- a/definitions/synth-runtime_validation/summary_metrics.yml
+++ b/definitions/synth-runtime_validation/summary_metrics.yml
@@ -1,8 +1,3 @@
-name:
-  title: Monitor Name
-  unit: STRING
-  tag:
-    key: name
 monitorType:
   title: Monitor Type
   unit: STRING
@@ -18,3 +13,8 @@ lastValidated:
   unit: TIMESTAMP
   tag:
     key: lastValidated
+validationError:
+  title: Error
+  unit: STRING
+  tag:
+    key: validationError


### PR DESCRIPTION
purpose: this will give us a way to index information for the ui to display about a monitors current runtime upgrade validation.
account|SYNTH|RUNTIME_VALIDATION|domainId
domainId is a 32 char uuid.

### Relevant information

Describe what you have done and any details that you think are relevant or that you might want to discuss with us. 

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
