### PR TITLE
add service.domain for opentelemetry tags

### DIFF
--- a/definitions/ext-service/definition.yml
+++ b/definitions/ext-service/definition.yml
@@ -54,6 +54,7 @@ synthesis:
         entityTagName: language
       telemetry.sdk.version:
       service.namespace:
+      service.domain:
 
     # telemetry from opentelemetry provider
   - identifier: service.name
@@ -73,6 +74,7 @@ synthesis:
         entityTagName: language
       telemetry.sdk.version:
       service.namespace:
+      service.domain:
 
     # telemetry from NewRelic opentelemetry distribution
   - identifier: service.name
@@ -92,6 +94,7 @@ synthesis:
         entityTagName: language
       telemetry.sdk.version:
       service.namespace:
+      service.domain:
 
     # telemetry from kamon-agent provider
   - identifier: service.name


### PR DESCRIPTION
### Relevant information

The organization I work for uses OpenTelemetry for formatting/transmitting service telemetry and Backstage to catalog services. The current `service.name` and `service.namespace` map well to the Backstage entity and system objects. We also want to capture the Backstage domain, which groups the `service.namespace` (system) values. This change will tag entities with `service.domain`, if it is defined in the telemetry payload. 

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
