### PR TITLE
Fix dashboard typo

### DIFF
--- a/definitions/ext-firewall/pulse-secure-dashboard.json
+++ b/definitions/ext-firewall/pulse-secure-dashboard.json
@@ -228,7 +228,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "FROM Metric SELECT round(latest(kentik.snmp.hrStorageUsed)*100/latest(kentik.snmp.hrStorageSize}.01) AS 'Used %', round(latest(kentik.snmp.hrStorageSize)*1e-6,.01) AS 'Total MBytes', round(latest(kentik.snmp.hrStorageUsed)*1e-6,.01) AS 'Used MBytes' WHERE instrumentation.name = 'pulse-secure' FACET storage_description LIMIT MAX"
+                "query": "FROM Metric SELECT round(latest(kentik.snmp.hrStorageUsed)*100/latest(kentik.snmp.hrStorageSize),.01) AS 'Used %', round(latest(kentik.snmp.hrStorageSize)*1e-6,.01) AS 'Total MBytes', round(latest(kentik.snmp.hrStorageUsed)*1e-6,.01) AS 'Used MBytes' WHERE instrumentation.name = 'pulse-secure' FACET storage_description LIMIT MAX"
               }
             ],
             "platformOptions": {


### PR DESCRIPTION
The query below has mismatched brackets (the `}` should be a `)`) and a missing comma