### PR TITLE
Improve CronJob, Job dashboards

### DIFF
--- a/definitions/infra-kubernetes_cronjob/dashboard.json
+++ b/definitions/infra-kubernetes_cronjob/dashboard.json
@@ -256,7 +256,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "FROM Metric WITH k8s.job.completedAt - k8s.job.startedAt AS duration SELECT latest(k8s.namespaceName) AS 'Namespace Name', latest(k8s.job.createdAt * 1000) AS 'Created', latest(k8s.job.startedAt * 1000) AS 'Started', if(latest(k8s.job.isComplete), 'Complete', if(latest(k8s.job.failed), 'Failed', 'Running')) as 'State', if(latest(duration), latest(duration), '-') AS 'Duration (sec)', if(latest(k8s.job.failed), latest(if(k8s.job.failedPodsReason is not null, k8s.job.failedPodsReason, 'No reason provided')), '-') AS 'Failure Reason' FACET k8s.jobName AS 'Job Name' WHERE metricName = 'k8s.job.createdAt' AND k8s.clusterName = '{{{tags.k8s.clusterName}}}' AND k8s.namespaceName = '{{{tags.k8s.namespaceName}}}' AND k8s.jobName LIKE '{{{entity.name}}}-%' LIMIT MAX"
+                "query": "FROM Metric WITH k8s.job.completedAt - k8s.job.startedAt AS duration SELECT latest(k8s.namespaceName) AS 'Namespace Name', latest(k8s.job.createdAt * 1000) AS 'Created', latest(k8s.job.startedAt * 1000) AS 'Started', if(latest(k8s.job.isComplete), 'Complete', if(latest(k8s.job.failed), 'Failed', '-')) as 'State', if(latest(duration), latest(duration), '-') AS 'Duration (sec)', if(latest(k8s.job.failed), latest(if(k8s.job.failedPodsReason is not null, k8s.job.failedPodsReason, 'No reason provided')), '-') AS 'Failure Reason' FACET k8s.jobName AS 'Job Name' WHERE metricName = 'k8s.job.createdAt' AND k8s.clusterName = '{{{tags.k8s.clusterName}}}' AND k8s.namespaceName = '{{{tags.k8s.namespaceName}}}' AND k8s.jobName LIKE '{{{entity.name}}}-%' LIMIT MAX"
               }
             ],
             "platformOptions": {

--- a/definitions/infra-kubernetes_job/dashboard.json
+++ b/definitions/infra-kubernetes_job/dashboard.json
@@ -117,7 +117,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "FROM Metric SELECT if(latest(k8s.job.isComplete), 'Complete', if(latest(k8s.job.failed), 'Failed', 'Running')) as 'State' WHERE metricName = 'k8s.job.createdAt' AND `entity.guid` = '{{entity.id}}'"
+                "query": "FROM Metric SELECT if(latest(k8s.job.isComplete), 'Complete', if(latest(k8s.job.failed), 'Failed', '-')) as 'State' WHERE metricName = 'k8s.job.createdAt' AND `entity.guid` = '{{entity.id}}'"
               }
             ],
             "platformOptions": {


### PR DESCRIPTION
### Relevant information

Currently, we only have status states `Failed` and `Complete`. Assuming that a job can only have a third state `Running` ignores the fact that we could be in `Unknown` state if nothing gets reported.

### Checklist

* [y] I've read the guidelines and understand the acceptance criteria.
* [y] The value of the attribute marked as `identifier` will be unique and valid. 
* [y] I've confirmed that my entity type wasn't already defined. If it is I'm providing an
 explanation above.
