### PR TITLE
Fix: Kubernetes Job golden metrics typo

### DIFF
--- a/definitions/infra-kubernetes_job/summary_metrics.yml
+++ b/definitions/infra-kubernetes_job/summary_metrics.yml
@@ -12,7 +12,7 @@ completedAt:
   title: Completed At
   unit: TIMESTAMP
   tag:
-    key: completedAt
+    key: k8s.job.completedAt
 podsSucceeded:
   goldenMetric: podsSucceeded
   unit: COUNT


### PR DESCRIPTION
### Relevant information

This PR fixes a typo in a golden metric name. 

### Checklist

* [X] I've read the guidelines and understand the acceptance criteria.
* [X] The value of the attribute marked as `identifier` will be unique and valid. 
* [X] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
