### PR TITLE
Add exception for WIN_SERVICES in ext_service

### DIFF
--- a/definitions/ext-service/definition.yml
+++ b/definitions/ext-service/definition.yml
@@ -12,6 +12,9 @@ synthesis:
     encodeIdentifierInGUID: true
     conditions:
     - attribute: service_name
+    # if host.windowsVersion it's produced by the infrastructure_agent running on windows, so it's a WIN_SERVICE
+    - attribute: host.windowsVersion
+      present: false
     tags:
       telemetry.sdk.name:
         entityTagName: instrumentation.provider


### PR DESCRIPTION
### Relevant information

Add exception to not synthetize infra-agent emitted WIN_SERVICES as ext_services.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
