### PR TITLE
Mobile golden metrics -  change title to reflect query

### DIFF
--- a/definitions/mobile-application/golden_metrics.yml
+++ b/definitions/mobile-application/golden_metrics.yml
@@ -27,9 +27,9 @@ networkFailuresCountMetric:
     select: average(newrelic.timeslice.value)
     where: metricTimesliceName = 'Mobile/FailedCallRate'
     eventName: appName
-httpErrorsCountMetric:
-  title: HTTP error count
-  unit: COUNT
+httpErrorsRateMetric:
+  title: HTTP error rate
+  unit: PERCENTAGE
   query:
     select: average(newrelic.timeslice.value)
     where: metricTimesliceName = 'Mobile/StatusErrorRate'

--- a/definitions/mobile-application/summary_metrics.yml
+++ b/definitions/mobile-application/summary_metrics.yml
@@ -14,10 +14,10 @@ networkFailuresCount:
   goldenMetric: networkFailuresCountMetric
   title: Network errors count
   unit: COUNT
-httpErrorsCount:
-  goldenMetric: httpErrorsCountMetric
-  title: HTTP errors count
-  unit: COUNT
+httpErrorsRate:
+  goldenMetric: httpErrorsRateMetric
+  title: HTTP errors rate
+  unit: PERCENTAGE
 requestsPerMinute:
   goldenMetric: requestsPerMinute
   title: Requests per minute


### PR DESCRIPTION
### Relevant information

We noticed that the golden metric that was labeled `HTTP errors count` was actually querying for an `average`. We want to change the name of the query to `HTTP errors rate`. I also updated the summary metric to stay in sync with the golden metric.

### Checklist

* [ X] I've read the guidelines and understand the acceptance criteria.
* [ X] The value of the attribute marked as `identifier` will be unique and valid. 
* [ X] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
