### PR TITLE
Key Transaction Error %

### DIFF
--- a/entity-types/ext-key_transaction/golden_metrics.yml
+++ b/entity-types/ext-key_transaction/golden_metrics.yml
@@ -13,9 +13,9 @@ throughput:
     from: Metric
     eventId: entity.guid  
 errorRate:
-  title: Error rate
+  title: Error %
   unit: PERCENTAGE
   query:
-    select: count(apm.key.transaction.error.count) / count(apm.key.transaction.duration) as 'Error rate'
+    select: count(apm.key.transaction.error.count) / count(apm.key.transaction.duration) * 100 as 'Error %'
     from: Metric
     eventId: entity.guid  


### PR DESCRIPTION
### Relevant information
Key Transaction Errors are supposed to be a measured in `percentage` but queried as `count`

### Checklist
* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
