### PR TITLE
feat(Azure Monitor): Adding different entity types based on the kind attribute

### DIFF
--- a/definitions/infra-azurefunctionsapp/definition.yml
+++ b/definitions/infra-azurefunctionsapp/definition.yml
@@ -9,3 +9,45 @@ goldenTags:
 configuration:
   entityExpirationTime: DAILY
   alertable: true
+synthesis:
+  rules:
+    - identifier: azure.resourceId
+      name: displayName
+      legacyFeatures:
+        overrideGuidType: true
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: azure.resourceType
+          value: microsoft.web/sites
+        - attribute: azure.resourceKind
+          value: 'functionapp'
+    - identifier: azure.resourceId
+      name: displayName
+      legacyFeatures:
+        overrideGuidType: true
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: azure.resourceType
+          value: microsoft.web/sites
+        - attribute: azure.resourceKind
+          value: 'functionapp,linux'
+    - identifier: azure.resourceId
+      name: displayName
+      legacyFeatures:
+        overrideGuidType: true
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: azure.resourceType
+          value: microsoft.web/sites
+        - attribute: azure.resourceKind
+          value: 'functionapp,linux,container,kubernetes'
+    - identifier: azure.resourceId
+      name: displayName
+      legacyFeatures:
+        overrideGuidType: true
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: azure.resourceType
+          value: microsoft.web/sites
+        - attribute: azure.resourceKind
+          value: 'functionapp,linux,kubernetes'

--- a/definitions/infra-azurefunctionsapp/tests/MetricRaw.json
+++ b/definitions/infra-azurefunctionsapp/tests/MetricRaw.json
@@ -1,0 +1,39 @@
+[
+  {
+    "azure.metricNamespace": "microsoft.web/sites",
+    "azure.region": "West US",
+    "azure.resourceGroup": "streams",
+    "azure.resourceId": "/subscriptions/9bcb5134-f0a6-11ed-a05b-0242ac120003/resourcegroups/streams/providers/microsoft.web/sites/test",
+    "azure.resourceKind": "functionapp,linux",
+    "azure.resourceName": "test",
+    "azure.resourceType": "microsoft.web/sites",
+    "azure.subscriptionId": "9bcb5134-f0a6-11ed-a05b-0242ac120003",
+    "azure.web.sites.AppConnections": {
+      "type": "summary",
+      "count": 6,
+      "sum": 54,
+      "min": 9,
+      "max": 9
+    },
+    "azure.web.sites.Instance": "1-1-1-1",
+    "collector.name": "azure-monitor",
+    "collector.version": "release-209",
+    "displayName": "test",
+    "endTimestamp": 1683883260000,
+    "entity.guid": "MXxJTkZSQXxOQXwtMjI4MTk4NzE5NDA0NzM0NjcxMQ",
+    "entity.id": "-2281987194047346711",
+    "entity.name": "test",
+    "entity.type": "AZUREFUNCTIONSAPP",
+    "instrumentation.provider": "azure",
+    "metricName": "azure.web.sites.AppConnections",
+    "newrelic.cloudIntegrations.integrationId": "1",
+    "newrelic.cloudIntegrations.integrationName": "Azure Monitor metrics",
+    "newrelic.cloudIntegrations.providerAccountId": "1",
+    "newrelic.cloudIntegrations.providerAccountName": "azure-dev-all-metrics",
+    "newrelic.cloudIntegrations.providerExternalId": "9bcb5134-f0a6-11ed-a05b-0242ac120003",
+    "newrelic.source": "metricAPI",
+    "nr.entity.id": "-2281987194047346711",
+    "tags.owner": "test",
+    "timestamp": 1683883200000
+  }
+]

--- a/definitions/infra-azurewebapp/definition.yml
+++ b/definitions/infra-azurewebapp/definition.yml
@@ -16,3 +16,65 @@ synthesis:
     conditions:
     - attribute: azure.resourceType
       value: microsoft.web/sites
+    - attribute: azure.resourceKind
+      value: 'app'
+  - identifier: azure.resourceId
+    name: displayName
+    legacyFeatures:
+      overrideGuidType: true
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: azure.resourceType
+      value: microsoft.web/sites
+    - attribute: azure.resourceKind
+      value: 'app,linux'
+  - identifier: azure.resourceId
+    name: displayName
+    legacyFeatures:
+      overrideGuidType: true
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: azure.resourceType
+      value: microsoft.web/sites
+    - attribute: azure.resourceKind
+      value: 'app,linux,container'
+  - identifier: azure.resourceId
+    name: displayName
+    legacyFeatures:
+      overrideGuidType: true
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: azure.resourceType
+      value: microsoft.web/sites
+    - attribute: azure.resourceKind
+      value: 'hyperV'
+  - identifier: azure.resourceId
+    name: displayName
+    legacyFeatures:
+      overrideGuidType: true
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: azure.resourceType
+      value: microsoft.web/sites
+    - attribute: azure.resourceKind
+      value: 'app,container,windows'
+  - identifier: azure.resourceId
+    name: displayName
+    legacyFeatures:
+      overrideGuidType: true
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: azure.resourceType
+      value: microsoft.web/sites
+    - attribute: azure.resourceKind
+      value: 'app,linux,kubernetes'
+  - identifier: azure.resourceId
+    name: displayName
+    legacyFeatures:
+      overrideGuidType: true
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: azure.resourceType
+      value: microsoft.web/sites
+    - attribute: azure.resourceKind
+      value: 'app,linux,container,kubernetes'

--- a/definitions/infra-azurewebapp/tests/MetricRaw.json
+++ b/definitions/infra-azurewebapp/tests/MetricRaw.json
@@ -1,0 +1,39 @@
+[
+  {
+    "azure.metricNamespace": "microsoft.web/sites",
+    "azure.region": "West US",
+    "azure.resourceGroup": "streams",
+    "azure.resourceId": "/subscriptions/9bcb5134-f0a6-11ed-a05b-0242ac120003/resourcegroups/streams/providers/microsoft.web/sites/test",
+    "azure.resourceKind": "app,linux",
+    "azure.resourceName": "test",
+    "azure.resourceType": "microsoft.web/sites",
+    "azure.subscriptionId": "9bcb5134-f0a6-11ed-a05b-0242ac120003",
+    "azure.web.sites.AppConnections": {
+      "type": "summary",
+      "count": 6,
+      "sum": 54,
+      "min": 9,
+      "max": 9
+    },
+    "azure.web.sites.Instance": "1-1-1-1",
+    "collector.name": "azure-monitor",
+    "collector.version": "release-209",
+    "displayName": "test",
+    "endTimestamp": 1683883260000,
+    "entity.guid": "MXxJTkZSQXxOQXwtMjI4MTk4NzE5NDA0NzM0NjcxMQ",
+    "entity.id": "-2281987194047346711",
+    "entity.name": "test",
+    "entity.type": "AZUREWEBAPP",
+    "instrumentation.provider": "azure",
+    "metricName": "azure.web.sites.AppConnections",
+    "newrelic.cloudIntegrations.integrationId": "1",
+    "newrelic.cloudIntegrations.integrationName": "Azure Monitor metrics",
+    "newrelic.cloudIntegrations.providerAccountId": "1",
+    "newrelic.cloudIntegrations.providerAccountName": "azure-dev-all-metrics",
+    "newrelic.cloudIntegrations.providerExternalId": "9bcb5134-f0a6-11ed-a05b-0242ac120003",
+    "newrelic.source": "metricAPI",
+    "nr.entity.id": "-2281987194047346711",
+    "tags.owner": "test",
+    "timestamp": 1683883200000
+  }
+]


### PR DESCRIPTION
### Relevant information

Adding differentiation of entities based on the Azure Kind attribute.

This is an internal request. 

Could we please take it to staging first to confirm that it will work correctly?

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
