### PR TITLE
feat: add Kubernetes PersistentVolume summary metrics

### DIFF
--- a/definitions/infra-kubernetes_persistentvolume/summary_metrics.yml
+++ b/definitions/infra-kubernetes_persistentvolume/summary_metrics.yml
@@ -3,3 +3,28 @@ cluster:
   unit: STRING
   tag:
     key: k8s.clusterName
+requestedStorageBytes:
+  title: Capacity
+  unit: STRING
+  tag:
+    key: k8s.persistentvolume.capacityBytes
+claimNamespace:
+  title: Claim Namespace
+  unit: STRING
+  tag:
+    key: k8s.persistentvolume.pvcNamespace
+claim:
+  title: Claim Name
+  unit: STRING
+  tag:
+    key: k8s.persistentvolume.pvcName
+storageClass:
+  title: Storage Class
+  unit: STRING
+  tag:
+    key: k8s.persistentvolume.storageClass
+createdAt:
+  title: Created At
+  unit: TIMESTAMP
+  tag:
+    key: k8s.persistentvolume.createdAt


### PR DESCRIPTION
### Relevant information

This PR adds summary metrics to the new Kubernetes PersistentVolumeClaim entity.

### Checklist

* [X] I've read the guidelines and understand the acceptance criteria.
* [X] The value of the attribute marked as `identifier` will be unique and valid. 
* [X] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
