### PR TITLE
Fix unit: AWS EC Redis Node swap usage

### DIFF
--- a/entity-types/infra-awselasticacheredisnode/golden_metrics.yml
+++ b/entity-types/infra-awselasticacheredisnode/golden_metrics.yml
@@ -45,7 +45,7 @@ evictedItems:
       eventName: entityName
 swapUsage:
   title: Swap usage
-  unit: PERCENTAGE
+  unit: BYTES
   queries:
     aws:
       select: average(aws.elasticache.SwapUsage.byRedisNode)


### PR DESCRIPTION
AWS Elasticache Redis Node swap was a %, but it's bytes.

### Relevant information

AWS Elasticache Redis Node Swap Usage [should be `BYTES`](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheMetrics.WhichShouldIMonitor.html#metrics-swap-usage), but it's currently `PERCENTAGE`. 

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
