### PR TITLE
sum(apm.service.error.count) for NR Otel distro

### DIFF
--- a/definitions/ext-service/golden_metrics.yml
+++ b/definitions/ext-service/golden_metrics.yml
@@ -26,7 +26,7 @@ errorRate:
       from: Span
       where: span.kind LIKE 'server' OR span.kind LIKE 'consumer' OR kind LIKE 'server' OR kind LIKE 'consumer'
     newrelic-opentelemetry:
-      select: count(apm.service.error.count) / count(apm.service.transaction.duration)
+      select: sum(apm.service.error.count) / count(apm.service.transaction.duration)
       from: Metric
     kamon-agent:
       select: (filter(sum(http.server.requests), where http.status_code = '5xx') * 100) / sum(http.server.requests)


### PR DESCRIPTION
sum(apm.service.error.count) for NR Otel distro because counters are broken in Dirac.

For timeslice blobs in Dirac, count() sums the count column, and sum() sums the total column.  For counter metrics, count() is the # of data points, and sum() is the sum of the counts.  It's sad.  Anyway, this will fix the error rate for the new NR Otel distro agent.

But!  It's almost working!

<img width="1122" alt="Notification_Center" src="https://github.com/newrelic/entity-definitions/assets/1627067/173f8eba-8eb4-468f-a822-584cfb58063f">


### Relevant information

<!--
  Describe what you have done.
  Provide details that are relevant to the PR

  Always think that the person reviewing the PR doesn't have the context you have.

  Links to examples, documentation and similar resources make the process easier to review.
-->

<!--
  Contributions to this repository are reviewed at least twice a week

  There's no further action required once the PR has been created.
 -->

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
