### PR TITLE
Fix k8sHostContainsPod rule

### DIFF
--- a/relationships/synthesis/INFRA-HOST-to-INFRA-KUBERNETES_POD.yml
+++ b/relationships/synthesis/INFRA-HOST-to-INFRA-KUBERNETES_POD.yml
@@ -16,6 +16,6 @@ relationships:
             value: HOST
       target:
         extractGuid:
-          attribute: entity.guid
+          attribute: entityGuid
           entityType:
             value: KUBERNETES_POD


### PR DESCRIPTION
### Relevant information

We migrated the rule correctly internally but when moving into the public repo we changed to `entity.guid` by mistake

<!--
  Describe what you have done.
  Provide details that are relevant to the PR

  Always think that the person reviewing the PR doesn't have the context you have.

  Links to examples, documentation and similar resources make the process easier to review.
-->

<!--
  Contributions to this repository are reviewed at least twice a week

  There's no further action required once the PR has been created.
 -->

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
