### PR TITLE
fix: Kubernetes CronJob summary metrics typo

### DIFF
--- a/definitions/infra-kubernetes_cronjob/summary_metrics.yml
+++ b/definitions/infra-kubernetes_cronjob/summary_metrics.yml
@@ -23,5 +23,5 @@ isActive:
   title: Active
 lastScheduled:
   goldenMetric: lastScheduled
-  unit: COUNT
+  unit: TIMESTAMP
   title: Last Scheduled


### PR DESCRIPTION
### Relevant information


### Checklist

* [X] I've read the guidelines and understand the acceptance criteria.
* [X] The value of the attribute marked as `identifier` will be unique and valid. 
* [X] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
