### PR TITLE
feat: add kubernetes ingress entity

### DIFF
--- a/definitions/ext-kubernetes_ingress/definition.yml
+++ b/definitions/ext-kubernetes_ingress/definition.yml
@@ -1,0 +1,31 @@
+domain: EXT
+type: KUBERNETES_INGRESS
+
+goldenTags:
+  - cluster_name
+  - k8s.namespace
+  - ingress_class
+
+synthesis:
+  rules:
+    - compositeIdentifier:
+        separator: "/"
+        attributes:
+          - cluster_name
+          - exported_namespace
+          - ingress
+      encodeIdentifierInGUID: true
+      name: ingress
+      conditions:
+        - attribute: metricName
+          prefix: nginx_ingress_controller_
+      tags:
+        k8s.namespace:
+          entityTagNames: [exported_namespace]
+          multiValue: false
+        ingress_class:
+          entityTagNames: [controller_class]
+          multiValue: false
+
+configuration:
+  alertable: true

--- a/definitions/ext-kubernetes_ingress/golden_metrics.yml
+++ b/definitions/ext-kubernetes_ingress/golden_metrics.yml
@@ -1,0 +1,20 @@
+requestsPerSecond:
+  title: Requests per second
+  unit: REQUESTS_PER_SECOND
+  queries:
+    prometheus:
+      select: rate(sum(nginx_ingress_controller_request_size_count), 1 SECONDS) AS 'Requests Per Second'
+
+p99Latency:
+  title: "99% of requests are completed within this many milliseconds"
+  unit: MS
+  queries:
+    prometheus:
+      select: bucketpercentile(nginx_ingress_controller_request_duration_seconds_bucket, 99)*1000 AS 'Latency'
+
+errorRate:
+  title: Percentage of requests which result in 4xx or 5xx responses
+  unit: PERCENTAGE
+  queries:
+    prometheus:
+      select: filter( rate(Sum( nginx_ingress_controller_requests),1 seconds),  WHERE status Not RLIKE '[4-5].*') * 100  / filter( rate(sum( nginx_ingress_controller_requests), 1 seconds), WHERE status RLIKE '.*') AS 'Error Rate'

--- a/definitions/ext-kubernetes_ingress/summary_metrics.yml
+++ b/definitions/ext-kubernetes_ingress/summary_metrics.yml
@@ -1,0 +1,12 @@
+requestPerSecond:
+  title: Requests per second
+  unit: REQUESTS_PER_SECOND
+  goldenMetric: requestsPerSecond
+p99Latency:
+  title: P99 latency
+  unit: MS
+  goldenMetric: p99Latency
+errorRate:
+  title: Error rate
+  unit: PERCENTAGE
+  goldenMetric: errorRate


### PR DESCRIPTION
### Relevant information

This PR adds an entity to represent Kubernetes Ingress objects. Specifically, this synthesizes Ingress objects from the metrics exported by the `ingress-nginx` ingress controller, though it leaves room for the addition of rules to synthesize Ingress objects from the metrics of other ingress controllers in the future.

There _is_ one concern I have when it comes to adding additional rules for other ingress controllers: adding different _synthesis rules_ for different ingress controllers seems straightforward enough, as the `conditions` field would allows you to distinguish between data sources for the same entity via e.g. metrics name prefixes, such as the `nginx_ingress_controller_` prefix vs e.g. the `ambassador_` prefix or the `traefik_` prefix. But the Golden Metrics definitions in `golden_metrics.yml` can only distinguish between data sources for the same entity via the `instrumentation.provider` and/or `instrumentation.name` fields, and for all of these different ingress controllers, those fields would by default be `prometheus` and `remote-write`, respectively (some ingress controllers may optionally be able to export metrics in other formats besides Prometheus, but to the extent that I am familiar with other ingress controllers besides `ingress-nginx`, Prometheus metrics seem to be a pretty common default format).

That said, I think that addressing that particular concern can be handled in a separate issue. See also [this Slack thread](https://newrelicusers.slack.com/archives/C03LSNGL491/p1678306696238199?thread_ts=1678138168.142379&cid=C03LSNGL491).

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
