### PR TITLE
Feat: add Kubernetes PersistentVolumeClaim summary metrics

### DIFF
--- a/definitions/infra-kubernetes_persistentvolumeclaim/summary_metrics.yml
+++ b/definitions/infra-kubernetes_persistentvolumeclaim/summary_metrics.yml
@@ -8,3 +8,33 @@ namespace:
   unit: STRING
   tag:
     key: k8s.namespaceName
+status:
+  title: Status
+  unit: STRING
+  tag:
+    key: k8s.persistentvolumeclaim.statusPhase
+volume:
+  title: Volume
+  unit: STRING
+  tag:
+    key: k8s.persistentvolumeclaim.volumeName
+requestedStorageBytes:
+  title: Capacity
+  unit: STRING
+  tag:
+    key: k8s.persistentvolumeclaim.requestedStorageBytes
+accessMode:
+  title: Access Modes
+  unit: STRING
+  tag:
+    key: k8s.persistentvolumeclaim.accessMode
+storageClass:
+  title: Storage Class
+  unit: STRING
+  tag:
+    key: k8s.persistentvolumeclaim.storageClass
+createdAt:
+  title: Created At
+  unit: TIMESTAMP
+  tag:
+    key: k8s.persistentvolumeclaim.createdAt


### PR DESCRIPTION
### Relevant information

This PR adds summary metrics to the new Kubernetes PersistentVolumeClaim entity.

### Checklist

* [X] I've read the guidelines and understand the acceptance criteria.
* [X] The value of the attribute marked as `identifier` will be unique and valid. 
* [X] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
