### PR TITLE
feat: Update Micro Frontend synthesis rules and add golden metrics

### DIFF
--- a/definitions/browser-micro_frontend/definition.yml
+++ b/definitions/browser-micro_frontend/definition.yml
@@ -10,8 +10,8 @@ synthesis:
     - identifier: mfe.id
       name: mfe.name
       conditions:
-        - attribute: eventName
-          value: "MicroFrontendView"
+        - attribute: eventSource
+          value: "MicroFrontendBrowserAgent"
       prefixedTags:
         "mfe.":
 configuration:

--- a/definitions/browser-micro_frontend/golden_metrics.yml
+++ b/definitions/browser-micro_frontend/golden_metrics.yml
@@ -1,0 +1,18 @@
+views:
+  title: Views
+  unit: COUNT
+  query:
+    select: count(*)
+    from: MicroFrontendView
+errors:
+  title: Errors
+  unit: COUNT
+  query:
+    select: count(*)
+    from: MicroFrontendJavaScriptError
+loadSeconds:
+  title: Load time (s)
+  unit: SECONDS
+  query:
+    select: average(duration)
+    from: MicroFrontendLoadTiming

--- a/definitions/browser-micro_frontend/summary_metrics.yml
+++ b/definitions/browser-micro_frontend/summary_metrics.yml
@@ -1,0 +1,12 @@
+views:
+  goldenMetric: views
+  unit: COUNT
+  title: Views
+errors:
+  goldenMetric: errors
+  unit: COUNT
+  title: Errors
+loadSeconds:
+  goldenMetric: loadSeconds
+  unit: SECONDS
+  title: Load time (s)


### PR DESCRIPTION
### Relevant information

- Updated the attribute to match the entity synthesis to something that can be shared between all the different event types (MicroFrontendView, MicroFrontendLoadTiming, MicroFrontendJavaScriptError, etc.).
- Added the Golden Metrics definition for the entity type
- Added the Summary Metrics definition for the entity type pointing to the Golden Metrics definitions.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
