### PR TITLE
Fixing space issue

### DIFF
--- a/definitions/ext-firewall/cisco-asa-dashboard.json
+++ b/definitions/ext-firewall/cisco-asa-dashboard.json
@@ -293,7 +293,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "FROM Metric SELECT latest(kentik.snmp.IfInUtilization) AS 'RX %', latest(kentik.snmp.IfOutUtilization) AS 'TX %', latest(if_OperStatus) AS 'Operational Status', latest(kentik.snmp.ifInErrorPercent) AS 'RX Error %', latest(kentik.snmp.ifOutErrorPercent) AS 'TX Error %' FACET if_interface_name AS 'Interface', if_Speed AS 'Interface Speed' WHERE instrumentation name = 'cisco-asa' LIMIT MAX "
+                "query": "FROM Metric SELECT latest(kentik.snmp.IfInUtilization) AS 'RX %', latest(kentik.snmp.IfOutUtilization) AS 'TX %', latest(if_OperStatus) AS 'Operational Status', latest(kentik.snmp.ifInErrorPercent) AS 'RX Error %', latest(kentik.snmp.ifOutErrorPercent) AS 'TX Error %' FACET if_interface_name AS 'Interface', if_Speed AS 'Interface Speed' WHERE instrumentation.name = 'cisco-asa' LIMIT MAX "
               }
             ]
           }


### PR DESCRIPTION
Fixing space issue in the entity default dashboard

### Relevant information

Error:
There was a problem…
NRQL Syntax Error: Error at line 1 position 362, unexpected 'name'

There was a space/syntax issue so fixed it.

Before:
FROM Metric SELECT latest(kentik.snmp.IfInUtilization) AS 'RX %', latest(kentik.snmp.IfOutUtilization) AS 'TX %', latest(if_OperStatus) AS 'Operational Status', latest(kentik.snmp.ifInErrorPercent) AS 'RX Error %', latest(kentik.snmp.ifOutErrorPercent) AS 'TX Error %' FACET if_interface_name AS 'Interface', if_Speed AS 'Interface Speed' WHERE **instrumentation name** = 'cisco-asa' LIMIT MAX

After:
FROM Metric SELECT latest(kentik.snmp.IfInUtilization) AS 'RX %', latest(kentik.snmp.IfOutUtilization) AS 'TX %', latest(if_OperStatus) AS 'Operational Status', latest(kentik.snmp.ifInErrorPercent) AS 'RX Error %', latest(kentik.snmp.ifOutErrorPercent) AS 'TX Error %' FACET if_interface_name AS 'Interface', if_Speed AS 'Interface Speed' WHERE **instrumentation.name** = 'cisco-asa' LIMIT MAX

<!--
  Contributions to this repository are reviewed at least twice a week

  There's no further action required once the PR has been created.
 -->

### Checklist

* [ Yes] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
