### PR TITLE
fix: use account attribute in the package relationship

### DIFF
--- a/relationships/synthesis/INFRA-HOST-to-EXT-PACKAGE.yml
+++ b/relationships/synthesis/INFRA-HOST-to-EXT-PACKAGE.yml
@@ -14,7 +14,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes
+            attribute: accountId
           domain:
             value: INFRA
           type:


### PR DESCRIPTION
### Relevant information

This is another fix for the package entity definition. This time, I'm trying to fix the relationship synthesis rule.
### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
