### PR TITLE
Rename newrelic.cloudIntegrations.providerAccountName to providerAcco…

### DIFF
--- a/entity-types/infra-azurefunctionsapp/definition.yml
+++ b/entity-types/infra-azurefunctionsapp/definition.yml
@@ -10,6 +10,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    providerAccountName:
+      entityTagNames: [providerAccountName, newrelic.cloudIntegrations.providerAccountName]
   rules:
     - identifier: azure.resourceId
       name: displayName


### PR DESCRIPTION
Rename newrelic.cloudIntegrations.providerAccountName to providerAccountName

### Relevant information

Azure polling provides the tag `providerAccountName`, while Azure Monitor `newrelic.cloudIntegrations.providerAccountName`

This tag rename aims to have both values tagged as `providerAccountName`. It should apply to all rules.


### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
