### PR TITLE
Include unit of measure for errorRate ext-service

### DIFF
--- a/entity-types/ext-service/golden_metrics.yml
+++ b/entity-types/ext-service/golden_metrics.yml
@@ -20,6 +20,7 @@ throughput:
       from: Metric
 errorRate:
   title: Error rate (%)
+  unit: PERCENTAGE
   queries:
     opentelemetry:
       select: (filter(count(*), WHERE otel.status_code = 'ERROR') * 100) / count(*)


### PR DESCRIPTION
### Relevant information
The unit of measure for `errorRate` on EXT-Service entity types was missing

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
