### PR TITLE
Migrate another batch of rules

### DIFF
--- a/relationships/synthesis/EXT-SERVICE-to-EXT-PIXIE-AMQP.yml
+++ b/relationships/synthesis/EXT-SERVICE-to-EXT-PIXIE-AMQP.yml
@@ -1,5 +1,5 @@
 relationships:
-  - name: extServiceCallsExtPixieDns
+  - name: extServiceCallsExtPixieAmqp
     version: 1
     origins:
       - OpenTelemetry
@@ -7,7 +7,7 @@ relationships:
       - attribute: eventType
         anyOf: [ "MetricRaw" ]
       - attribute: entity.type
-        anyOf: [ "PIXIE_DNS" ]
+        anyOf: [ "PIXIE_AMQP" ]
     relationship:
       expires: P75M
       relationshipType: CALLS

--- a/relationships/synthesis/EXT-SERVICE-to-EXT-PIXIE-CASSANDRA.yml
+++ b/relationships/synthesis/EXT-SERVICE-to-EXT-PIXIE-CASSANDRA.yml
@@ -1,5 +1,5 @@
 relationships:
-  - name: extServiceCallsExtPixieDns
+  - name: extServiceCallsExtPixieCassandra
     version: 1
     origins:
       - OpenTelemetry
@@ -7,7 +7,7 @@ relationships:
       - attribute: eventType
         anyOf: [ "MetricRaw" ]
       - attribute: entity.type
-        anyOf: [ "PIXIE_DNS" ]
+        anyOf: [ "PIXIE_CASSANDRA" ]
     relationship:
       expires: P75M
       relationshipType: CALLS

--- a/relationships/synthesis/EXT-SERVICE-to-EXT-PIXIE-KAFKA.yml
+++ b/relationships/synthesis/EXT-SERVICE-to-EXT-PIXIE-KAFKA.yml
@@ -1,5 +1,5 @@
 relationships:
-  - name: extServiceCallsExtPixieDns
+  - name: extServiceCallsExtPixieKafka
     version: 1
     origins:
       - OpenTelemetry
@@ -7,7 +7,7 @@ relationships:
       - attribute: eventType
         anyOf: [ "MetricRaw" ]
       - attribute: entity.type
-        anyOf: [ "PIXIE_DNS" ]
+        anyOf: [ "PIXIE_KAFKABROKER" ]
     relationship:
       expires: P75M
       relationshipType: CALLS

--- a/relationships/synthesis/EXT-SERVICE-to-EXT-PIXIE-MYSQL.yml
+++ b/relationships/synthesis/EXT-SERVICE-to-EXT-PIXIE-MYSQL.yml
@@ -1,5 +1,5 @@
 relationships:
-  - name: extServiceCallsExtPixieDns
+  - name: extServiceCallsExtPixieMysql
     version: 1
     origins:
       - OpenTelemetry
@@ -7,7 +7,7 @@ relationships:
       - attribute: eventType
         anyOf: [ "MetricRaw" ]
       - attribute: entity.type
-        anyOf: [ "PIXIE_DNS" ]
+        anyOf: [ "PIXIE_MYSQL" ]
     relationship:
       expires: P75M
       relationshipType: CALLS

--- a/relationships/synthesis/EXT-SERVICE-to-EXT-PIXIE-POSTGRES.yml
+++ b/relationships/synthesis/EXT-SERVICE-to-EXT-PIXIE-POSTGRES.yml
@@ -1,5 +1,5 @@
 relationships:
-  - name: extServiceCallsExtPixieDns
+  - name: extServiceCallsExtPixiePostgres
     version: 1
     origins:
       - OpenTelemetry
@@ -7,7 +7,7 @@ relationships:
       - attribute: eventType
         anyOf: [ "MetricRaw" ]
       - attribute: entity.type
-        anyOf: [ "PIXIE_DNS" ]
+        anyOf: [ "PIXIE_POSTGRES" ]
     relationship:
       expires: P75M
       relationshipType: CALLS

--- a/relationships/synthesis/EXT-SERVICE-to-EXT-PIXIE_REDIS.yml
+++ b/relationships/synthesis/EXT-SERVICE-to-EXT-PIXIE_REDIS.yml
@@ -1,5 +1,5 @@
 relationships:
-  - name: extServiceCallsExtPixieDns
+  - name: extServiceCallsExtPixieRedis
     version: 1
     origins:
       - OpenTelemetry
@@ -7,7 +7,7 @@ relationships:
       - attribute: eventType
         anyOf: [ "MetricRaw" ]
       - attribute: entity.type
-        anyOf: [ "PIXIE_DNS" ]
+        anyOf: [ "PIXIE_REDIS" ]
     relationship:
       expires: P75M
       relationshipType: CALLS

--- a/relationships/synthesis/INFRA-HOST-to-EXT-SERVICE.yml
+++ b/relationships/synthesis/INFRA-HOST-to-EXT-SERVICE.yml
@@ -7,7 +7,7 @@ relationships:
       - attribute: eventType
         anyOf: [ "Span" ]
       - attribute: newrelic.source
-        anyOf: [ "api.metrics.otlp" ]
+        anyOf: [ "api.traces.otlp" ]
     relationship:
       expires: P75M
       relationshipType: HOSTS

--- a/relationships/synthesis/INFRA-HOST-to-EXT-SERVICE.yml
+++ b/relationships/synthesis/INFRA-HOST-to-EXT-SERVICE.yml
@@ -1,0 +1,64 @@
+relationships:
+  - name: otelServiceHost
+    version: 1
+    origins:
+      - Distributed Tracing
+    conditions:
+      - attribute: eventType
+        anyOf: [ "Span" ]
+      - attribute: newrelic.source
+        anyOf: [ "api.metrics.otlp" ]
+    relationship:
+      expires: P75M
+      relationshipType: HOSTS
+      source:
+        buildGuid:
+          account:
+            attribute: accountId
+          domain:
+            value: INFRA
+          type:
+            # This is an otel host hence no use of NA on the type.
+            value: HOST
+          identifier:
+            fragments:
+              - attribute: host.id
+            hashAlgorithm: FARM_HASH
+      target:
+        extractGuid:
+          attribute: entity.guid
+          entityType:
+            attribute: entity.type
+
+  - name: otelServiceHostMetric
+    version: 1
+    origins:
+      - OpenTelemetry
+    conditions:
+      - attribute: eventType
+        anyOf: [ "MetricRaw" ]
+      - attribute: newrelic.source
+        anyOf: [ "api.metrics.otlp" ]
+      - attribute: service.name
+        anyOf: [ "io.opentelemetry.collector" ]
+    relationship:
+      expires: P75M
+      relationshipType: HOSTS
+      source:
+        buildGuid:
+          account:
+            attribute: accountId
+          domain:
+            value: INFRA
+          type:
+            # This is an otel host hence no use of NA on the type.
+            value: HOST
+          identifier:
+            fragments:
+              - attribute: host.id
+            hashAlgorithm: FARM_HASH
+      target:
+        extractGuid:
+          attribute: entity.guid
+          entityType:
+            attribute: entity.type


### PR DESCRIPTION
### Relevant information

Bring another batch of rules into the public repo.

The two main things to note are:

- otelServiceHost is currently generating relationships from tracing but nothing from otel, so we only neabled the tracing origin.
- otelServiceHostMetric has a condition by `service.name` I believe that was for testing and was never removed, I'm following up with the team owning that relationship but for now we are migrating them as-is

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
