### PR TITLE
fix(mongodb): cleaning mongodb entity identifier

### DIFF
--- a/entity-types/infra-mongodb_collection/definition.yml
+++ b/entity-types/infra-mongodb_collection/definition.yml
@@ -6,7 +6,6 @@ synthesis:
     - compositeIdentifier:
         separator: ":"
         attributes:
-          - targetName
           - mongodb_cluster_name
           - database
           - collection
@@ -24,7 +23,6 @@ synthesis:
     - compositeIdentifier:
         separator: ":"
         attributes:
-          - targetName
           - mongodb_cluster_name
           - database
           - collection
@@ -42,7 +40,6 @@ synthesis:
     - compositeIdentifier:
         separator: ":"
         attributes:
-          - targetName
           - mongodb_cluster_name
           - database
           - collection

--- a/entity-types/infra-mongodb_database/definition.yml
+++ b/entity-types/infra-mongodb_database/definition.yml
@@ -6,7 +6,6 @@ synthesis:
     - compositeIdentifier:
         separator: ":"
         attributes:
-          - targetName
           - mongodb_cluster_name
           - database
       encodeIdentifierInGUID: true

--- a/entity-types/infra-mongodb_instance/definition.yml
+++ b/entity-types/infra-mongodb_instance/definition.yml
@@ -3,11 +3,8 @@ type: MONGODB_INSTANCE
 
 synthesis:
   rules:
-    - compositeIdentifier:
-        separator: ":"
-        attributes:
-          - targetName
-          - mongodb_cluster_name
+    - identifier: mongodb_cluster_name
+      encodeIdentifierInGUID: true
       name: mongodb_cluster_name
       conditions:
         - attribute: eventType
@@ -17,11 +14,8 @@ synthesis:
       tags:
         mongodb_cluster_name:
 
-    - compositeIdentifier:
-        separator: ":"
-        attributes:
-          - targetName
-          - mongodb_cluster_name
+    - identifier: mongodb_cluster_name
+      encodeIdentifierInGUID: true
       name: mongodb_cluster_name
       conditions:
         - attribute: eventType
@@ -31,11 +25,8 @@ synthesis:
       tags:
         mongodb_cluster_name:
 
-    - compositeIdentifier:
-        separator: ":"
-        attributes:
-          - targetName
-          - mongodb_cluster_name
+    - identifier: mongodb_cluster_name
+      encodeIdentifierInGUID: true
       name: mongodb_cluster_name
       conditions:
         - attribute: eventType
@@ -45,11 +36,8 @@ synthesis:
       tags:
         mongodb_cluster_name:
 
-    - compositeIdentifier:
-        separator: ":"
-        attributes:
-          - targetName
-          - mongodb_cluster_name
+    - identifier: mongodb_cluster_name
+      encodeIdentifierInGUID: true
       name: mongodb_cluster_name
       conditions:
         - attribute: eventType
@@ -59,11 +47,8 @@ synthesis:
       tags:
         mongodb_cluster_name:
 
-    - compositeIdentifier:
-        separator: ":"
-        attributes:
-          - targetName
-          - mongodb_cluster_name
+    - identifier: mongodb_cluster_name
+      encodeIdentifierInGUID: true
       name: mongodb_cluster_name
       conditions:
         - attribute: eventType
@@ -73,11 +58,8 @@ synthesis:
       tags:
         mongodb_cluster_name:
 
-    - compositeIdentifier:
-        separator: ":"
-        attributes:
-          - targetName
-          - mongodb_cluster_name
+    - identifier: mongodb_cluster_name
+      encodeIdentifierInGUID: true
       name: mongodb_cluster_name
       conditions:
         - attribute: eventType
@@ -87,11 +69,8 @@ synthesis:
       tags:
         mongodb_cluster_name:
 
-    - compositeIdentifier:
-        separator: ":"
-        attributes:
-          - targetName
-          - mongodb_cluster_name
+    - identifier: mongodb_cluster_name
+      encodeIdentifierInGUID: true
       name: mongodb_cluster_name
       conditions:
         - attribute: eventType
@@ -101,11 +80,8 @@ synthesis:
       tags:
         mongodb_cluster_name:
 
-    - compositeIdentifier:
-        separator: ":"
-        attributes:
-          - targetName
-          - mongodb_cluster_name
+    - identifier: mongodb_cluster_name
+      encodeIdentifierInGUID: true
       name: mongodb_cluster_name
       conditions:
         - attribute: eventType
@@ -115,11 +91,8 @@ synthesis:
       tags:
         mongodb_cluster_name:
 
-    - compositeIdentifier:
-        separator: ":"
-        attributes:
-          - targetName
-          - mongodb_cluster_name
+    - identifier: mongodb_cluster_name
+      encodeIdentifierInGUID: true
       name: mongodb_cluster_name
       conditions:
         - attribute: eventType
@@ -129,11 +102,8 @@ synthesis:
       tags:
         mongodb_cluster_name:
 
-    - compositeIdentifier:
-        separator: ":"
-        attributes:
-          - targetName
-          - mongodb_cluster_name
+    - identifier: mongodb_cluster_name
+      encodeIdentifierInGUID: true
       name: mongodb_cluster_name
       conditions:
         - attribute: eventType
@@ -143,11 +113,8 @@ synthesis:
       tags:
         mongodb_cluster_name:
 
-    - compositeIdentifier:
-        separator: ":"
-        attributes:
-          - targetName
-          - mongodb_cluster_name
+    - identifier: mongodb_cluster_name
+      encodeIdentifierInGUID: true
       name: mongodb_cluster_name
       conditions:
         - attribute: eventType


### PR DESCRIPTION
### Relevant information

 - in the definition, we should not add the targetName in the composite ID since the [mongodb_cluster_name](https://github.com/newrelic/newrelic-prometheus-exporters-packages/blob/efbcab034d9145a31056f83c330ce1891ed04269/exporters/mongodb3/mongodb3-config.yml.sample#L5) is already unique and added by the customer (this could be a problem since if the integration is restarted and a port assigned, the entity GUID changes)
 - we are not adding encodeIdentifierInGUID, which possibly causes the ID to be truncated at 50 chars. This would result in collisions for each ID longer than 50

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
