### PR TITLE
feat: Update node_exporter infra entities so hostname and host.id tag…

### DIFF
--- a/entity-types/infra-host/definition.yml
+++ b/entity-types/infra-host/definition.yml
@@ -140,6 +140,7 @@ synthesis:
       tags:
         taskArn:
         nodename:
+          entityTagNames: [hostname]
         instrumentation.provider:
     # AWS EC2 by instanceid
     - identifier: instanceid
@@ -157,7 +158,9 @@ synthesis:
         value: "true"
       tags:
         instanceid:
+          entityTagNames: [host.id, instanceid]
         nodename:
+          entityTagNames: [hostname]
         instrumentation.provider:
     # On a host
     - identifier: instance
@@ -174,6 +177,7 @@ synthesis:
       tags:
         instance:
         nodename:
+          entityTagNames: [hostname]
         instrumentation.provider:
 configuration:
   entityExpirationTime: DAILY


### PR DESCRIPTION
### Relevant information

This update maps the `nodename` attribute to a `hostname` tag and the `instanceid` attribute to a `host.id` tag on the created `INFRA-HOST` entity for proemtheus node_exporter entities.

This is done to standardize the tag names to better align with existing tags used on `INFRA-HOST` entities and to aid in leveraging existing/planned relationship formation with APM that uses the `hostname` and `host.id` tags for matching.

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
