### PR TITLE
Add squid exporter otel definition (NR-83160)

### DIFF
--- a/definitions/infra-squid_cachemgr/definition.yml
+++ b/definitions/infra-squid_cachemgr/definition.yml
@@ -1,0 +1,18 @@
+domain: INFRA
+type: SQUID_CACHEMGR
+
+synthesis:
+  rules:
+    - identifier: squid_server
+      name: squid_server
+      conditions:
+        - attribute: eventType
+          value: MetricRaw
+        - attribute: metricName
+          prefix: squid_
+      tags:
+        squid_server:
+
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/definitions/infra-squid_cachemgr/tests/MetricRaw.json
+++ b/definitions/infra-squid_cachemgr/tests/MetricRaw.json
@@ -1,0 +1,7 @@
+[
+    {
+        "metricName": "squid_server_http_requests_total",
+        "squid_server": "squid-server",
+        "newrelic.source": "api.metrics.otlp"
+    }
+]


### PR DESCRIPTION
### Relevant information

This PR adds entities for the upcoming squid open telemetry integration (using the prometheus expoter and its otel receiver) being worked by Coreint Team.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
