### PR TITLE
Fix Kubernetes CronJob golden metrics typo

### DIFF
--- a/definitions/infra-kubernetes_cronjob/golden_metrics.yml
+++ b/definitions/infra-kubernetes_cronjob/golden_metrics.yml
@@ -37,6 +37,6 @@ lastScheduled:
       eventName: entity.name
     newRelicSample:
       select: latest(lastScheduledTime)
-      from: K8sJobSample
+      from: K8sCronjobSample
       eventId: entityGuid
       eventName: entityName


### PR DESCRIPTION
### Relevant information

Fix typo in CronJob golden metrics file. 

### Checklist

* [X] I've read the guidelines and understand the acceptance criteria.
* [X] The value of the attribute marked as `identifier` will be unique and valid. 
* [X] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
