### PR TITLE
Add new attribute to K8s PersistentVolume summary metrics

### DIFF
--- a/definitions/infra-kubernetes_persistentvolume/summary_metrics.yml
+++ b/definitions/infra-kubernetes_persistentvolume/summary_metrics.yml
@@ -3,10 +3,11 @@ cluster:
   unit: STRING
   tag:
     key: k8s.clusterName
-requestedStorageBytes:
-  goldenMetric: requestedStorageBytes
-  unit: BYTES
-  title: Capacity
+status:
+  title: Status
+  unit: STRING
+  tag:
+    key: k8s.persistentvolume.statusPhase
 claimNamespace:
   title: Claim Namespace
   unit: STRING
@@ -22,6 +23,10 @@ storageClass:
   unit: STRING
   tag:
     key: k8s.persistentvolume.storageClass
+requestedStorageBytes:
+  goldenMetric: requestedStorageBytes
+  unit: BYTES
+  title: Capacity
 createdAt:
   goldenMetric: createdAt
   unit: TIMESTAMP


### PR DESCRIPTION
### Relevant information

Rearrange + add a new attribute to the summary metrics for K8s `PersistentVolume` entity. 

### Checklist

* [X] I've read the guidelines and understand the acceptance criteria.
* [X] The value of the attribute marked as `identifier` will be unique and valid. 
* [X] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
