### PR TITLE
APM calls REDISINSTANCE: Propose a change to the rule to use APM metrics

### DIFF
--- a/relationships/synthesis/APM-APPLICATION-to-INFRA-REDISINSTANCE.yml
+++ b/relationships/synthesis/APM-APPLICATION-to-INFRA-REDISINSTANCE.yml
@@ -2,12 +2,11 @@ relationships:
   - name: apmApplicationCallsInfraRedisInstance
     version: "1"
     origins:
-      - Distributed Tracing
+      - APM Metrics
     conditions:
-      - attribute: peer.address
-        present: true
-      - attribute: component
-        anyOf: [ "Redis" ]
+      - attribute: metricName
+        # "datastore/instance/redis/$host/$port"
+        startsWith: "datastore/instance/redis/"
     relationship:
       expires: P75M
       relationshipType: CALLS
@@ -17,7 +16,7 @@ relationships:
       target:
         buildGuid:
           account:
-            attribute: accountId
+            lookup: yes
           domain:
             value: INFRA
           type:
@@ -26,5 +25,7 @@ relationships:
           identifier:
             fragments:
               - value: "instance:"
-              - attribute: peer.address
+              - attribute: metricName__4 # hostname
+              - value: ":"
+              - attribute: metricName__5 # port
             hashAlgorithm: FARM_HASH


### PR DESCRIPTION
### Relevant information

Use APM metrics instead of DT.

Users don't need to opt-in into APM metrics and hence we will create more relationships than using DT for this.


Note: Approval is left to the team proposing these new relationships. Don't merge until they approve it.

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
