### PR TITLE
Fix cronjob

### DIFF
--- a/definitions/infra-kubernetes_cronjob/golden_metrics.yml
+++ b/definitions/infra-kubernetes_cronjob/golden_metrics.yml
@@ -31,7 +31,7 @@ lastScheduled:
   unit: TIMESTAMP
   queries:
     newRelic:
-      select: latest(k8s.cronjob.lastScheduledTime)
+      select: latest(k8s.cronjob.lastScheduledTime) * 1000
       from: Metric
       eventId: entity.guid
       eventName: entity.name


### PR DESCRIPTION
### Relevant information

The `Completed At` golden metric for the Kubernetes `CronJob` entity shows an incorrect timestamp:
https://staging.onenr.io/0kERz6xa8Rr
<img width="1533" alt="Screenshot 2023-03-29 at 10 51 03 AM" src="https://user-images.githubusercontent.com/66266496/228625284-6e756824-5cf3-47e1-bed5-8a3aa127d5d0.png">

This PR converts the timestamp from seconds to milliseconds (which appears to be the unit the UI wants).

### Checklist

* [X] I've read the guidelines and understand the acceptance criteria.
* [X] The value of the attribute marked as `identifier` will be unique and valid. 
* [X] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
