### PR TITLE
fix: update Kubernetes Job entityExpirationTime from daily to 4 hours

### DIFF
--- a/definitions/infra-kubernetes_job/definition.yml
+++ b/definitions/infra-kubernetes_job/definition.yml
@@ -1,7 +1,7 @@
 domain: INFRA
 type: KUBERNETES_JOB
 configuration:
-  entityExpirationTime: DAILY
+  entityExpirationTime: FOUR_HOURS
   alertable: true
 dashboardTemplates:
   newRelic:


### PR DESCRIPTION
### Relevant information

This PR changes the Kubernetes Job entity expiration time from daily ---> 4 hours. 

### Checklist

* [X] I've read the guidelines and understand the acceptance criteria.
* [X] The value of the attribute marked as `identifier` will be unique and valid. 
* [X] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
