### PR TITLE
Allow to configure prefixedTags into the definitions

### DIFF
--- a/validator/schemas/entity-schema-v1.json
+++ b/validator/schemas/entity-schema-v1.json
@@ -281,6 +281,18 @@
                 }
                 }
               },
+              "prefixedTags": {
+                "$id": "#/synthesis/rules/items/prefixedTags",
+                "type": "object",
+                "title": "Prefixed tags",
+                "description": "Use prefixes to convert attributes into tags",
+                "patternProperties": {
+                  "^": {
+                    "type": ["null"]
+                  }
+                },
+                "additionalProperties": false
+              },
               "legacyFeatures": {
                 "$id": "#/synthesis/rules/items/legacyFeatures",
                 "type": "object",


### PR DESCRIPTION
### Relevant information

We added prefixed tags in the past into our definitions & docs.

But seems we never updated the schema so if someone tries to use them like here: https://github.com/newrelic/entity-definitions/pull/1109/files

It will fail the schema validation.

This schema allows any key to be defined but the payload bust be null (for now we don't allow any configuration on the prefixed tags)

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
