### PR TITLE
Add entity definition for New Relic OpenTelemetry distribution

### DIFF
--- a/definitions/ext-service/definition.yml
+++ b/definitions/ext-service/definition.yml
@@ -74,6 +74,25 @@ synthesis:
       telemetry.sdk.version:
       service.namespace:
 
+    # telemetry from NewRelic opentelemetry distribution
+  - identifier: service.name
+    name: service.name
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: instrumentation.provider
+      value: newrelic-opentelemetry
+    tags:
+      k8s.cluster.name:
+        ttl: P1D
+      k8s.deployment.name:
+        ttl: P1D
+      k8s.namespace.name:
+        ttl: P1D
+      telemetry.sdk.language:
+        entityTagName: language
+      telemetry.sdk.version:
+      service.namespace:
+
     # telemetry from kamon-agent provider
   - identifier: service.name
     name: service.name
@@ -133,10 +152,10 @@ synthesis:
         ttl: P1D
 
     # IMPORTANT:
-    # This rule matches on any telemetry with service.name 
+    # This rule matches on any telemetry with service.name
     # which is too broad for some telemetry sources, resulting
     # in matches that are not actually about services.  We're
-    # keeping it for backwards compatibility reasons but it 
+    # keeping it for backwards compatibility reasons but it
     # is being ignored in some internal services while we add
     # a configuration option to choose the relevant ingestion
     # sources for each rule.

--- a/definitions/ext-service/tests/Log.json
+++ b/definitions/ext-service/tests/Log.json
@@ -4,5 +4,17 @@
         "host.name": "ip-172-31-15-60.eu-central-1.compute.internal",
         "newrelic.source": "api.logs.otlp",
         "service.name": "julien-otel-app"
+    },
+    {
+        "host": "51b2f92f328e",
+        "instrumentation.provider": "newrelic-opentelemetry",
+        "message": "HikariPool-1 - Shutdown completed.",
+        "messageId": "3113c420-c836-4b62-802d-453e15538061",
+        "newrelic.source": "api.logs.otlp",
+        "otel.library.name": "com.zaxxer.hikari.HikariDataSource",
+        "service.name": "NROtelConsumer",
+        "severity.number": 9,
+        "severity.text": "INFO",
+        "telemetry.sdk.language": "java"
     }
 ]


### PR DESCRIPTION
### Relevant information

We're developing a New Relic distribution of the java otel agent that sends metrics for our normal APM UI.
https://github.com/newrelic/newrelic-opentelemetry-java

This agent sets `instrumentation.provider` to `newrelic-opentelemetry` and the UI uses this as the signal to indicate which views to render.

We want to generate an `entity.guid` for this agent, hence the PR.

cc @erabug 

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
