### PR TITLE
chore: update EXT_UPS entity dashboards

### DIFF
--- a/definitions/ext-ups/definition.yml
+++ b/definitions/ext-ups/definition.yml
@@ -24,6 +24,9 @@ dashboardTemplates:
   # Tripplite UPS profiles
   kentik/tripplite-ups:
     template: kentik-tripplite-ups-dashboard.json
+  # Vertiv UPS profiles
+  kentik/vertiv-ups:
+    template: kentik-vertiv_ups-dashboard.json
   # Generic UPS profiles
   kentik/ups:
     template: kentik-ups-dashboard.json

--- a/definitions/ext-ups/golden_metrics.yml
+++ b/definitions/ext-ups/golden_metrics.yml
@@ -64,7 +64,7 @@ batteryTimeRemaining:
       where: "provider = 'kentik-ups'"
     # Vertiv UPS profiles
     kentik/vertiv-ups:
-      select: max(kentik.snmp.upsEstimatedMinutesRemaining)*60
+      select: latest(kentik.snmp.upsEstimatedMinutesRemaining)*60
       from: Metric
       where: "provider = 'kentik-ups'"
     # Generic UPS profiles

--- a/definitions/ext-ups/golden_metrics.yml
+++ b/definitions/ext-ups/golden_metrics.yml
@@ -12,6 +12,11 @@ outputLoadCapacity:
       select: max(kentik.snmp.upsOutputPercentLoad)
       from: Metric
       where: "provider = 'kentik-ups'"
+    # Vertiv UPS profiles
+    kentik/vertiv-ups:
+      select: max(kentik.snmp.upsOutputPercentLoad)
+      from: Metric
+      where: "provider = 'kentik-ups'"
     # Generic UPS profiles
     kentik/ups:
       select: max(kentik.snmp.upsOutputPercentLoad)
@@ -32,6 +37,11 @@ batteryTemperature:
       select: average(kentik.snmp.upsBatteryTemperature)
       from: Metric
       where: "provider = 'kentik-ups'"
+    # Vertiv UPS profiles
+    kentik/vertiv-ups:
+      select: average(kentik.snmp.lgpEnvTemperatureMeasurementDegC)
+      from: Metric
+      where: "provider = 'kentik-ups'"
     # Generic UPS profiles
     kentik/ups:
       select: average(kentik.snmp.upsBatteryTemperature)
@@ -50,6 +60,11 @@ batteryTimeRemaining:
     # Tripplite UPS profiles
     kentik/tripplite-ups:
       select: latest(kentik.snmp.upsEstimatedMinutesRemaining)*60
+      from: Metric
+      where: "provider = 'kentik-ups'"
+    # Vertiv UPS profiles
+    kentik/vertiv-ups:
+      select: max(kentik.snmp.upsEstimatedMinutesRemaining)*60
       from: Metric
       where: "provider = 'kentik-ups'"
     # Generic UPS profiles

--- a/definitions/ext-ups/kentik-apc_ups-dashboard.json
+++ b/definitions/ext-ups/kentik-apc_ups-dashboard.json
@@ -2,195 +2,235 @@
 	"name": "Kentik - UPS",
 	"description": null,
 	"pages": [
-		{
-			"name": "Kentik - UPS",
-			"description": null,
-			"widgets": [
+	  {
+		"name": "Kentik - UPS",
+		"description": null,
+		"widgets": [
+		  {
+			"title": "Summary",
+			"layout": {
+			  "column": 1,
+			  "row": 1,
+			  "width": 2,
+			  "height": 4
+			},
+			"linkedEntityGuids": null,
+			"visualization": {
+			  "id": "viz.billboard"
+			},
+			"rawConfiguration": {
+			  "dataFormatters": [
 				{
-					"visualization": {
-						"id": "viz.bar"
-					},
-					"layout": {
-						"column": 1,
-						"row": 1,
-						"height": 3,
-						"width": 4
-					},
-					"title": "Device Uptime (Hours)",
-					"rawConfiguration": {
-						"facet": {
-							"showOtherSeries": false
-						},
-						"nrqlQueries": [
-							{
-								"accountId": 0,
-								"query": "FROM Metric SELECT latest(`kentik.snmp.Uptime`)/100/60/60 AS 'Hours' WHERE provider = 'kentik-ups' LIMIT MAX"
-							}
-						]
-					}
+				  "name": "Uptime (Days)",
+				  "precision": 2,
+				  "type": "decimal"
 				},
 				{
-					"visualization": {
-						"id": "viz.bar"
-					},
-					"layout": {
-						"column": 5,
-						"row": 1,
-						"height": 3,
-						"width": 4
-					},
-					"title": "Time Currently Running on Battery (mins)",
-					"rawConfiguration": {
-						"facet": {
-							"showOtherSeries": false
-						},
-						"nrqlQueries": [
-							{
-								"accountId": 0,
-								"query": "FROM Metric SELECT latest(kentik.snmp.upsBasicBatteryTimeOnBattery)*.01/60 AS 'Time on Battery (mins)' WHERE provider = 'kentik-ups'"
-							}
-						]
-					}
-				},
-				{
-					"visualization": {
-						"id": "viz.bar"
-					},
-					"layout": {
-						"column": 9,
-						"row": 1,
-						"height": 3,
-						"width": 4
-					},
-					"title": "Battery Run Time Remaining (mins)",
-					"rawConfiguration": {
-						"facet": {
-							"showOtherSeries": false
-						},
-						"nrqlQueries": [
-							{
-								"accountId": 0,
-								"query": "FROM Metric SELECT latest(kentik.snmp.upsAdvBatteryRunTimeRemaining)*.01/60 AS 'Battery Run Time Remaining (mins)' WHERE provider = 'kentik-ups'"
-							}
-						]
-					}
-				},
-				{
-					"visualization": {
-						"id": "viz.line"
-					},
-					"layout": {
-						"column": 1,
-						"row": 4,
-						"height": 3,
-						"width": 4
-					},
-					"title": "Output Load Capacity %",
-					"rawConfiguration": {
-						"facet": {
-							"showOtherSeries": false
-						},
-						"legend": {
-							"enabled": true
-						},
-						"nrqlQueries": [
-							{
-								"accountId": 0,
-								"query": "FROM Metric SELECT latest(kentik.snmp.upsAdvOutputLoad) AS 'Output Load %' WHERE provider = 'kentik-ups' TIMESERIES 5 MINUTES"
-							}
-						],
-						"yAxisLeft": {
-							"max": 100,
-							"min": 0,
-							"zero": false
-						}
-					}
-				},
-				{
-					"visualization": {
-						"id": "viz.billboard"
-					},
-					"layout": {
-						"column": 5,
-						"row": 4,
-						"height": 3,
-						"width": 2
-					},
-					"title": "Battery Needs Replacing (1 == All Clear, 2 == Needs Replacing)",
-					"rawConfiguration": {
-						"dataFormatters": [],
-						"nrqlQueries": [
-							{
-								"accountId": 0,
-								"query": "FROM Metric SELECT latest(kentik.snmp.upsAdvBatteryReplaceIndicator) AS 'Battery Needs Replacing' WHERE provider = 'kentik-ups'"
-							}
-						],
-						"thresholds": [
-							{
-								"alertSeverity": "WARNING",
-								"value": 1.1
-							},
-							{
-								"alertSeverity": "CRITICAL",
-								"value": 1.9
-							}
-						]
-					}
-				},
-				{
-					"visualization": {
-						"id": "viz.billboard"
-					},
-					"layout": {
-						"column": 7,
-						"row": 4,
-						"height": 3,
-						"width": 2
-					},
-					"title": "Bad Battery Packs (Count)",
-					"rawConfiguration": {
-						"dataFormatters": [],
-						"nrqlQueries": [
-							{
-								"accountId": 0,
-								"query": "FROM Metric SELECT latest(kentik.snmp.upsAdvBatteryNumOfBadBattPacks) AS 'Bad Battery Packs' WHERE provider = 'kentik-ups'"
-							}
-						],
-						"thresholds": [
-							{
-								"alertSeverity": "WARNING",
-								"value": 0.5
-							},
-							{
-								"alertSeverity": "CRITICAL",
-								"value": 0.9
-							}
-						]
-					}
-				},
-				{
-					"visualization": {
-						"id": "viz.billboard"
-					},
-					"layout": {
-						"column": 9,
-						"row": 4,
-						"height": 3,
-						"width": 4
-					},
-					"title": "Battery Temperature",
-					"rawConfiguration": {
-						"dataFormatters": [],
-						"nrqlQueries": [
-							{
-								"accountId": 0,
-								"query": "FROM Metric SELECT latest(kentik.snmp.upsAdvBatteryTemperature) AS 'Celsius', (latest(kentik.snmp.upsAdvBatteryTemperature)*1.8) + 32 AS 'Fahrenheit' WHERE provider = 'kentik-ups'"
-							}
-						],
-						"thresholds": []
-					}
+				  "name": "Last Update",
+				  "type": "date"
 				}
-			]
-		}
-	]
-}
+			  ],
+			  "facet": {
+				"showOtherSeries": false
+			  },
+			  "nrqlQueries": [
+				{
+				  "accountIds": [
+					0
+				  ],
+				  "query": "FROM Metric SELECT latest(device_name) AS 'Device Name', latest(src_addr) AS 'Device IP', latest(SysObjectID) AS 'SysObjectID', latest(entity.type) AS 'NR Entity Type', latest(instrumentation.name) AS 'Ktranslate Profile', latest(kentik.snmp.Uptime)/8640000 AS 'Uptime (Days)', latest(timestamp) AS 'Last Update', latest(PollingHealth) AS 'Current Polling Health', latest(PollingHealthReason) AS 'Health Reason' WHERE provider = 'kentik-ups'"
+				}
+			  ],
+			  "platformOptions": {
+				"ignoreTimeRange": false
+			  }
+			}
+		  },
+		  {
+			"title": "Battery Replacement Indicator",
+			"layout": {
+			  "column": 3,
+			  "row": 1,
+			  "width": 2,
+			  "height": 2
+			},
+			"linkedEntityGuids": null,
+			"visualization": {
+			  "id": "viz.billboard"
+			},
+			"rawConfiguration": {
+			  "dataFormatters": [],
+			  "facet": {
+				"showOtherSeries": false
+			  },
+			  "nrqlQueries": [
+				{
+				  "accountIds": [
+					0
+				  ],
+				  "query": "FROM Metric SELECT if(latest(upsAdvBatteryReplaceIndicator) = 'noBatteryNeedsReplacing', 0, 1) FACET upsAdvBatteryReplaceIndicator WHERE provider = 'kentik-ups'"
+				}
+			  ],
+			  "platformOptions": {
+				"ignoreTimeRange": false
+			  },
+			  "thresholds": [
+				{
+				  "alertSeverity": "WARNING",
+				  "value": 0.1
+				},
+				{
+				  "alertSeverity": "CRITICAL",
+				  "value": 0.2
+				}
+			  ]
+			}
+		  },
+		  {
+			"title": "Output Load Capacity %",
+			"layout": {
+			  "column": 5,
+			  "row": 1,
+			  "width": 8,
+			  "height": 4
+			},
+			"linkedEntityGuids": null,
+			"visualization": {
+			  "id": "viz.line"
+			},
+			"rawConfiguration": {
+			  "facet": {
+				"showOtherSeries": false
+			  },
+			  "legend": {
+				"enabled": true
+			  },
+			  "nrqlQueries": [
+				{
+				  "accountId": 0,
+				  "query": "FROM Metric SELECT latest(kentik.snmp.upsAdvOutputLoad) AS 'Output Load %' WHERE provider = 'kentik-ups' TIMESERIES 5 MINUTES"
+				}
+			  ],
+			  "yAxisLeft": {
+				"max": 100,
+				"min": 0,
+				"zero": false
+			  }
+			}
+		  },
+		  {
+			"title": "Battery Status",
+			"layout": {
+			  "column": 3,
+			  "row": 3,
+			  "width": 2,
+			  "height": 2
+			},
+			"linkedEntityGuids": null,
+			"visualization": {
+			  "id": "viz.billboard"
+			},
+			"rawConfiguration": {
+			  "dataFormatters": [],
+			  "facet": {
+				"showOtherSeries": false
+			  },
+			  "nrqlQueries": [
+				{
+				  "accountIds": [
+					0
+				  ],
+				  "query": "FROM Metric SELECT if(latest(upsBatteryStatus) = 'batteryNormal', 0, 1) FACET upsBatteryStatus WHERE provider = 'kentik-ups'"
+				}
+			  ],
+			  "platformOptions": {
+				"ignoreTimeRange": false
+			  },
+			  "thresholds": [
+				{
+				  "alertSeverity": "WARNING",
+				  "value": 0.1
+				},
+				{
+				  "alertSeverity": "CRITICAL",
+				  "value": 0.2
+				}
+			  ]
+			}
+		  },
+		  {
+			"title": "Battery Temperature",
+			"layout": {
+			  "column": 1,
+			  "row": 5,
+			  "width": 4,
+			  "height": 3
+			},
+			"linkedEntityGuids": null,
+			"visualization": {
+			  "id": "viz.billboard"
+			},
+			"rawConfiguration": {
+			  "dataFormatters": [],
+			  "nrqlQueries": [
+				{
+				  "accountId": 0,
+				  "query": "FROM Metric SELECT latest(kentik.snmp.upsAdvBatteryTemperature) AS 'Celsius', (latest(kentik.snmp.upsAdvBatteryTemperature)*1.8) + 32 AS 'Fahrenheit' WHERE provider = 'kentik-ups'"
+				}
+			  ],
+			  "thresholds": []
+			}
+		  },
+		  {
+			"title": "Time Currently Running on Battery (mins)",
+			"layout": {
+			  "column": 5,
+			  "row": 5,
+			  "width": 4,
+			  "height": 3
+			},
+			"linkedEntityGuids": null,
+			"visualization": {
+			  "id": "viz.bar"
+			},
+			"rawConfiguration": {
+			  "facet": {
+				"showOtherSeries": false
+			  },
+			  "nrqlQueries": [
+				{
+				  "accountId": 0,
+				  "query": "FROM Metric SELECT latest(kentik.snmp.upsBasicBatteryTimeOnBattery)*.01/60 AS 'Time on Battery (mins)' WHERE provider = 'kentik-ups'"
+				}
+			  ]
+			}
+		  },
+		  {
+			"title": "Battery Run Time Remaining (mins)",
+			"layout": {
+			  "column": 9,
+			  "row": 5,
+			  "width": 4,
+			  "height": 3
+			},
+			"linkedEntityGuids": null,
+			"visualization": {
+			  "id": "viz.bar"
+			},
+			"rawConfiguration": {
+			  "facet": {
+				"showOtherSeries": false
+			  },
+			  "nrqlQueries": [
+				{
+				  "accountId": 0,
+				  "query": "FROM Metric SELECT latest(kentik.snmp.upsAdvBatteryRunTimeRemaining)*.01/60 AS 'Battery Run Time Remaining (mins)' WHERE provider = 'kentik-ups'"
+				}
+			  ]
+			}
+		  }
+		]
+	  }
+	],
+	"variables": []
+  }

--- a/definitions/ext-ups/kentik-apc_ups-dashboard.json
+++ b/definitions/ext-ups/kentik-apc_ups-dashboard.json
@@ -14,7 +14,6 @@
 			  "width": 2,
 			  "height": 4
 			},
-			"linkedEntityGuids": null,
 			"visualization": {
 			  "id": "viz.billboard"
 			},
@@ -54,7 +53,6 @@
 			  "width": 2,
 			  "height": 2
 			},
-			"linkedEntityGuids": null,
 			"visualization": {
 			  "id": "viz.billboard"
 			},
@@ -94,7 +92,6 @@
 			  "width": 8,
 			  "height": 4
 			},
-			"linkedEntityGuids": null,
 			"visualization": {
 			  "id": "viz.line"
 			},
@@ -126,7 +123,6 @@
 			  "width": 2,
 			  "height": 2
 			},
-			"linkedEntityGuids": null,
 			"visualization": {
 			  "id": "viz.billboard"
 			},
@@ -166,7 +162,6 @@
 			  "width": 4,
 			  "height": 3
 			},
-			"linkedEntityGuids": null,
 			"visualization": {
 			  "id": "viz.billboard"
 			},
@@ -189,7 +184,6 @@
 			  "width": 4,
 			  "height": 3
 			},
-			"linkedEntityGuids": null,
 			"visualization": {
 			  "id": "viz.bar"
 			},
@@ -213,7 +207,6 @@
 			  "width": 4,
 			  "height": 3
 			},
-			"linkedEntityGuids": null,
 			"visualization": {
 			  "id": "viz.bar"
 			},
@@ -231,6 +224,5 @@
 		  }
 		]
 	  }
-	],
-	"variables": []
+	]
   }

--- a/definitions/ext-ups/kentik-apc_ups-dashboard.json
+++ b/definitions/ext-ups/kentik-apc_ups-dashboard.json
@@ -34,9 +34,7 @@
 			  },
 			  "nrqlQueries": [
 				{
-				  "accountIds": [
-					0
-				  ],
+				  "accountId": 0,
 				  "query": "FROM Metric SELECT latest(device_name) AS 'Device Name', latest(src_addr) AS 'Device IP', latest(SysObjectID) AS 'SysObjectID', latest(entity.type) AS 'NR Entity Type', latest(instrumentation.name) AS 'Ktranslate Profile', latest(kentik.snmp.Uptime)/8640000 AS 'Uptime (Days)', latest(timestamp) AS 'Last Update', latest(PollingHealth) AS 'Current Polling Health', latest(PollingHealthReason) AS 'Health Reason' WHERE provider = 'kentik-ups'"
 				}
 			  ],
@@ -63,9 +61,7 @@
 			  },
 			  "nrqlQueries": [
 				{
-				  "accountIds": [
-					0
-				  ],
+				  "accountId": 0,
 				  "query": "FROM Metric SELECT if(latest(upsAdvBatteryReplaceIndicator) = 'noBatteryNeedsReplacing', 0, 1) FACET upsAdvBatteryReplaceIndicator WHERE provider = 'kentik-ups'"
 				}
 			  ],
@@ -133,9 +129,7 @@
 			  },
 			  "nrqlQueries": [
 				{
-				  "accountIds": [
-					0
-				  ],
+				  "accountId": 0,
 				  "query": "FROM Metric SELECT if(latest(upsBatteryStatus) = 'batteryNormal', 0, 1) FACET upsBatteryStatus WHERE provider = 'kentik-ups'"
 				}
 			  ],

--- a/definitions/ext-ups/kentik-ups-dashboard.json
+++ b/definitions/ext-ups/kentik-ups-dashboard.json
@@ -47,84 +47,12 @@
 			}
 		  },
 		  {
-			"title": "Battery Replacement Indicator",
-			"layout": {
-			  "column": 3,
-			  "row": 1,
-			  "width": 2,
-			  "height": 2
-			},
-			"linkedEntityGuids": null,
-			"visualization": {
-			  "id": "viz.billboard"
-			},
-			"rawConfiguration": {
-			  "dataFormatters": [],
-			  "facet": {
-				"showOtherSeries": false
-			  },
-			  "nrqlQueries": [
-				{
-				  "accountIds": [
-					0
-				  ],
-				  "query": "FROM Metric SELECT if(latest(upsAdvBatteryReplaceIndicator) = 'noBatteryNeedsReplacing', 0, 1) FACET upsAdvBatteryReplaceIndicator WHERE provider = 'kentik-ups'"
-				}
-			  ],
-			  "platformOptions": {
-				"ignoreTimeRange": false
-			  },
-			  "thresholds": [
-				{
-				  "alertSeverity": "WARNING",
-				  "value": 0.1
-				},
-				{
-				  "alertSeverity": "CRITICAL",
-				  "value": 0.2
-				}
-			  ]
-			}
-		  },
-		  {
-			"title": "Output Load Capacity %",
-			"layout": {
-			  "column": 5,
-			  "row": 1,
-			  "width": 8,
-			  "height": 4
-			},
-			"linkedEntityGuids": null,
-			"visualization": {
-			  "id": "viz.line"
-			},
-			"rawConfiguration": {
-			  "facet": {
-				"showOtherSeries": false
-			  },
-			  "legend": {
-				"enabled": true
-			  },
-			  "nrqlQueries": [
-				{
-				  "accountId": 0,
-				  "query": "FROM Metric SELECT latest(kentik.snmp.upsAdvOutputLoad) AS 'Output Load %' WHERE provider = 'kentik-ups' TIMESERIES 5 MINUTES"
-				}
-			  ],
-			  "yAxisLeft": {
-				"max": 100,
-				"min": 0,
-				"zero": false
-			  }
-			}
-		  },
-		  {
 			"title": "Battery Status",
 			"layout": {
 			  "column": 3,
-			  "row": 3,
+			  "row": 1,
 			  "width": 2,
-			  "height": 2
+			  "height": 4
 			},
 			"linkedEntityGuids": null,
 			"visualization": {
@@ -149,13 +77,79 @@
 			  "thresholds": [
 				{
 				  "alertSeverity": "WARNING",
-				  "value": 0.5
+				  "value": 0.1
 				},
 				{
 				  "alertSeverity": "CRITICAL",
-				  "value": 0.9
+				  "value": 0.2
 				}
 			  ]
+			}
+		  },
+		  {
+			"title": "Battery Summary",
+			"layout": {
+			  "column": 5,
+			  "row": 1,
+			  "width": 3,
+			  "height": 4
+			},
+			"linkedEntityGuids": null,
+			"visualization": {
+			  "id": "viz.billboard"
+			},
+			"rawConfiguration": {
+			  "facet": {
+				"showOtherSeries": false
+			  },
+			  "nrqlQueries": [
+				{
+				  "accountIds": [
+					0
+				  ],
+				  "query": "FROM Metric SELECT latest(kentik.snmp.upsEstimatedChargeRemaining) AS 'Battery Charge (%)', latest(upsTestResultsDetail) AS 'Latest Test Results' WHERE provider = 'kentik-ups'"
+				}
+			  ],
+			  "platformOptions": {
+				"ignoreTimeRange": false
+			  }
+			}
+		  },
+		  {
+			"title": "Output Load Capacity %",
+			"layout": {
+			  "column": 8,
+			  "row": 1,
+			  "width": 5,
+			  "height": 4
+			},
+			"linkedEntityGuids": null,
+			"visualization": {
+			  "id": "viz.line"
+			},
+			"rawConfiguration": {
+			  "facet": {
+				"showOtherSeries": false
+			  },
+			  "legend": {
+				"enabled": true
+			  },
+			  "nrqlQueries": [
+				{
+				  "accountIds": [
+					0
+				  ],
+				  "query": "FROM Metric SELECT latest(kentik.snmp.upsOutputPercentLoad) AS 'Output Load %' WHERE provider = 'kentik-ups' TIMESERIES 5 MINUTES"
+				}
+			  ],
+			  "platformOptions": {
+				"ignoreTimeRange": false
+			  },
+			  "yAxisLeft": {
+				"max": 100,
+				"min": 0,
+				"zero": false
+			  }
 			}
 		  },
 		  {
@@ -172,13 +166,20 @@
 			},
 			"rawConfiguration": {
 			  "dataFormatters": [],
+			  "facet": {
+				"showOtherSeries": false
+			  },
 			  "nrqlQueries": [
 				{
-				  "accountId": 0,
-				  "query": "FROM Metric SELECT latest(kentik.snmp.upsAdvBatteryTemperature) AS 'Celsius', (latest(kentik.snmp.upsAdvBatteryTemperature)*1.8) + 32 AS 'Fahrenheit' WHERE provider = 'kentik-ups'"
+				  "accountIds": [
+					0
+				  ],
+				  "query": "FROM Metric SELECT latest(kentik.snmp.upsBatteryTemperature) AS 'Celsius', (latest(kentik.snmp.upsBatteryTemperature)*1.8) + 32 AS 'Fahrenheit' WHERE provider = 'kentik-ups'"
 				}
 			  ],
-			  "thresholds": []
+			  "platformOptions": {
+				"ignoreTimeRange": false
+			  }
 			}
 		  },
 		  {
@@ -199,10 +200,15 @@
 			  },
 			  "nrqlQueries": [
 				{
-				  "accountId": 0,
-				  "query": "FROM Metric SELECT latest(kentik.snmp.upsBasicBatteryTimeOnBattery)*.01/60 AS 'Time on Battery (mins)' WHERE provider = 'kentik-ups'"
+				  "accountIds": [
+					0
+				  ],
+				  "query": "FROM Metric SELECT latest(kentik.snmp.upsSecondsOnBattery)*.01/60 FACET cases(WHERE metricName = 'kentik.snmp.upsSecondsOnBattery' AS 'Time on Battery (mins)') WHERE provider = 'kentik-ups'"
 				}
-			  ]
+			  ],
+			  "platformOptions": {
+				"ignoreTimeRange": false
+			  }
 			}
 		  },
 		  {
@@ -223,14 +229,19 @@
 			  },
 			  "nrqlQueries": [
 				{
-				  "accountId": 0,
-				  "query": "FROM Metric SELECT latest(kentik.snmp.upsAdvBatteryRunTimeRemaining)*.01/60 AS 'Battery Run Time Remaining (mins)' WHERE provider = 'kentik-ups'"
+				  "accountIds": [
+					0
+				  ],
+				  "query": "FROM Metric SELECT latest(kentik.snmp.upsEstimatedMinutesRemaining) FACET cases(WHERE metricName = 'kentik.snmp.upsEstimatedMinutesRemaining' AS 'Battery Run Time Remaining (mins)') WHERE provider = 'kentik-ups'"
 				}
-			  ]
+			  ],
+			  "platformOptions": {
+				"ignoreTimeRange": false
+			  }
 			}
 		  }
 		]
 	  }
 	],
 	"variables": []
-}
+  }

--- a/definitions/ext-ups/kentik-ups-dashboard.json
+++ b/definitions/ext-ups/kentik-ups-dashboard.json
@@ -2,195 +2,235 @@
 	"name": "Kentik - UPS",
 	"description": null,
 	"pages": [
-		{
-			"name": "Kentik - UPS",
-			"description": null,
-			"widgets": [
+	  {
+		"name": "Kentik - UPS",
+		"description": null,
+		"widgets": [
+		  {
+			"title": "Summary",
+			"layout": {
+			  "column": 1,
+			  "row": 1,
+			  "width": 2,
+			  "height": 4
+			},
+			"linkedEntityGuids": null,
+			"visualization": {
+			  "id": "viz.billboard"
+			},
+			"rawConfiguration": {
+			  "dataFormatters": [
 				{
-					"visualization": {
-						"id": "viz.bar"
-					},
-					"layout": {
-						"column": 1,
-						"row": 1,
-						"height": 3,
-						"width": 4
-					},
-					"title": "Device Uptime (Hours)",
-					"rawConfiguration": {
-						"facet": {
-							"showOtherSeries": false
-						},
-						"nrqlQueries": [
-							{
-								"accountId": 0,
-								"query": "FROM Metric SELECT latest(`kentik.snmp.Uptime`)/100/60/60 AS 'Hours' WHERE provider = 'kentik-ups' LIMIT MAX"
-							}
-						]
-					}
+				  "name": "Uptime (Days)",
+				  "precision": 2,
+				  "type": "decimal"
 				},
 				{
-					"visualization": {
-						"id": "viz.bar"
-					},
-					"layout": {
-						"column": 5,
-						"row": 1,
-						"height": 3,
-						"width": 4
-					},
-					"title": "Time Currently Running on Battery (mins)",
-					"rawConfiguration": {
-						"facet": {
-							"showOtherSeries": false
-						},
-						"nrqlQueries": [
-							{
-								"accountId": 0,
-								"query": "FROM Metric SELECT latest(kentik.snmp.upsSecondsOnBattery)/60 AS 'Time on Battery (mins)' WHERE provider = 'kentik-ups'"
-							}
-						]
-					}
-				},
-				{
-					"visualization": {
-						"id": "viz.bar"
-					},
-					"layout": {
-						"column": 9,
-						"row": 1,
-						"height": 3,
-						"width": 4
-					},
-					"title": "Battery Run Time Remaining (mins)",
-					"rawConfiguration": {
-						"facet": {
-							"showOtherSeries": false
-						},
-						"nrqlQueries": [
-							{
-								"accountId": 0,
-								"query": "FROM Metric SELECT latest(kentik.snmp.upsEstimatedMinutesRemaining) AS 'Battery Run Time Remaining (mins)' WHERE provider = 'kentik-ups'"
-							}
-						]
-					}
-				},
-				{
-					"visualization": {
-						"id": "viz.line"
-					},
-					"layout": {
-						"column": 1,
-						"row": 4,
-						"height": 3,
-						"width": 4
-					},
-					"title": "Output Load Capacity %",
-					"rawConfiguration": {
-						"facet": {
-							"showOtherSeries": false
-						},
-						"legend": {
-							"enabled": true
-						},
-						"nrqlQueries": [
-							{
-								"accountId": 0,
-								"query": "FROM Metric SELECT max(kentik.snmp.upsOutputPercentLoad) AS 'Output Load %' FACET Index WHERE provider = 'kentik-ups' TIMESERIES 5 MINUTES"
-							}
-						],
-						"yAxisLeft": {
-							"max": 100,
-							"min": 0,
-							"zero": false
-						}
-					}
-				},
-				{
-					"visualization": {
-						"id": "viz.billboard"
-					},
-					"layout": {
-						"column": 5,
-						"row": 4,
-						"height": 3,
-						"width": 2
-					},
-					"title": "Battery Capacity Status (1 == Unknown, 2 == Normal, 3 == Low, 4 == Depleted)",
-					"rawConfiguration": {
-						"dataFormatters": [],
-						"nrqlQueries": [
-							{
-								"accountId": 0,
-								"query": "FROM Metric SELECT latest(kentik.snmp.upsBatteryStatus) AS 'Battery Status' WHERE provider = 'kentik-ups'"
-							}
-						],
-						"thresholds": [
-							{
-								"alertSeverity": "WARNING",
-								"value": 3
-							},
-							{
-								"alertSeverity": "CRITICAL",
-								"value": 4
-							}
-						]
-					}
-				},
-				{
-					"visualization": {
-						"id": "viz.billboard"
-					},
-					"layout": {
-						"column": 7,
-						"row": 4,
-						"height": 3,
-						"width": 2
-					},
-					"title": "Active Alarm Conditions (Count)",
-					"rawConfiguration": {
-						"dataFormatters": [],
-						"nrqlQueries": [
-							{
-								"accountId": 0,
-								"query": "FROM Metric SELECT latest(kentik.snmp.upsAlarmsPresent) AS 'Active Alarm Conditions' WHERE provider = 'kentik-ups'"
-							}
-						],
-						"thresholds": [
-							{
-								"alertSeverity": "WARNING",
-								"value": 0.5
-							},
-							{
-								"alertSeverity": "CRITICAL",
-								"value": 0.9
-							}
-						]
-					}
-				},
-				{
-					"visualization": {
-						"id": "viz.billboard"
-					},
-					"layout": {
-						"column": 9,
-						"row": 4,
-						"height": 3,
-						"width": 4
-					},
-					"title": "Battery Temperature",
-					"rawConfiguration": {
-						"dataFormatters": [],
-						"nrqlQueries": [
-							{
-								"accountId": 0,
-								"query": "FROM Metric SELECT latest(kentik.snmp.upsBatteryTemperature) AS 'Celsius', (latest(kentik.snmp.upsBatteryTemperature)*1.8) + 32 AS 'Fahrenheit' WHERE provider = 'kentik-ups'"
-							}
-						],
-						"thresholds": []
-					}
+				  "name": "Last Update",
+				  "type": "date"
 				}
-			]
-		}
-	]
+			  ],
+			  "facet": {
+				"showOtherSeries": false
+			  },
+			  "nrqlQueries": [
+				{
+				  "accountIds": [
+					0
+				  ],
+				  "query": "FROM Metric SELECT latest(device_name) AS 'Device Name', latest(src_addr) AS 'Device IP', latest(SysObjectID) AS 'SysObjectID', latest(entity.type) AS 'NR Entity Type', latest(instrumentation.name) AS 'Ktranslate Profile', latest(kentik.snmp.Uptime)/8640000 AS 'Uptime (Days)', latest(timestamp) AS 'Last Update', latest(PollingHealth) AS 'Current Polling Health', latest(PollingHealthReason) AS 'Health Reason' WHERE provider = 'kentik-ups'"
+				}
+			  ],
+			  "platformOptions": {
+				"ignoreTimeRange": false
+			  }
+			}
+		  },
+		  {
+			"title": "Battery Replacement Indicator",
+			"layout": {
+			  "column": 3,
+			  "row": 1,
+			  "width": 2,
+			  "height": 2
+			},
+			"linkedEntityGuids": null,
+			"visualization": {
+			  "id": "viz.billboard"
+			},
+			"rawConfiguration": {
+			  "dataFormatters": [],
+			  "facet": {
+				"showOtherSeries": false
+			  },
+			  "nrqlQueries": [
+				{
+				  "accountIds": [
+					0
+				  ],
+				  "query": "FROM Metric SELECT if(latest(upsAdvBatteryReplaceIndicator) = 'noBatteryNeedsReplacing', 0, 1) FACET upsAdvBatteryReplaceIndicator WHERE provider = 'kentik-ups'"
+				}
+			  ],
+			  "platformOptions": {
+				"ignoreTimeRange": false
+			  },
+			  "thresholds": [
+				{
+				  "alertSeverity": "WARNING",
+				  "value": 0.1
+				},
+				{
+				  "alertSeverity": "CRITICAL",
+				  "value": 0.2
+				}
+			  ]
+			}
+		  },
+		  {
+			"title": "Output Load Capacity %",
+			"layout": {
+			  "column": 5,
+			  "row": 1,
+			  "width": 8,
+			  "height": 4
+			},
+			"linkedEntityGuids": null,
+			"visualization": {
+			  "id": "viz.line"
+			},
+			"rawConfiguration": {
+			  "facet": {
+				"showOtherSeries": false
+			  },
+			  "legend": {
+				"enabled": true
+			  },
+			  "nrqlQueries": [
+				{
+				  "accountId": 0,
+				  "query": "FROM Metric SELECT latest(kentik.snmp.upsAdvOutputLoad) AS 'Output Load %' WHERE provider = 'kentik-ups' TIMESERIES 5 MINUTES"
+				}
+			  ],
+			  "yAxisLeft": {
+				"max": 100,
+				"min": 0,
+				"zero": false
+			  }
+			}
+		  },
+		  {
+			"title": "Battery Status",
+			"layout": {
+			  "column": 3,
+			  "row": 3,
+			  "width": 2,
+			  "height": 2
+			},
+			"linkedEntityGuids": null,
+			"visualization": {
+			  "id": "viz.billboard"
+			},
+			"rawConfiguration": {
+			  "dataFormatters": [],
+			  "facet": {
+				"showOtherSeries": false
+			  },
+			  "nrqlQueries": [
+				{
+				  "accountIds": [
+					0
+				  ],
+				  "query": "FROM Metric SELECT if(latest(upsBatteryStatus) = 'batteryNormal', 0, 1) FACET upsBatteryStatus WHERE provider = 'kentik-ups'"
+				}
+			  ],
+			  "platformOptions": {
+				"ignoreTimeRange": false
+			  },
+			  "thresholds": [
+				{
+				  "alertSeverity": "WARNING",
+				  "value": 0.5
+				},
+				{
+				  "alertSeverity": "CRITICAL",
+				  "value": 0.9
+				}
+			  ]
+			}
+		  },
+		  {
+			"title": "Battery Temperature",
+			"layout": {
+			  "column": 1,
+			  "row": 5,
+			  "width": 4,
+			  "height": 3
+			},
+			"linkedEntityGuids": null,
+			"visualization": {
+			  "id": "viz.billboard"
+			},
+			"rawConfiguration": {
+			  "dataFormatters": [],
+			  "nrqlQueries": [
+				{
+				  "accountId": 0,
+				  "query": "FROM Metric SELECT latest(kentik.snmp.upsAdvBatteryTemperature) AS 'Celsius', (latest(kentik.snmp.upsAdvBatteryTemperature)*1.8) + 32 AS 'Fahrenheit' WHERE provider = 'kentik-ups'"
+				}
+			  ],
+			  "thresholds": []
+			}
+		  },
+		  {
+			"title": "Time Currently Running on Battery (mins)",
+			"layout": {
+			  "column": 5,
+			  "row": 5,
+			  "width": 4,
+			  "height": 3
+			},
+			"linkedEntityGuids": null,
+			"visualization": {
+			  "id": "viz.bar"
+			},
+			"rawConfiguration": {
+			  "facet": {
+				"showOtherSeries": false
+			  },
+			  "nrqlQueries": [
+				{
+				  "accountId": 0,
+				  "query": "FROM Metric SELECT latest(kentik.snmp.upsBasicBatteryTimeOnBattery)*.01/60 AS 'Time on Battery (mins)' WHERE provider = 'kentik-ups'"
+				}
+			  ]
+			}
+		  },
+		  {
+			"title": "Battery Run Time Remaining (mins)",
+			"layout": {
+			  "column": 9,
+			  "row": 5,
+			  "width": 4,
+			  "height": 3
+			},
+			"linkedEntityGuids": null,
+			"visualization": {
+			  "id": "viz.bar"
+			},
+			"rawConfiguration": {
+			  "facet": {
+				"showOtherSeries": false
+			  },
+			  "nrqlQueries": [
+				{
+				  "accountId": 0,
+				  "query": "FROM Metric SELECT latest(kentik.snmp.upsAdvBatteryRunTimeRemaining)*.01/60 AS 'Battery Run Time Remaining (mins)' WHERE provider = 'kentik-ups'"
+				}
+			  ]
+			}
+		  }
+		]
+	  }
+	],
+	"variables": []
 }

--- a/definitions/ext-ups/kentik-ups-dashboard.json
+++ b/definitions/ext-ups/kentik-ups-dashboard.json
@@ -34,9 +34,7 @@
 			  },
 			  "nrqlQueries": [
 				{
-				  "accountIds": [
-					0
-				  ],
+				  "accountId": 0,
 				  "query": "FROM Metric SELECT latest(device_name) AS 'Device Name', latest(src_addr) AS 'Device IP', latest(SysObjectID) AS 'SysObjectID', latest(entity.type) AS 'NR Entity Type', latest(instrumentation.name) AS 'Ktranslate Profile', latest(kentik.snmp.Uptime)/8640000 AS 'Uptime (Days)', latest(timestamp) AS 'Last Update', latest(PollingHealth) AS 'Current Polling Health', latest(PollingHealthReason) AS 'Health Reason' WHERE provider = 'kentik-ups'"
 				}
 			  ],
@@ -63,9 +61,7 @@
 			  },
 			  "nrqlQueries": [
 				{
-				  "accountIds": [
-					0
-				  ],
+				  "accountId": 0,
 				  "query": "FROM Metric SELECT if(latest(upsBatteryStatus) = 'batteryNormal', 0, 1) FACET upsBatteryStatus WHERE provider = 'kentik-ups'"
 				}
 			  ],
@@ -101,9 +97,7 @@
 			  },
 			  "nrqlQueries": [
 				{
-				  "accountIds": [
-					0
-				  ],
+				  "accountId": 0,
 				  "query": "FROM Metric SELECT latest(kentik.snmp.upsEstimatedChargeRemaining) AS 'Battery Charge (%)', latest(upsTestResultsDetail) AS 'Latest Test Results' WHERE provider = 'kentik-ups'"
 				}
 			  ],
@@ -132,9 +126,7 @@
 			  },
 			  "nrqlQueries": [
 				{
-				  "accountIds": [
-					0
-				  ],
+				  "accountId": 0,
 				  "query": "FROM Metric SELECT latest(kentik.snmp.upsOutputPercentLoad) AS 'Output Load %' WHERE provider = 'kentik-ups' TIMESERIES 5 MINUTES"
 				}
 			  ],
@@ -166,9 +158,7 @@
 			  },
 			  "nrqlQueries": [
 				{
-				  "accountIds": [
-					0
-				  ],
+				  "accountId": 0,
 				  "query": "FROM Metric SELECT latest(kentik.snmp.upsBatteryTemperature) AS 'Celsius', (latest(kentik.snmp.upsBatteryTemperature)*1.8) + 32 AS 'Fahrenheit' WHERE provider = 'kentik-ups'"
 				}
 			  ],
@@ -194,9 +184,7 @@
 			  },
 			  "nrqlQueries": [
 				{
-				  "accountIds": [
-					0
-				  ],
+				  "accountId": 0,
 				  "query": "FROM Metric SELECT latest(kentik.snmp.upsSecondsOnBattery)*.01/60 FACET cases(WHERE metricName = 'kentik.snmp.upsSecondsOnBattery' AS 'Time on Battery (mins)') WHERE provider = 'kentik-ups'"
 				}
 			  ],
@@ -222,9 +210,7 @@
 			  },
 			  "nrqlQueries": [
 				{
-				  "accountIds": [
-					0
-				  ],
+				  "accountId": 0,
 				  "query": "FROM Metric SELECT latest(kentik.snmp.upsEstimatedMinutesRemaining) FACET cases(WHERE metricName = 'kentik.snmp.upsEstimatedMinutesRemaining' AS 'Battery Run Time Remaining (mins)') WHERE provider = 'kentik-ups'"
 				}
 			  ],

--- a/definitions/ext-ups/kentik-ups-dashboard.json
+++ b/definitions/ext-ups/kentik-ups-dashboard.json
@@ -14,7 +14,6 @@
 			  "width": 2,
 			  "height": 4
 			},
-			"linkedEntityGuids": null,
 			"visualization": {
 			  "id": "viz.billboard"
 			},
@@ -54,7 +53,6 @@
 			  "width": 2,
 			  "height": 4
 			},
-			"linkedEntityGuids": null,
 			"visualization": {
 			  "id": "viz.billboard"
 			},
@@ -94,7 +92,6 @@
 			  "width": 3,
 			  "height": 4
 			},
-			"linkedEntityGuids": null,
 			"visualization": {
 			  "id": "viz.billboard"
 			},
@@ -123,7 +120,6 @@
 			  "width": 5,
 			  "height": 4
 			},
-			"linkedEntityGuids": null,
 			"visualization": {
 			  "id": "viz.line"
 			},
@@ -160,7 +156,6 @@
 			  "width": 4,
 			  "height": 3
 			},
-			"linkedEntityGuids": null,
 			"visualization": {
 			  "id": "viz.billboard"
 			},
@@ -190,7 +185,6 @@
 			  "width": 4,
 			  "height": 3
 			},
-			"linkedEntityGuids": null,
 			"visualization": {
 			  "id": "viz.bar"
 			},
@@ -219,7 +213,6 @@
 			  "width": 4,
 			  "height": 3
 			},
-			"linkedEntityGuids": null,
 			"visualization": {
 			  "id": "viz.bar"
 			},
@@ -242,6 +235,5 @@
 		  }
 		]
 	  }
-	],
-	"variables": []
+	]
   }

--- a/definitions/ext-ups/kentik-vertiv_ups-dashboard.json
+++ b/definitions/ext-ups/kentik-vertiv_ups-dashboard.json
@@ -14,7 +14,6 @@
               "width": 2,
               "height": 4
             },
-            "linkedEntityGuids": null,
             "visualization": {
               "id": "viz.billboard"
             },
@@ -54,7 +53,6 @@
               "width": 2,
               "height": 4
             },
-            "linkedEntityGuids": null,
             "visualization": {
               "id": "viz.billboard"
             },
@@ -94,7 +92,6 @@
               "width": 3,
               "height": 4
             },
-            "linkedEntityGuids": null,
             "visualization": {
               "id": "viz.billboard"
             },
@@ -123,7 +120,6 @@
               "width": 5,
               "height": 4
             },
-            "linkedEntityGuids": null,
             "visualization": {
               "id": "viz.line"
             },
@@ -160,7 +156,6 @@
               "width": 4,
               "height": 3
             },
-            "linkedEntityGuids": null,
             "visualization": {
               "id": "viz.billboard"
             },
@@ -190,7 +185,6 @@
               "width": 4,
               "height": 3
             },
-            "linkedEntityGuids": null,
             "visualization": {
               "id": "viz.bar"
             },
@@ -219,7 +213,6 @@
               "width": 4,
               "height": 3
             },
-            "linkedEntityGuids": null,
             "visualization": {
               "id": "viz.bar"
             },
@@ -242,6 +235,5 @@
           }
         ]
       }
-    ],
-    "variables": []
+    ]
   }

--- a/definitions/ext-ups/kentik-vertiv_ups-dashboard.json
+++ b/definitions/ext-ups/kentik-vertiv_ups-dashboard.json
@@ -107,7 +107,7 @@
                   "accountIds": [
                     0
                   ],
-                  "query": "FROM Metric SELECT latest(kentik.snmp.gpPwrBatteryCapacity) AS 'Battery Capacity (%)', latest(lgpPwrBatteryChargeStatus) AS 'Battery Charge Status' WHERE entity.type = 'UPS'"
+                  "query": "FROM Metric SELECT latest(kentik.snmp.gpPwrBatteryCapacity) AS 'Battery Capacity (%)', latest(lgpPwrBatteryChargeStatus) AS 'Battery Charge Status' WHERE provider = 'kentik-ups'"
                 }
               ],
               "platformOptions": {

--- a/definitions/ext-ups/kentik-vertiv_ups-dashboard.json
+++ b/definitions/ext-ups/kentik-vertiv_ups-dashboard.json
@@ -1,0 +1,247 @@
+{
+    "name": "Kentik - UPS",
+    "description": null,
+    "pages": [
+      {
+        "name": "Kentik - UPS",
+        "description": null,
+        "widgets": [
+          {
+            "title": "Summary",
+            "layout": {
+              "column": 1,
+              "row": 1,
+              "width": 2,
+              "height": 4
+            },
+            "linkedEntityGuids": null,
+            "visualization": {
+              "id": "viz.billboard"
+            },
+            "rawConfiguration": {
+              "dataFormatters": [
+                {
+                  "name": "Uptime (Days)",
+                  "precision": 2,
+                  "type": "decimal"
+                },
+                {
+                  "name": "Last Update",
+                  "type": "date"
+                }
+              ],
+              "facet": {
+                "showOtherSeries": false
+              },
+              "nrqlQueries": [
+                {
+                  "accountIds": [
+                    0
+                  ],
+                  "query": "FROM Metric SELECT latest(device_name) AS 'Device Name', latest(src_addr) AS 'Device IP', latest(SysObjectID) AS 'SysObjectID', latest(entity.type) AS 'NR Entity Type', latest(instrumentation.name) AS 'Ktranslate Profile', latest(kentik.snmp.Uptime)/8640000 AS 'Uptime (Days)', latest(timestamp) AS 'Last Update', latest(PollingHealth) AS 'Current Polling Health', latest(PollingHealthReason) AS 'Health Reason' WHERE provider = 'kentik-ups'"
+                }
+              ],
+              "platformOptions": {
+                "ignoreTimeRange": false
+              }
+            }
+          },
+          {
+            "title": "Battery Status",
+            "layout": {
+              "column": 3,
+              "row": 1,
+              "width": 2,
+              "height": 4
+            },
+            "linkedEntityGuids": null,
+            "visualization": {
+              "id": "viz.billboard"
+            },
+            "rawConfiguration": {
+              "dataFormatters": [],
+              "facet": {
+                "showOtherSeries": false
+              },
+              "nrqlQueries": [
+                {
+                  "accountIds": [
+                    0
+                  ],
+                  "query": "FROM Metric SELECT if(latest(upsBatteryStatus) = 'batteryNormal', 0, 1) FACET upsBatteryStatus WHERE provider = 'kentik-ups'"
+                }
+              ],
+              "platformOptions": {
+                "ignoreTimeRange": false
+              },
+              "thresholds": [
+                {
+                  "alertSeverity": "WARNING",
+                  "value": 0.1
+                },
+                {
+                  "alertSeverity": "CRITICAL",
+                  "value": 0.2
+                }
+              ]
+            }
+          },
+          {
+            "title": "Battery Summary",
+            "layout": {
+              "column": 5,
+              "row": 1,
+              "width": 3,
+              "height": 4
+            },
+            "linkedEntityGuids": null,
+            "visualization": {
+              "id": "viz.billboard"
+            },
+            "rawConfiguration": {
+              "facet": {
+                "showOtherSeries": false
+              },
+              "nrqlQueries": [
+                {
+                  "accountIds": [
+                    0
+                  ],
+                  "query": "FROM Metric SELECT latest(kentik.snmp.gpPwrBatteryCapacity) AS 'Battery Capacity (%)', latest(lgpPwrBatteryChargeStatus) AS 'Battery Charge Status' WHERE entity.type = 'UPS'"
+                }
+              ],
+              "platformOptions": {
+                "ignoreTimeRange": false
+              }
+            }
+          },
+          {
+            "title": "Output Load Capacity %",
+            "layout": {
+              "column": 8,
+              "row": 1,
+              "width": 5,
+              "height": 4
+            },
+            "linkedEntityGuids": null,
+            "visualization": {
+              "id": "viz.line"
+            },
+            "rawConfiguration": {
+              "facet": {
+                "showOtherSeries": false
+              },
+              "legend": {
+                "enabled": true
+              },
+              "nrqlQueries": [
+                {
+                  "accountIds": [
+                    0
+                  ],
+                  "query": "FROM Metric SELECT latest(kentik.snmp.upsOutputPercentLoad) AS 'Output Load %' WHERE provider = 'kentik-ups' TIMESERIES 5 MINUTES"
+                }
+              ],
+              "platformOptions": {
+                "ignoreTimeRange": false
+              },
+              "yAxisLeft": {
+                "max": 100,
+                "min": 0,
+                "zero": false
+              }
+            }
+          },
+          {
+            "title": "Battery Temperature",
+            "layout": {
+              "column": 1,
+              "row": 5,
+              "width": 4,
+              "height": 3
+            },
+            "linkedEntityGuids": null,
+            "visualization": {
+              "id": "viz.billboard"
+            },
+            "rawConfiguration": {
+              "dataFormatters": [],
+              "facet": {
+                "showOtherSeries": false
+              },
+              "nrqlQueries": [
+                {
+                  "accountIds": [
+                    0
+                  ],
+                  "query": "FROM Metric SELECT latest(kentik.snmp.lgpEnvTemperatureMeasurementDegC) AS 'Celsius', (latest(kentik.snmp.lgpEnvTemperatureMeasurementDegC)*1.8) + 32 AS 'Fahrenheit' WHERE provider = 'kentik-ups'"
+                }
+              ],
+              "platformOptions": {
+                "ignoreTimeRange": false
+              }
+            }
+          },
+          {
+            "title": "Time Currently Running on Battery (mins)",
+            "layout": {
+              "column": 5,
+              "row": 5,
+              "width": 4,
+              "height": 3
+            },
+            "linkedEntityGuids": null,
+            "visualization": {
+              "id": "viz.bar"
+            },
+            "rawConfiguration": {
+              "facet": {
+                "showOtherSeries": false
+              },
+              "nrqlQueries": [
+                {
+                  "accountIds": [
+                    0
+                  ],
+                  "query": "FROM Metric SELECT latest(kentik.snmp.upsSecondsOnBattery)*.01/60 FACET cases(WHERE metricName = 'kentik.snmp.upsSecondsOnBattery' AS 'Time on Battery (mins)') WHERE provider = 'kentik-ups'"
+                }
+              ],
+              "platformOptions": {
+                "ignoreTimeRange": false
+              }
+            }
+          },
+          {
+            "title": "Battery Run Time Remaining (mins)",
+            "layout": {
+              "column": 9,
+              "row": 5,
+              "width": 4,
+              "height": 3
+            },
+            "linkedEntityGuids": null,
+            "visualization": {
+              "id": "viz.bar"
+            },
+            "rawConfiguration": {
+              "facet": {
+                "showOtherSeries": false
+              },
+              "nrqlQueries": [
+                {
+                  "accountIds": [
+                    0
+                  ],
+                  "query": "FROM Metric SELECT latest(kentik.snmp.upsEstimatedMinutesRemaining) FACET cases(WHERE metricName = 'kentik.snmp.upsEstimatedMinutesRemaining' AS 'Battery Run Time Remaining (mins)') WHERE provider = 'kentik-ups'"
+                }
+              ],
+              "platformOptions": {
+                "ignoreTimeRange": false
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "variables": []
+  }

--- a/definitions/ext-ups/kentik-vertiv_ups-dashboard.json
+++ b/definitions/ext-ups/kentik-vertiv_ups-dashboard.json
@@ -34,9 +34,7 @@
               },
               "nrqlQueries": [
                 {
-                  "accountIds": [
-                    0
-                  ],
+                  "accountId": 0,
                   "query": "FROM Metric SELECT latest(device_name) AS 'Device Name', latest(src_addr) AS 'Device IP', latest(SysObjectID) AS 'SysObjectID', latest(entity.type) AS 'NR Entity Type', latest(instrumentation.name) AS 'Ktranslate Profile', latest(kentik.snmp.Uptime)/8640000 AS 'Uptime (Days)', latest(timestamp) AS 'Last Update', latest(PollingHealth) AS 'Current Polling Health', latest(PollingHealthReason) AS 'Health Reason' WHERE provider = 'kentik-ups'"
                 }
               ],
@@ -63,9 +61,7 @@
               },
               "nrqlQueries": [
                 {
-                  "accountIds": [
-                    0
-                  ],
+                  "accountId": 0,
                   "query": "FROM Metric SELECT if(latest(upsBatteryStatus) = 'batteryNormal', 0, 1) FACET upsBatteryStatus WHERE provider = 'kentik-ups'"
                 }
               ],
@@ -101,9 +97,7 @@
               },
               "nrqlQueries": [
                 {
-                  "accountIds": [
-                    0
-                  ],
+                  "accountId": 0,
                   "query": "FROM Metric SELECT latest(kentik.snmp.gpPwrBatteryCapacity) AS 'Battery Capacity (%)', latest(lgpPwrBatteryChargeStatus) AS 'Battery Charge Status' WHERE provider = 'kentik-ups'"
                 }
               ],
@@ -132,9 +126,7 @@
               },
               "nrqlQueries": [
                 {
-                  "accountIds": [
-                    0
-                  ],
+                  "accountId": 0,
                   "query": "FROM Metric SELECT latest(kentik.snmp.upsOutputPercentLoad) AS 'Output Load %' WHERE provider = 'kentik-ups' TIMESERIES 5 MINUTES"
                 }
               ],
@@ -166,9 +158,7 @@
               },
               "nrqlQueries": [
                 {
-                  "accountIds": [
-                    0
-                  ],
+                  "accountId": 0,
                   "query": "FROM Metric SELECT latest(kentik.snmp.lgpEnvTemperatureMeasurementDegC) AS 'Celsius', (latest(kentik.snmp.lgpEnvTemperatureMeasurementDegC)*1.8) + 32 AS 'Fahrenheit' WHERE provider = 'kentik-ups'"
                 }
               ],
@@ -194,9 +184,7 @@
               },
               "nrqlQueries": [
                 {
-                  "accountIds": [
-                    0
-                  ],
+                  "accountId": 0,
                   "query": "FROM Metric SELECT latest(kentik.snmp.upsSecondsOnBattery)*.01/60 FACET cases(WHERE metricName = 'kentik.snmp.upsSecondsOnBattery' AS 'Time on Battery (mins)') WHERE provider = 'kentik-ups'"
                 }
               ],
@@ -222,9 +210,7 @@
               },
               "nrqlQueries": [
                 {
-                  "accountIds": [
-                    0
-                  ],
+                  "accountId": 0,
                   "query": "FROM Metric SELECT latest(kentik.snmp.upsEstimatedMinutesRemaining) FACET cases(WHERE metricName = 'kentik.snmp.upsEstimatedMinutesRemaining' AS 'Battery Run Time Remaining (mins)') WHERE provider = 'kentik-ups'"
                 }
               ],


### PR DESCRIPTION
### Relevant information

Updating the existing `EXT_UPS` entity dashboards to align with consistent styling in other network entities. 
Also adding new telemetry source `instrumentation.name: vertiv-ups` to the definition.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
