### PR TITLE
Tweak firewall dashboard for readability

### DIFF
--- a/definitions/ext-firewall/default-dashboard.json
+++ b/definitions/ext-firewall/default-dashboard.json
@@ -12,7 +12,61 @@
             "column": 1,
             "row": 1,
             "width": 4,
-            "height": 4
+            "height": 2
+          },
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "dataFormatters": [],
+            "facet": {
+              "showOtherSeries": false
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT latest(device_name) AS 'Device Name', latest(src_addr) AS 'Device IP', latest(SysObjectID) AS 'SysObjectID' WHERE entity.type  = 'FIREWALL'"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 2
+          },
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "dataFormatters": [],
+            "facet": {
+              "showOtherSeries": false
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT latest(entity.type) AS 'Type', latest(instrumentation.name) AS 'Profile', latest(tags.kentik.model) as 'Model' WHERE entity.type  = 'FIREWALL'"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 2
           },
           "visualization": {
             "id": "viz.billboard"
@@ -35,7 +89,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "FROM Metric SELECT latest(device_name) AS 'Device Name', latest(src_addr) AS 'Device IP', latest(kentik.snmp.Uptime)/8640000 AS 'Uptime (Days)', latest(SysObjectID) AS 'SysObjectID', latest(entity.type) AS 'Entity Type', latest(instrumentation.name) AS 'Ktranslate Profile', latest(timestamp) AS 'Last Update', latest(PollingHealth) AS 'Polling Health', latest(PollingHealthReason) AS 'Health Reason'"
+                "query": "FROM Metric SELECT latest(PollingHealth) AS 'Polling Health', latest(kentik.snmp.Uptime)/8640000 AS 'Uptime (Days)', latest(timestamp) AS 'Last Update', latest(PollingHealthReason) AS 'Health Reason' WHERE entity.type  = 'FIREWALL'"
               }
             ],
             "platformOptions": {
@@ -47,9 +101,9 @@
           "title": "CPU Utilization (%)",
           "layout": {
             "column": 5,
-            "row": 1,
-            "width": 4,
-            "height": 4
+            "row": 3,
+            "width": 6,
+            "height": 2
           },
           "visualization": {
             "id": "viz.line"
@@ -81,9 +135,9 @@
           "title": "Memory Utilization (%)",
           "layout": {
             "column": 9,
-            "row": 1,
-            "width": 4,
-            "height": 4
+            "row": 3,
+            "width": 6,
+            "height": 2
           },
           "visualization": {
             "id": "viz.line"


### PR DESCRIPTION
### Relevant information

This PR tweaks the firewall dashboard to line up better with the router and switch dashboard visual styles. Instead of having summary info in one scrollable billboard, we'll have it across 3 billboards in the top row. Also, changed the size of a couple charts

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
