### PR TITLE
Revert "Redis Instance - Use a string field for the composite identifier temporarily."

### DIFF
--- a/entity-types/infra-redisinstance/definition.yml
+++ b/entity-types/infra-redisinstance/definition.yml
@@ -8,7 +8,7 @@ synthesis:
       separator: ":"
       attributes:
         - server.address
-        - redis.version
+        - server.port
     name: server.address
     encodeIdentifierInGUID: true
     conditions:


### PR DESCRIPTION
Reverts newrelic/entity-definitions#1240