### PR TITLE
fix: swap CPU % with processorLoad

### DIFF
--- a/definitions/ext-aws_elemental/golden_metrics.yml
+++ b/definitions/ext-aws_elemental/golden_metrics.yml
@@ -1,10 +1,10 @@
-cpuUtilization:
+cpuLoad:
   title: CPU Load
-  unit: PERCENTAGE
+  unit: COUNT
   queries:
     # Kentik profiles (default)
     kentik:
-      select: average(kentik.snmp.CPU)
+      select: average(kentik.snmp.hrProcessorLoad)
       from: Metric
       where: "provider = 'kentik-aws-elemental'"
 

--- a/definitions/ext-aws_elemental/summary_metrics.yml
+++ b/definitions/ext-aws_elemental/summary_metrics.yml
@@ -5,9 +5,9 @@ ipAddress:
     key: device_ip
 
 cpuUtilization:
-  goldenMetric: cpuUtilization
+  goldenMetric: cpuLoad
   title: CPU
-  unit: PERCENTAGE
+  unit: COUNT
 memoryUtilization:
   goldenMetric: memoryUtilization
   title: Memory


### PR DESCRIPTION
### Relevant information
This entity does not report a cpu %, it reports a count of items in the processor queue. Matched GM query to dashboard query.


### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
