### PR TITLE
fix: use correct entity name for OTEL packages

### DIFF
--- a/entity-types/ext-package/definition.yml
+++ b/entity-types/ext-package/definition.yml
@@ -3,7 +3,6 @@ type: PACKAGE
 goldenTags:
 - account
 - name
-- type
 - version
 - architecture
 synthesis:
@@ -33,7 +32,7 @@ synthesis:
           - columns.name
           - columns.version
           - columns.arch
-      name: name
+      name: columns.name
       encodeIdentifierInGUID: true
       conditions:
         - attribute: eventType
@@ -43,7 +42,7 @@ synthesis:
       tags:
         column.arch:
           entityTagName: arch
-        column.name:
+        columns.name:
           entityTagName: name
         column.version:
           entityTagName: version


### PR DESCRIPTION
### Relevant information

I found an error in the previous [PR](https://github.com/newrelic/entity-definitions/pull/1232/files) for OTEL packages. This PR fixes it.

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
