### PR TITLE
Redis Instance - Use a string field for the composite identifier temporarily.

### DIFF
--- a/entity-types/infra-redisinstance/definition.yml
+++ b/entity-types/infra-redisinstance/definition.yml
@@ -8,7 +8,7 @@ synthesis:
       separator: ":"
       attributes:
         - server.address
-        - server.port
+        - redis.version
     name: server.address
     encodeIdentifierInGUID: true
     conditions:


### PR DESCRIPTION
Temporary debugging PR: It looks like otel ingest only takes strings into account. This commit is to test this assumption.

Not intended to go to prod.
