### PR TITLE
billable_user: update definition to composite

### DIFF
--- a/definitions/ext-billable_user/definition.yml
+++ b/definitions/ext-billable_user/definition.yml
@@ -3,13 +3,18 @@ type: BILLABLE_USER
 
 synthesis:
   rules:
-  - identifier: email
-    name: email
+  - compositeIdentifier:
+      separator: "/"
+      attributes:
+        - email
+        - authDomain
     encodeIdentifierInGUID: true
     conditions:
     - attribute: eventType
       value: NrUsers
     tags:
+      authDomain:
+        multiValue: false
       billableType:
         multiValue: false
       name:

--- a/definitions/ext-billable_user/definition.yml
+++ b/definitions/ext-billable_user/definition.yml
@@ -6,9 +6,10 @@ synthesis:
   - compositeIdentifier:
       separator: "/"
       attributes:
-        - email
         - authDomain
+        - email
     encodeIdentifierInGUID: true
+    name: email
     conditions:
     - attribute: eventType
       value: NrUsers

--- a/definitions/ext-billable_user/summary_metrics.yml
+++ b/definitions/ext-billable_user/summary_metrics.yml
@@ -3,3 +3,8 @@ userType:
     key: billableType
   title: User Type
   unit: STRING
+authDomain:
+  tag:
+    key: authDomain
+  title: Auth Domain
+  unit: STRING


### PR DESCRIPTION
### Relevant information

 - Definition now uses composite to stamp guid
 - Added relevant tag to summary metrics

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
