### PR TITLE
NR-142172: Use host.name for the entity name 

### DIFF
--- a/entity-types/infra-host/definition.yml
+++ b/entity-types/infra-host/definition.yml
@@ -23,7 +23,7 @@ synthesis:
   rules:
     # opentelemetry host data from opentelemetry-collector
     - identifier: host.id
-      name: host.id
+      name: host.name
       encodeIdentifierInGUID: true
       conditions:
         - attribute: eventType
@@ -53,7 +53,7 @@ synthesis:
         instrumentation.provider:
     # opentelemetry host data from opentelemetry-collector
     - identifier: host.id
-      name: host.id
+      name: host.name
       encodeIdentifierInGUID: true
       conditions:
         - attribute: eventType
@@ -83,7 +83,7 @@ synthesis:
         instrumentation.provider:
     # opentelemetry host data from opentelemetry-collector
     - identifier: host.id
-      name: host.id
+      name: host.name
       encodeIdentifierInGUID: true
       conditions:
         - attribute: eventType


### PR DESCRIPTION
### Relevant information

Needs to be tested in staging before releasing

Changing entity name from host.id to host.name for OTEL hosts

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
