### PR TITLE
Fix EXT_SITE summary metrics

### DIFF
--- a/definitions/ext-site/golden_metrics.yml
+++ b/definitions/ext-site/golden_metrics.yml
@@ -1,12 +1,15 @@
-Success_Rate_Percent:
+successRatePercent:
   title: Success Rate Percent
   query: 
     select: percentage(count(*), WHERE StatusCode = 200 )
-Requests:
+    from: SITE
+requests:
   title: Requests
   query:
     select: count(*)
-RPM:
+    from: SITE
+throughput:
   title: Throughput
   query:
     select: rate(count(*),1 minute)
+    from: SITE

--- a/definitions/ext-site/summary_metrics.yml
+++ b/definitions/ext-site/summary_metrics.yml
@@ -1,12 +1,12 @@
 totalQueries:
-  goldenMetric: Requests
+  goldenMetric: requests
   title: Requests
   unit: COUNT
-Success_Rate_Percent:
-  goldenMetric: Success_Rate_Percent
+successRatePercent:
+  goldenMetric: successRatePercent
   title: Success Rate
   unit: PERCENTAGE
-Throughput:
- goldenMetric: RPM
+throughput:
+ goldenMetric: throughput
  title: Throughput
  unit: REQUESTS_PER_MINUTE

--- a/definitions/ext-site/summary_metrics.yml
+++ b/definitions/ext-site/summary_metrics.yml
@@ -1,4 +1,4 @@
-totalQueries:
+requests:
   goldenMetric: requests
   title: Requests
   unit: COUNT


### PR DESCRIPTION
### Relevant information
Fix summary metrics / golden metric definition for EXT_SITE to query from SITE table instead of the default Metric one.

Also slightly changed some summary metric names to be more consistent with existing ones.
