### PR TITLE
ext-service: Add deployment tag for data that comes from Pixie

### DIFF
--- a/definitions/ext-service/definition.yml
+++ b/definitions/ext-service/definition.yml
@@ -128,6 +128,9 @@ synthesis:
       k8s.namespace.name:
         entityTagName: k8s.namespaceName
         ttl: P1D
+      k8s.deployment.name:
+        entityTagName: k8s.deploymentName
+        ttl: P1D
 
     # IMPORTANT:
     # This rule matches on any telemetry with service.name 


### PR DESCRIPTION
### Relevant information
Added a deployment tag for service data that comes from Pixie. We've had this data for a while
now coming from Pixie, we just haven't utilized it yet: https://github.com/pixie-io/pixie-plugin/commit/ce56307508c79421a683a0bb72baa095e87de0d4
This will help connect service data that comes from Pixie to infrastructure data available in New Relic.


### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
