### PR TITLE
Reflecting tag rule precedence change in our docs

### DIFF
--- a/docs/entities/synthesis.md
+++ b/docs/entities/synthesis.md
@@ -228,7 +228,7 @@ Every attribute name including any of the provided prefixes will get indexed as 
 * If there are multiple attributes matching against the same prefix, all of them will get indexed.
 * The prefix gets removed from the final tag name.
 * Prefixed attributes take the lower precedence, meaning that after removing the prefix, if there's already a tag with the same name coming from the same telemetry datapoint, it will be discarded.
-* The prefix "tags." doesn't get specified as part of this structure, it still works independently and also takes a higher precedence over these prefixes. 
+* The prefix "tags." doesn't get specified as part of this structure, it still works independently. 
 
 > With a `label.` prefix as part of the `prefixedTags` list, and the telemetry containing any attribute prefixed with it,
 for instance, `label.name`, the final tag name will be `name`.

--- a/docs/entities/synthesis.md
+++ b/docs/entities/synthesis.md
@@ -225,9 +225,9 @@ Also, if present in the telemetry, these attributes are also added to the entity
 #### Prefixed tags
 
 Every attribute name including any of the provided prefixes will get indexed as a tag, taking into account the following:
+* There is no explicit tag rule that matches the attribute's name including the prefix. 
 * If there are multiple attributes matching against the same prefix, all of them will get indexed.
 * The prefix gets removed from the final tag name.
-* Prefixed attributes take the lower precedence, meaning that after removing the prefix, if there's already a tag with the same name coming from the same telemetry datapoint, it will be discarded.
 * The prefix "tags." doesn't get specified as part of this structure, it still works independently. 
 
 > With a `label.` prefix as part of the `prefixedTags` list, and the telemetry containing any attribute prefixed with it,


### PR DESCRIPTION
### Relevant information
Small docs update on revised tag rule precedence in synthesis.
Explicit definitions are now evaluated first and implicit conventions are applied later on if no explicit definitions matched.

### Checklist
n/a
