### PR TITLE
Change the Uninstrumented Container TTL to 4 hours

### DIFF
--- a/definitions/uninstrumented-container/definition.yml
+++ b/definitions/uninstrumented-container/definition.yml
@@ -2,5 +2,5 @@ domain: UNINSTRUMENTED
 type: CONTAINER
 
 configuration:
-  entityExpirationTime: DAILY
+  entityExpirationTime: FOUR_HOURS
   alertable: false


### PR DESCRIPTION
Change the Uninstrumented Container TTL to 4 hours.

### Relevant information

The container entity leaves for 4 hours. In this case, it makes sense to have it for 4 hours. 

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
