### PR TITLE
chore: re-order to put generic filter last

### DIFF
--- a/entity-types/ext-pdu/definition.yml
+++ b/entity-types/ext-pdu/definition.yml
@@ -22,7 +22,9 @@ goldenTags:
 - device_model
 
 dashboardTemplates:
-  kentik:
-    template: kentik-dashboard.json
+  # Servertech-4 profile
   kentik/servertech-pdu4:
     template: servertech-pdu4-dashboard.json
+  # Generic/catchall
+  kentik:
+    template: kentik-dashboard.json

--- a/entity-types/ext-pdu/golden_metrics.yml
+++ b/entity-types/ext-pdu/golden_metrics.yml
@@ -2,13 +2,13 @@ outputLoadCapacity:
   title: Aggregate load (amps)
   unit: COUNT
   queries:
-    # Kentik profiles (default)
-    kentik:
-      select: max(kentik.snmp.rPDULoadStatusLoad)*10
-      from: Metric
-      where: "provider = 'kentik-pdu'"
     # Servertech PDU 4 profiles
     kentik/servertech-pdu4:
       select: max(kentik.snmp.st4PhaseCurrent)*100 #Centiamperes to Amperes
+      from: Metric
+      where: "provider = 'kentik-pdu'"
+    # Kentik profiles (generic)
+    kentik:
+      select: max(kentik.snmp.rPDULoadStatusLoad)*10
       from: Metric
       where: "provider = 'kentik-pdu'"


### PR DESCRIPTION
### Relevant information

updating the order of filtering on the PDU entity to move the "catchall" to the end on dashboard and GM

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
