### PR TITLE
chore: add default provider to GM definition

### DIFF
--- a/definitions/ext-environment_sensor/golden_metrics.yml
+++ b/definitions/ext-environment_sensor/golden_metrics.yml
@@ -2,7 +2,13 @@ uptime:
   title: Uptime
   unit: SECONDS
   queries:
-    # APC Netbotz devices (default)
+    # Default catch-all
+    kentik:
+      select: latest(kentik.snmp.Uptime)/100
+      from: Metric
+      where: "provider = 'kentik-envir-sensor'"
+      eventId: entity.guid
+    # APC Netbotz devices
     kentik/apc-netbotz:
       select: latest(kentik.snmp.Uptime)/100
       from: Metric


### PR DESCRIPTION
### Relevant information

Adding the default provider to the GM definition to capture entities that don't match any other `instrumentation.source/instrumentation.name` pattern

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
