### PR TITLE
Feat: add Kubernetes CronJob golden metrics

### DIFF
--- a/definitions/infra-kubernetes_cronjob/golden_metrics.yml
+++ b/definitions/infra-kubernetes_cronjob/golden_metrics.yml
@@ -1,17 +1,3 @@
-schedule:
-  title: Schedule
-  unit: STRING
-  queries:
-    newRelic:
-      select: latest(k8s.cronjob.schedule)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: latest(schedule)
-      from: K8sCronjobSample
-      eventId: entityGuid
-      eventName: entityName
 isSuspended:
   title: Suspended
   unit: COUNT

--- a/definitions/infra-kubernetes_cronjob/golden_metrics.yml
+++ b/definitions/infra-kubernetes_cronjob/golden_metrics.yml
@@ -1,0 +1,56 @@
+schedule:
+  title: Schedule
+  unit: STRING
+  queries:
+    newRelic:
+      select: latest(k8s.cronjob.schedule)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    newRelicSample:
+      select: latest(schedule)
+      from: K8sCronjobSample
+      eventId: entityGuid
+      eventName: entityName
+isSuspended:
+  title: Suspended
+  unit: COUNT
+  queries:
+    newRelic:
+      select: latest(k8s.cronjob.isSuspended)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    newRelicSample:
+      select: latest(isSuspended)
+      from: K8sCronjobSample
+      eventId: entityGuid
+      eventName: entityName
+isActive:
+  title: Active
+  unit: COUNT
+  queries:
+    newRelic:
+      select: latest(k8s.cronjob.isActive)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    newRelicSample:
+      select: latest(isActive)
+      from: K8sCronjobSample
+      eventId: entityGuid
+      eventName: entityName
+lastScheduled:
+  title: Last Scheduled
+  unit: TIMESTAMP
+  queries:
+    newRelic:
+      select: latest(k8s.cronjob.lastScheduledTime)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    newRelicSample:
+      select: latest(lastScheduledTime)
+      from: K8sJobSample
+      eventId: entityGuid
+      eventName: entityName

--- a/definitions/infra-kubernetes_cronjob/summary_metrics.yml
+++ b/definitions/infra-kubernetes_cronjob/summary_metrics.yml
@@ -8,3 +8,19 @@ namespace:
   unit: STRING
   tag:
     key: k8s.namespaceName
+schedule:
+  goldenMetric: schedule
+  unit: STRING
+  title: Schedule
+isSuspended:
+  goldenMetric: isSuspended
+  unit: COUNT
+  title: Suspended
+isActive:
+  goldenMetric: isActive
+  unit: COUNT
+  title: Active
+lastScheduled:
+  goldenMetric: lastScheduled
+  unit: COUNT
+  title: Last Scheduled

--- a/definitions/infra-kubernetes_cronjob/summary_metrics.yml
+++ b/definitions/infra-kubernetes_cronjob/summary_metrics.yml
@@ -9,9 +9,10 @@ namespace:
   tag:
     key: k8s.namespaceName
 schedule:
-  goldenMetric: schedule
-  unit: STRING
   title: Schedule
+  unit: STRING
+  tag:
+    key: k8s.cronjob.schedule
 isSuspended:
   goldenMetric: isSuspended
   unit: COUNT


### PR DESCRIPTION
### Relevant information

This PR adds golden metrics for the new Kubernetes CronJob entity. 

### Checklist

* [X] I've read the guidelines and understand the acceptance criteria.
* [X] The value of the attribute marked as `identifier` will be unique and valid. 
* [X] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
