### PR TITLE
Fix Days Remaining Dashboard Query

### DIFF
--- a/definitions/ext-ssl_certificate/dashboard.json
+++ b/definitions/ext-ssl_certificate/dashboard.json
@@ -24,7 +24,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "FROM Metric SELECT min(days.remaining) SINCE 1 day ago"
+                "query": "FROM Metric SELECT min(ssl.cert.days_remaining) SINCE 1 day ago"
               }
             ],
             "platformOptions": {


### PR DESCRIPTION
### Relevant information

Updated SSL Days Remaining dashboard query, it was referencing an incorrect metricName.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
