### PR TITLE
Add APM-APPLICATION-to-INFRA-REDISINSTANCE again

### DIFF
--- a/relationships/synthesis/APM-APPLICATION-to-INFRA-REDISINSTANCE.yml
+++ b/relationships/synthesis/APM-APPLICATION-to-INFRA-REDISINSTANCE.yml
@@ -1,0 +1,31 @@
+relationships:
+  - name: apmApplicationCallsInfraRedisInstance
+    version: "1"
+    origins:
+      - APM Metrics
+    conditions:
+      - attribute: metricName
+        # "datastore/instance/redis/$host/$port"
+        startsWith: "datastore/instance/redis/"
+    relationship:
+      expires: P75M
+      relationshipType: CALLS
+      source:
+        extractGuid:
+          attribute: entity.guid
+      target:
+        buildGuid:
+          account:
+            lookup: yes
+          domain:
+            value: INFRA
+          type:
+            value: REDISINSTANCE
+            valueInGuid: NA
+          identifier:
+            fragments:
+              - value: "instance:"
+              - attribute: metricName__4 # hostname
+              - value: ":"
+              - attribute: metricName__5 # port
+            hashAlgorithm: FARM_HASH


### PR DESCRIPTION
Bring the rule again that we removed in: https://github.com/newrelic/entity-definitions/pull/1174

So we can switch systems to create relationships for APM.

For the team:

The internal rule we used for testing is named `apmApplicationCallsInfraRedisInstanceAPMVersion` and is not present on our FF's

This means that is currently creating relationships, once we switch from the internal to the public version no relationships will be created without this PR.

So we need to have the rule defined & also need to remove it from all existing FF's.

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
