### PR TITLE
Revert "Adding request duration metric with histogrampercentile (#939)"

### DIFF
--- a/definitions/ext-coredns/golden_metrics.yml
+++ b/definitions/ext-coredns/golden_metrics.yml
@@ -25,10 +25,3 @@ requestLatency:
     select: sum(coredns_dns_request_duration_seconds_sum * 1000) / count(coredns_dns_request_duration_seconds_count)
     from: Metric
     facet: server, zone
-requestDuration:
-  title: CoreDNS request latency as 'Average request duration(MS)'
-  unit: 'MS'
-  query:
-    select: histogrampercentile(coredns_dns_request_duration_seconds_bucket, 50)*1000
-    from: Metric
-    facet: server, zone


### PR DESCRIPTION
This reverts commit 015745c56bd5642fe96392760534fd5884fd3e9c.

### Relevant information

The `bucketpercentile` value function doesn't seem to be supported well by the platform. While we investigate the issue, we'll revert to the previous commit.  

cc. @RagalahariP 

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
