### PR TITLE
NR-154038: OHI dashboards migration

### DIFF
--- a/entity-types/infra-apacheserver/definition.yml
+++ b/entity-types/infra-apacheserver/definition.yml
@@ -7,3 +7,8 @@ goldenTags:
 configuration:
   entityExpirationTime: DAILY
   alertable: true
+
+dashboardTemplates:
+  # This should match the entity created from the ohi in the infra pipeline
+  newRelic:
+    template: newrelic_dashboard.json

--- a/entity-types/infra-apacheserver/newrelic_dashboard.json
+++ b/entity-types/infra-apacheserver/newrelic_dashboard.json
@@ -1,0 +1,110 @@
+{
+  "name": "ApacheSample",
+  "pages": [
+    {
+      "name": "ApacheSample",
+      "widgets": [
+        {
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Requests per second",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`apache.server.net.requestsPerSecond`) as 'Requests' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 7,
+            "row": 1,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Bytes sent per request",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT (average(`apache.server.net.bytesPerSecond`)/average(`apache.server.net.requestsPerSecond`)) as 'Bytes sent per request' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 12,
+            "height": 3
+          },
+          "title": "Status",
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`apache.server.idleWorkers` * 1) as 'Idle workers', latest(`apache.server.busyWorkers`) as 'Busy workers', latest(`apache.server.scoreboard.totalWorkers`) as 'Total workers', latest(`apache.server.scoreboard.readingWorkers`) as 'Reading request', latest(`apache.server.scoreboard.writingWorkers`) as 'Writing', latest(`apache.server.scoreboard.loggingWorkers`) as 'Logging', latest(`apache.server.scoreboard.finishingWorkers`) as 'Finishing', latest(`apache.server.scoreboard.closingWorkers`) as 'Closing connection', latest(`apache.server.scoreboard.keepAliveWorkers`) as 'Keep alive', latest(`apache.server.scoreboard.dnsLookupWorkers`) as 'DNS lookup', latest(`apache.server.scoreboard.idleCleanupWorkers`) as 'Idle cleanup', latest(`apache.server.scoreboard.startingWorkers`) as 'Starting' FROM Metric "
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Busy worker status",
+          "visualization": {
+            "id": "viz.area"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`apache.server.scoreboard.readingWorkers`) as 'Reading request', average(`apache.server.scoreboard.writingWorkers`) as 'Writing', average(`apache.server.scoreboard.loggingWorkers`) as 'Logging', average(`apache.server.scoreboard.finishingWorkers`) as 'Finishing', average(`apache.server.scoreboard.closingWorkers`) as 'Closing connection', average(`apache.server.scoreboard.keepAliveWorkers`) as 'Keep alive', average(`apache.server.scoreboard.dnsLookupWorkers`) as 'DNS lookup', average(`apache.server.scoreboard.idleCleanupWorkers`) as 'Idle cleanup', average(`apache.server.scoreboard.startingWorkers`) as 'Starting' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 7,
+            "row": 7,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Total vs idle vs busy workers",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`apache.server.idleWorkers`) as 'Idle workers', average(`apache.server.busyWorkers`) as 'Busy workers', average(`apache.server.scoreboard.totalWorkers`) as 'Total workers' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-cassandranode/definition.yml
+++ b/entity-types/infra-cassandranode/definition.yml
@@ -9,3 +9,8 @@ goldenTags:
 configuration:
   entityExpirationTime: DAILY
   alertable: true
+
+dashboardTemplates:
+  # This should match the entity created from the ohi in the infra pipeline
+  newRelic:
+    template: newrelic_dashboard.json

--- a/entity-types/infra-cassandranode/newrelic_dashboard.json
+++ b/entity-types/infra-cassandranode/newrelic_dashboard.json
@@ -1,0 +1,250 @@
+{
+  "name": "CassandraSample",
+  "pages": [
+    {
+      "name": "CassandraSample",
+      "widgets": [
+        {
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 12,
+            "height": 3
+          },
+          "title": "Client request rates",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`cassandra.node.query.casWriteRequestsPerSecond`) AS 'CAS write', average(`cassandra.node.query.casReadRequestsPerSecond`) AS 'CAS read', average(`cassandra.node.query.viewWriteRequestsPerSecond`) AS 'View write', average(`cassandra.node.query.rangeSliceRequestsPerSecond`) AS 'Range slice', average(`cassandra.node.query.readRequestsPerSecond`) AS 'Read', average(`cassandra.node.query.writeRequestsPerSecond`) AS 'Write' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Pending request pool tasks",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`cassandra.node.threadPool.counterMutationStage.pendingTasks`) AS 'Counter mutation stage', average(`cassandra.node.threadPool.viewMutationStage.pendingTasks`) AS 'View mutation stage', average(`cassandra.node.threadPool.readRepairStage.pendingTasks`) AS 'Read repair stage', average(`cassandra.node.threadPool.readStage.pendingTasks`) AS 'Read stage', average(`cassandra.node.threadPool.requestResponseStage.pendingTasks`) AS 'Request response stage', average(`cassandra.node.threadPool.mutationStage.pendingTasks`) AS 'Mutation stage' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 7,
+            "row": 4,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Active request pool threads",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`cassandra.node.threadPool.counterMutationStage.activeTasks`) AS 'Counter mutation stage', average(`cassandra.node.threadPool.viewMutationStage.activeTasks`) AS 'View mutation stage', average(`cassandra.node.threadPool.readRepairStage.activeTasks`) AS 'Read repair stage', average(`cassandra.node.threadPool.readStage.activeTasks`) AS 'Read stage', average(`cassandra.node.threadPool.requestResponseStage.activeTasks`) AS 'Request response stage', average(`cassandra.node.threadPool.mutationStage.activeTasks`) AS 'Mutation stage' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Pending read tasks",
+          "visualization": {
+            "id": "viz.area"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT max(`cassandra.node.threadPool.readStage.pendingTasks`) AS 'Read stage' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 5,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Active read tasks",
+          "visualization": {
+            "id": "viz.area"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT max(`cassandra.node.threadPool.readStage.activeTasks`) AS 'Read stage' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 9,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Write latency (ms)",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`cassandra.node.query.writeLatency50ThPercentileMilliseconds`) as '50th', average(`cassandra.node.query.writeLatency75ThPercentileMilliseconds`) as '75th', average(`cassandra.node.query.writeLatency95ThPercentileMilliseconds`) as '95th', average(`cassandra.node.query.writeLatency98ThPercentileMilliseconds`) as '98th', average(`cassandra.node.query.writeLatency99ThPercentileMilliseconds`) as '99th' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 10,
+            "width": 8,
+            "height": 3
+          },
+          "title": "Active internal threadpool tasks",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`cassandra.node.threadPool.antiEntropyStage.activeTasks`) AS 'AntiEntropyStage', average(`cassandra.node.threadPool.cacheCleanupExecutor.activeTasks`) AS 'CacheCleanupExecutor', average(`cassandra.node.threadPool.compactionExecutor.activeTasks`) AS 'CompactionExecutor', average(`cassandra.node.threadPool.gossipStage.activeTasks`) AS 'GossipStage', average(`cassandra.node.threadPool.hintsDispatcher.activeTasks`) AS 'HintsDispatcher', average(`cassandra.node.threadPool.internalResponseStage.activeTasks`) AS 'InternalResponseStage', average(`cassandra.node.threadPool.memtableFlushWriter.activeTasks`) AS 'MemtableFlushWriter', average(`cassandra.node.threadPool.memtablePostFlush.activeTasks`) AS 'MemtablePostFlush', average(`cassandra.node.threadPool.memtableReclaimMemory.activeTasks`) AS 'MemtableReclaimMemory', average(`cassandra.node.threadPool.migrationStage.activeTasks`) AS 'MigrationStage', average(`cassandra.node.threadPool.miscStage.activeTasks`) AS 'MiscStage', average(`cassandra.node.threadPool.pendingRangeCalculator.activeTasks`) AS 'PendingRangeCalculator', average(`cassandra.node.threadPool.sampler.activeTasks`) AS 'Sampler', average(`cassandra.node.threadPool.secondaryIndexManagement.activeTasks`) AS 'SecondaryIndexManagement', average(`cassandra.node.threadPool.validationExecutor.activeTasks`) AS 'ValidationExecutor' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 9,
+            "row": 10,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Read latency (ms)",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`cassandra.node.query.readLatency50ThPercentileMilliseconds`) as '50th', average(`cassandra.node.query.readLatency75ThPercentileMilliseconds`) as '75th', average(`cassandra.node.query.readLatency95ThPercentileMilliseconds`) as '95th',average(`cassandra.node.query.readLatency98ThPercentileMilliseconds`) as '98th', average(`cassandra.node.query.readLatency99ThPercentileMilliseconds`) as '99th' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 13,
+            "width": 8,
+            "height": 3
+          },
+          "title": "Pending internal threadpool tasks",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`cassandra.node.threadPool.antiEntropyStage.pendingTasks`) AS 'AntiEntropyStage', average(`cassandra.node.threadPool.cacheCleanupExecutor.activeTasks`) AS 'CacheCleanupExecutor', average(`cassandra.node.threadPool.compactionExecutor.activeTasks`) AS 'CompactionExecutor', average(`cassandra.node.threadPool.gossipStage.activeTasks`) AS 'GossipStage', average(`cassandra.node.threadPool.hintsDispatcher.activeTasks`) AS 'HintsDispatcher', average(`cassandra.node.threadPool.internalResponseStage.activeTasks`) AS 'InternalResponseStage', average(`cassandra.node.threadPool.memtableFlushWriter.activeTasks`) AS 'MemtableFlushWriter', average(`cassandra.node.threadPool.memtablePostFlush.activeTasks`) AS 'MemtablePostFlush', average(`cassandra.node.threadPool.memtableReclaimMemory.activeTasks`) AS 'MemtableReclaimMemory', average(`cassandra.node.threadPool.migrationStage.activeTasks`) AS 'MigrationStage', average(`cassandra.node.threadPool.miscStage.activeTasks`) AS 'MiscStage', average(`cassandra.node.threadPool.pendingRangeCalculator.activeTasks`) AS 'PendingRangeCalculator', average(`cassandra.node.threadPool.sampler.activeTasks`) AS 'Sampler', average(`cassandra.node.threadPool.secondaryIndexManagement.activeTasks`) AS 'SecondaryIndexManagement', average(`cassandra.node.threadPool.validationExecutor.activeTasks`) AS 'ValidationExecutor' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 9,
+            "row": 13,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Dropped messages per second",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`cassandra.node.droppedBatchRemoveMessagesPerSecond`) AS 'Batch remove', average(`cassandra.node.droppedBatchStoreMessagesPerSecond`) AS 'Batch store', average(`cassandra.node.droppedCounterMutationMessagesPerSecond`) AS 'Counter mutation', average(`cassandra.node.droppedHintMessagesPerSecond`) AS 'Hint', average(`cassandra.node.droppedMutationMessagesPerSecond`) AS 'Mutation', average(`cassandra.node.droppedPagedRangeMessagesPerSecond`) AS 'Paged range', average(`cassandra.node.droppedRangeSliceMessagesPerSecond`) AS 'Range slice', average(`cassandra.node.droppedReadMessagesPerSecond`) AS 'Read', average(`cassandra.node.droppedReadRepairMessagesPerSecond`) AS 'Read repair', average(`cassandra.node.droppedRequestResponseMessagesPerSecond`) AS 'Request response', average(`cassandra.node.droppedTraceMessagesPerSecond`) AS 'Trace' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 16,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Memtable sizes",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`cassandra.node.allMemtablesOnHeapSizeBytes`) AS 'On heap', average(`cassandra.node.allMemtablesOffHeapSizeBytes`) AS 'Off heap' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 7,
+            "row": 16,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Hints in progress.",
+          "visualization": {
+            "id": "viz.area"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`cassandra.node.totalHintsInProgress`) AS 'In progress' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-consulagent/definition.yml
+++ b/entity-types/infra-consulagent/definition.yml
@@ -3,3 +3,8 @@ type: CONSULAGENT
 configuration:
   entityExpirationTime: DAILY
   alertable: true
+
+dashboardTemplates:
+  # This should match the entity created from the ohi in the infra pipeline
+  newRelic:
+    template: newrelic_dashboard.json

--- a/entity-types/infra-consulagent/newrelic_dashboard.json
+++ b/entity-types/infra-consulagent/newrelic_dashboard.json
@@ -1,0 +1,210 @@
+{
+  "name": "ConsulAgentSample",
+  "pages": [
+    {
+      "name": "ConsulAgentSample",
+      "widgets": [
+        {
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Cache hits",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`consul.agent.aclCacheHitPerSecond`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Cache misses",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`consul.agent.aclCacheMissPerSecond`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Stale queries",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`consul.agent.staleQueries`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Peers",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`consul.agent.peers`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Transaction time",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`consul.agent.txnAvgInMilliseconds`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Transactions",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`consul.agent.txns`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Transaction max time to apply",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`consul.agent.txnMaxInMilliseconds`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 5,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "title": "KV store update time",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`consul.agent.kvStoresAvgInMilliseconds`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 9,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "title": "KV store Samples",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`consul.agent.kvStores`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 10,
+            "width": 4,
+            "height": 3
+          },
+          "title": "KV max time to update",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`consul.agent.kvStoresMaxInMilliseconds`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-couchbasebucket/definition.yml
+++ b/entity-types/infra-couchbasebucket/definition.yml
@@ -3,3 +3,8 @@ type: COUCHBASEBUCKET
 configuration:
   entityExpirationTime: DAILY
   alertable: true
+
+dashboardTemplates:
+  # This should match the entity created from the ohi in the infra pipeline
+  newRelic:
+    template: newrelic_dashboard.json

--- a/entity-types/infra-couchbasebucket/newrelic_dashboard.json
+++ b/entity-types/infra-couchbasebucket/newrelic_dashboard.json
@@ -1,0 +1,290 @@
+{
+  "name": "CouchbaseBucketSample",
+  "pages": [
+    {
+      "name": "CouchbaseBucketSample",
+      "widgets": [
+        {
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Current connections",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`couchbase.bucket.currentConnections`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 7,
+            "row": 1,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Total operations per second",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`couchbase.bucket.totalOperationsPerSecond`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Data used",
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`couchbase.bucket.dataUsedInBytes`) FROM Metric "
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Active resident items ratio",
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`couchbase.bucket.activeResidentItemsRatio`) FROM Metric "
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Ejections per second",
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`couchbase.bucket.ejectionsPerSecond`) FROM Metric "
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Read rate per second",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`couchbase.bucket.readRatePerSecond`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 7,
+            "row": 7,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Read operations per second",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`couchbase.bucket.readOperationsPerSecond`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 10,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Write rate per second",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`couchbase.bucket.writeRatePerSecond`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 7,
+            "row": 10,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Write operations per second",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`couchbase.bucket.writeOperationsPerSecond`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 13,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Memory usage",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`couchbase.bucket.memoryUsedInBytes`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 5,
+            "row": 13,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Quota utilization",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`couchbase.bucket.quotaUtilization`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 9,
+            "row": 13,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Disk usage",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`couchbase.bucket.diskUsedInBytes`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 16,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Disk write queue",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`couchbase.bucket.diskWriteQueue`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 7,
+            "row": 16,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Out of memory errors per second",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`couchbase.bucket.outOfMemoryErrorsPerSecond`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-couchbasecluster/definition.yml
+++ b/entity-types/infra-couchbasecluster/definition.yml
@@ -3,3 +3,8 @@ type: COUCHBASECLUSTER
 configuration:
   entityExpirationTime: DAILY
   alertable: true
+
+dashboardTemplates:
+  # This should match the entity created from the ohi in the infra pipeline
+  newRelic:
+    template: newrelic_dashboard.json

--- a/entity-types/infra-couchbasecluster/newrelic_dashboard.json
+++ b/entity-types/infra-couchbasecluster/newrelic_dashboard.json
@@ -1,0 +1,250 @@
+{
+  "name": "CouchbaseClusterSample",
+  "pages": [
+    {
+      "name": "CouchbaseClusterSample",
+      "widgets": [
+        {
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Used disk space",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`couchbase.cluster.diskUsedInBytes`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Total disk space",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`couchbase.cluster.diskTotalInBytes`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Disk space",
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`couchbase.cluster.diskUsedByDataInBytes`) FROM Metric "
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Total RAM",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`couchbase.cluster.memoryTotalInBytes`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Used RAM by data",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`couchbase.cluster.memoryUsedByDataInBytes`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Used RAM",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`couchbase.cluster.memoryUsedInBytes`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "title": "The number of auto failovers",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`couchbase.cluster.autoFailoverCount`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 5,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Indicates if failover is enabled",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`couchbase.cluster.autoFailoverEnabled`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 9,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Maximum number of buckets",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`couchbase.cluster.maximumBucketCount`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 10,
+            "width": 4,
+            "height": 3
+          },
+          "title": "The percentage level within the database at which compaction occurs",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`couchbase.cluster.databaseFragmentationThreshold`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 5,
+            "row": 10,
+            "width": 4,
+            "height": 3
+          },
+          "title": "The percentage level within indexes at which compaction occurs",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`couchbase.cluster.indexFragmentationThreshold`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 9,
+            "row": 10,
+            "width": 4,
+            "height": 3
+          },
+          "title": "The percentage of fragmentation within all the view index files at which compaction is triggered",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`couchbase.cluster.viewFragmentationThreshold`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-couchbasenode/definition.yml
+++ b/entity-types/infra-couchbasenode/definition.yml
@@ -3,3 +3,8 @@ type: COUCHBASENODE
 configuration:
   entityExpirationTime: DAILY
   alertable: true
+
+dashboardTemplates:
+  # This should match the entity created from the ohi in the infra pipeline
+  newRelic:
+    template: newrelic_dashboard.json

--- a/entity-types/infra-couchbasenode/newrelic_dashboard.json
+++ b/entity-types/infra-couchbasenode/newrelic_dashboard.json
@@ -1,0 +1,130 @@
+{
+  "name": "CouchbaseNodeSample",
+  "pages": [
+    {
+      "name": "CouchbaseNodeSample",
+      "widgets": [
+        {
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Node status",
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`couchbase.nodeStatus`) FROM Metric "
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Memory free",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`couchbase.node.memoryFreeInBytes`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Swap used",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`couchbase.node.swapUsedInBytes`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "title": "CPU utilization",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`couchbase.node.cpuUtilization`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Memory total",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`couchbase.node.memoryTotalInBytes`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Swap total",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`couchbase.node.swapTotalInBytes`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-elasticsearchnode/definition.yml
+++ b/entity-types/infra-elasticsearchnode/definition.yml
@@ -7,3 +7,8 @@ goldenTags:
 configuration:
   entityExpirationTime: DAILY
   alertable: true
+
+dashboardTemplates:
+  # This should match the entity created from the ohi in the infra pipeline
+  newRelic:
+    template: newrelic_dashboard.json

--- a/entity-types/infra-elasticsearchnode/newrelic_dashboard.json
+++ b/entity-types/infra-elasticsearchnode/newrelic_dashboard.json
@@ -1,0 +1,250 @@
+{
+  "name": "ElasticsearchNodeSample",
+  "pages": [
+    {
+      "name": "ElasticsearchNodeSample",
+      "widgets": [
+        {
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Running GET requests and Missing requests",
+          "visualization": {
+            "id": "viz.area"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`elasticsearch.node.get.currentRequestsRunning`) as 'Running', average(`elasticsearch.node.get.requestsDocumentMissing`) as 'Missing' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 7,
+            "row": 1,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Total I/O operations",
+          "visualization": {
+            "id": "viz.area"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`elasticsearch.node.fs.ioOperations`) as 'I/O operations' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Documents currently being indexed and deleted",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`elasticsearch.node.indexing.documentsCurrentlyIndexing`) as 'Indexed',average(`elasticsearch.node.indexing.docsCurrentlyDeleted`) as 'Deleted' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Total documents indexed and deleted",
+          "visualization": {
+            "id": "viz.area"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`elasticsearch.node.indexing.documentsIndexed`) as 'Indexed', average(`elasticsearch.node.indexing.totalDocumentsDeleted`) as 'Deleted' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Time spent indexing and deleting documents",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`elasticsearch.node.indexing.timeIndexingDocumentsInMilliseconds`) as 'Indexed', average(`elasticsearch.node.indexing.timeDeletingDocumentsInMilliseconds`) as 'Deleted' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Query cache evictions, hits and misses",
+          "visualization": {
+            "id": "viz.area"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`elasticsearch.node.index.queryCacheEvictions`) as 'Evictions', average(`elasticsearch.node.index.queryCacheHits`) as 'Hits', average(`elasticsearch.node.index.queryCacheMisses`) as 'Misses' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 7,
+            "row": 7,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Shard source ongoing recoveries",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`elasticsearch.node.index.recoveryOngoingShardSource`) as 'Ongoing recoveries' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 10,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Doc merges across segments",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`elasticsearch.node.merges.docsSegmentsMerging`) as 'Documents' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 7,
+            "row": 10,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Current active segment merges",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`elasticsearch.node.merges.currentActive`) as 'Active segment' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 13,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Total garbage collections run by the JVM",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`jvm.gc.collections`) as 'Garbage collections' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 5,
+            "row": 13,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Memory currently used by JVM.",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`elasticsearch.node.jvm.mem.heapUsed`) as 'Memory used' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 9,
+            "row": 13,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Threads active in the JVM.",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`elasticsearch.node.jvm.threadsActive`) as 'Threads active' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-f5node/definition.yml
+++ b/entity-types/infra-f5node/definition.yml
@@ -3,3 +3,8 @@ type: F5NODE
 configuration:
   entityExpirationTime: DAILY
   alertable: true
+
+dashboardTemplates:
+  # This should match the entity created from the ohi in the infra pipeline
+  newRelic:
+    template: newrelic_dashboard.json

--- a/entity-types/infra-f5node/newrelic_dashboard.json
+++ b/entity-types/infra-f5node/newrelic_dashboard.json
@@ -1,0 +1,90 @@
+{
+  "name": "F5BigIpNodeSample",
+  "pages": [
+    {
+      "name": "F5BigIpNodeSample",
+      "widgets": [
+        {
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Node connections",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`f5.node.connections`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 7,
+            "row": 1,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Node requests",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`f5.node.requestsPerSecond`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Node packets out",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`f5.node.sessions`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 7,
+            "row": 4,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Node packets in",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`node.packetsReceived`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-f5pool/definition.yml
+++ b/entity-types/infra-f5pool/definition.yml
@@ -4,3 +4,8 @@ goldenTags: []
 configuration:
   entityExpirationTime: DAILY
   alertable: true
+
+dashboardTemplates:
+  # This should match the entity created from the ohi in the infra pipeline
+  newRelic:
+    template: newrelic_dashboard.json

--- a/entity-types/infra-f5pool/newrelic_dashboard.json
+++ b/entity-types/infra-f5pool/newrelic_dashboard.json
@@ -1,0 +1,110 @@
+{
+  "name": "F5BigIpPoolSample",
+  "pages": [
+    {
+      "name": "F5BigIpPoolSample",
+      "widgets": [
+        {
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 4
+          },
+          "title": "Pool availability status",
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`f5.pool.availabilityState`) FROM Metric "
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 4
+          },
+          "title": "Pool requests",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`f5.pool.requestsPerSecond`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 4
+          },
+          "title": "Pool connections",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`f5.pool.connections`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 5,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Pool packets in",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`f5.pool.packetsReceivedPerSecond`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 7,
+            "row": 5,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Pool packets out",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`f5.pool.packetsSentPerSecond`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-f5poolmember/definition.yml
+++ b/entity-types/infra-f5poolmember/definition.yml
@@ -4,3 +4,8 @@ goldenTags: []
 configuration:
   entityExpirationTime: DAILY
   alertable: true
+
+dashboardTemplates:
+  # This should match the entity created from the ohi in the infra pipeline
+  newRelic:
+    template: newrelic_dashboard.json

--- a/entity-types/infra-f5poolmember/newrelic_dashboard.json
+++ b/entity-types/infra-f5poolmember/newrelic_dashboard.json
@@ -1,0 +1,110 @@
+{
+  "name": "F5BigIpPoolMemberSample",
+  "pages": [
+    {
+      "name": "F5BigIpPoolMemberSample",
+      "widgets": [
+        {
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Pool member connections",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`f5.poolMember.connections`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Pool member requests",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`f5.poolMember.requestsPerSecond`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Pool member sessions",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`f5.poolMember.sessions`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Pool member packets in",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`f5.poolMember.packetsReceivedPerSecond`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 7,
+            "row": 4,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Pool member packets out",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`f5.poolMember.packetsSentPerSecond`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-f5system/definition.yml
+++ b/entity-types/infra-f5system/definition.yml
@@ -3,3 +3,8 @@ type: F5SYSTEM
 configuration:
   entityExpirationTime: DAILY
   alertable: true
+
+dashboardTemplates:
+  # This should match the entity created from the ohi in the infra pipeline
+  newRelic:
+    template: newrelic_dashboard.json

--- a/entity-types/infra-f5system/newrelic_dashboard.json
+++ b/entity-types/infra-f5system/newrelic_dashboard.json
@@ -1,0 +1,110 @@
+{
+  "name": "F5BigIpSystemSample",
+  "pages": [
+    {
+      "name": "F5BigIpSystemSample",
+      "widgets": [
+        {
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Average percentage of time the CPU is used by user processes",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`f5.system.cpuUserUtilization`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Average percentage of time the CPU is used by the kernel",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`f5.system.cpuSystemUtilization`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Average percentage of time the CPU is idle",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`f5.system.cpuIdleUtilization`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Total amount of memory used in bytes",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`f5.system.memoryUsedInBytes`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 7,
+            "row": 4,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Swap space used in bytes",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`f5.system.swapUsedInBytes`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-f5virtualserver/definition.yml
+++ b/entity-types/infra-f5virtualserver/definition.yml
@@ -4,3 +4,8 @@ goldenTags: []
 configuration:
   entityExpirationTime: DAILY
   alertable: true
+
+dashboardTemplates:
+  # This should match the entity created from the ohi in the infra pipeline
+  newRelic:
+    template: newrelic_dashboard.json

--- a/entity-types/infra-f5virtualserver/newrelic_dashboard.json
+++ b/entity-types/infra-f5virtualserver/newrelic_dashboard.json
@@ -1,0 +1,110 @@
+{
+  "name": "F5BigIpVirtualServerSample",
+  "pages": [
+    {
+      "name": "F5BigIpVirtualServerSample",
+      "widgets": [
+        {
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 4
+          },
+          "title": "Virtual server availability status",
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(f5.virtualserver.availabilityState) FROM Metric "
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 8,
+            "height": 4
+          },
+          "title": "Virtual server connections",
+          "visualization": {
+            "id": "viz.bar"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`f5.virtualserver.connections`) FROM Metric "
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 5,
+            "width": 6,
+            "height": 6
+          },
+          "title": "Virtual server requests",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`f5.virtualserver.requestsPerSecond`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 7,
+            "row": 5,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Virtual server data in",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`f5.virtualserver.inDataInBytesPerSecond`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 8,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Virtual server data out",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`f5.virtualserver.outDataInBytesPerSecond`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-kafkabroker/definition.yml
+++ b/entity-types/infra-kafkabroker/definition.yml
@@ -6,3 +6,8 @@ goldenTags:
 configuration:
   entityExpirationTime: DAILY
   alertable: true
+
+dashboardTemplates:
+  # This should match the entity created from the ohi in the infra pipeline
+  newRelic:
+    template: newrelic_dashboard.json

--- a/entity-types/infra-kafkabroker/newrelic_dashboard.json
+++ b/entity-types/infra-kafkabroker/newrelic_dashboard.json
@@ -1,0 +1,130 @@
+{
+  "name": "KafkaBrokerSample",
+  "pages": [
+    {
+      "name": "KafkaBrokerSample",
+      "widgets": [
+        {
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Messages",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`kafka.broker.messagesInPerSecond`) as 'Messages in per second' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 7,
+            "row": 1,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Bytes in and out",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`kafka.broker.ioInPerSecond`) as 'Bytes in', average(`kafka.broker.ioOutPerSecond`) as 'Bytes out' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Bytes written",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`kafka.broker.bytesWrittenToTopicPerSecond`) as 'Bytes written' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 7,
+            "row": 4,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Unreplicated partitions",
+          "visualization": {
+            "id": "viz.bar"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`kafka.broker.replication.unreplicatedPartitions`) as 'Partitions' FROM Metric "
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Produce requests failed per second",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`kafka.broker.request.produceRequestsFailedPerSecond`) as 'Requests' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 7,
+            "row": 7,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Request produce time 99 percentile",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`kafka.broker.request.produceTime99Percentile`) as 'Requests' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-memcachedinstance/definition.yml
+++ b/entity-types/infra-memcachedinstance/definition.yml
@@ -3,3 +3,8 @@ type: MEMCACHEDINSTANCE
 configuration:
   entityExpirationTime: DAILY
   alertable: true
+
+dashboardTemplates:
+  # This should match the entity created from the ohi in the infra pipeline
+  newRelic:
+    template: newrelic_dashboard.json

--- a/entity-types/infra-memcachedinstance/newrelic_dashboard.json
+++ b/entity-types/infra-memcachedinstance/newrelic_dashboard.json
@@ -1,0 +1,150 @@
+{
+  "name": "MemcachedSample",
+  "pages": [
+    {
+      "name": "MemcachedSample",
+      "widgets": [
+        {
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 6,
+            "height": 4
+          },
+          "title": "Bytes read",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`memcached.server.bytesReadServerPerSecond`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 7,
+            "row": 1,
+            "width": 6,
+            "height": 4
+          },
+          "title": "Bytes written",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`memcached.server.bytesWrittenServerPerSecond`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 5,
+            "width": 6,
+            "height": 4
+          },
+          "title": "Command rates",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`memcached.server.cmdGetRatePerSecond`), average(`memcached.server.cmdSetRatePerSecond`), average(`memcached.server.cmdFlushRatePerSecond`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 7,
+            "row": 5,
+            "width": 6,
+            "height": 4
+          },
+          "title": "Connection rate",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`memcached.server.connectionRateServerPerSecond`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 9,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Uptime (Hours)",
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(memcached.server.uptimeInMilliseconds)/1000/3600 AS `Hours` FROM Metric "
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 5,
+            "row": 9,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Open connections (Connections)",
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`memcached.server.openConnectionsServer`) FROM Metric "
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 9,
+            "row": 9,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Percent max memory used (%)",
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`memcached.server.storingItemsPercentMemory`) FROM Metric "
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-mssqlinstance/definition.yml
+++ b/entity-types/infra-mssqlinstance/definition.yml
@@ -6,3 +6,8 @@ goldenTags:
 configuration:
   entityExpirationTime: DAILY
   alertable: true
+
+dashboardTemplates:
+  # This should match the entity created from the ohi in the infra pipeline
+  newRelic:
+    template: newrelic_dashboard.json

--- a/entity-types/infra-mssqlinstance/newrelic_dashboard.json
+++ b/entity-types/infra-mssqlinstance/newrelic_dashboard.json
@@ -1,0 +1,210 @@
+{
+  "name": "MssqlInstanceSample",
+  "pages": [
+    {
+      "name": "MssqlInstanceSample",
+      "widgets": [
+        {
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Connections",
+          "visualization": {
+            "id": "viz.area"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`mssql.instance.stats.connections`) as 'Connections' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 7,
+            "row": 1,
+            "width": 6,
+            "height": 3
+          },
+          "title": "SQL compilations and re-compilations",
+          "visualization": {
+            "id": "viz.area"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`mssql.instance.stats.sqlCompilationsPerSecond`) as `Compilations`, average(`mssql.instance.stats.sqlRecompilationsPerSecond`) as `Re-compilations` FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Buffer cache hit percentage",
+          "visualization": {
+            "id": "viz.area"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`mssql.instance.system.bufferPoolHitPercent`) as 'Cache hit' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Average batch requests",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`mssql.instance.bufferpool.batchRequestsPerSecond`) as 'Batch requests' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Page life expectancy",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`mssql.instance.bufferpool.pageLifeExpectancyInMilliseconds`) as 'Page life expentancy' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Number of blocked processes",
+          "visualization": {
+            "id": "viz.area"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`mssql.instance.instance.blockedProcessesCount`) as 'Blocked processes' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 5,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Lock waits",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`mssql.instance.stats.lockWaitsPerSecond`) as 'Times' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 9,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Total wait time",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`mssql.instance.system.waitTimeInMillisecondsPerSecond`) as 'Wait time' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 10,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Page splits",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`mssql.instance.access.pageSplitsPerSecond`) as 'Page splits' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 7,
+            "row": 10,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Checkpoint pages",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`mssql.instance.buffer.checkpointPagesPerSecond`) as 'Checkpoint pages' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-mysqlnode/definition.yml
+++ b/entity-types/infra-mysqlnode/definition.yml
@@ -9,3 +9,8 @@ goldenTags:
 configuration:
   entityExpirationTime: DAILY
   alertable: true
+
+dashboardTemplates:
+  # This should match the entity created from the ohi in the infra pipeline
+  newRelic:
+    template: newrelic_dashboard.json

--- a/entity-types/infra-mysqlnode/newrelic_dashboard.json
+++ b/entity-types/infra-mysqlnode/newrelic_dashboard.json
@@ -1,0 +1,150 @@
+{
+  "name": "MysqlSample",
+  "pages": [
+    {
+      "name": "MysqlSample",
+      "widgets": [
+        {
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 12,
+            "height": 3
+          },
+          "title": "Operations per second",
+          "visualization": {
+            "id": "viz.area"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`mysql.node.query.insertPerSecond`) as 'Insert commands', average(`mysql.node.query.selectPerSecond`) as 'Select commands', average(`mysql.node.query.updatePerSecond`) as 'Update comands', average(`mysql.node.query.deletePerSecond`) as 'Delete commands' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Queries per second",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`mysql.node.query.queriesPerSecond`) as 'Queries' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 7,
+            "row": 4,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Slow queries per minute",
+          "visualization": {
+            "id": "viz.area"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`mysql.node.query.slowQueriesPerSecond`) * 60 as 'Slow queries' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Active connections",
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`mysql.node.net.threadsConnected`) as 'Active connections' FROM Metric "
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 7,
+            "row": 7,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Max connections",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT max(`mysql.node.net.threadsConnected`) as 'Max connections' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 10,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Read and written InnoDB bytes per second",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`mysql.node.innodb.dataReadBytesPerSecond`) as 'Read InnoDB data', average(`mysql.node.innodb.dataWrittenBytesPerSecond`) as 'Write InnoDB data' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 7,
+            "row": 10,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Received and sent bytes per second",
+          "visualization": {
+            "id": "viz.area"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`mysql.node.net.bytesReceivedPerSecond`) as 'Bytes received', average(`mysql.node.net.bytesSentPerSecond`) as 'Bytes sent' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-nginxserver/definition.yml
+++ b/entity-types/infra-nginxserver/definition.yml
@@ -8,3 +8,8 @@ goldenTags:
 configuration:
   entityExpirationTime: DAILY
   alertable: true
+
+dashboardTemplates:
+  # This should match the entity created from the ohi in the infra pipeline
+  newRelic:
+    template: newrelic_dashboard.json

--- a/entity-types/infra-nginxserver/newrelic_dashboard.json
+++ b/entity-types/infra-nginxserver/newrelic_dashboard.json
@@ -1,0 +1,90 @@
+{
+  "name": "NginxSample",
+  "pages": [
+    {
+      "name": "NginxSample",
+      "widgets": [
+        {
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Requests per second",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`nginx.server.net.requestsPerSecond`) as 'Requests' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 7,
+            "row": 1,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Active connections",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`nginx.server.net.connectionsActive`) as 'Active connections' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Connections accepted per second",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`nginx.server.net.connectionsAcceptedPerSecond`) as 'Connections accepted' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 7,
+            "row": 4,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Connections dropped per second",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`nginx.server.net.connectionsDroppedPerSecond`) as 'Connections dropped' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-oracledbinstance/definition.yml
+++ b/entity-types/infra-oracledbinstance/definition.yml
@@ -4,3 +4,8 @@ goldenTags: []
 configuration:
   entityExpirationTime: DAILY
   alertable: true
+
+dashboardTemplates:
+  # This should match the entity created from the ohi in the infra pipeline
+  newRelic:
+    template: newrelic_dashboard.json

--- a/entity-types/infra-oracledbinstance/newrelic_dashboard.json
+++ b/entity-types/infra-oracledbinstance/newrelic_dashboard.json
@@ -1,0 +1,170 @@
+{
+  "name": "OracleDatabaseSample",
+  "pages": [
+    {
+      "name": "OracleDatabaseSample",
+      "widgets": [
+        {
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Executions",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`oracle.database.executionsPerSecond`) as 'Executions' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Session count",
+          "visualization": {
+            "id": "viz.area"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`oracle.database.sessionCount`) AS `Sessions` FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Transactions",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`oracle.database.query.transactionsPerSecond`) as 'Transactions' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Disk reads and writes",
+          "visualization": {
+            "id": "viz.area"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`oracle.database.disk.readsPerSecond`) as 'Reads',average(`oracle.database.disk.writesPerSecond`) as 'Writes' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Total physical reads and writes in bytes",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`oracle.database.disk.physicalReadBytesPerSecond`) as 'Physical reads', average(`oracle.database.disk.physicalWritesPerSecond`) as 'Physical writes' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "title": "IO megabytes",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`oracle.database.network.ioMegabytesPerSecond`) as 'IO megabytes' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Host CPU utilization",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`oracle.database.hostCpuUtilization`) as 'CPU utilization' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 7,
+            "row": 7,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Global bound memory",
+          "visualization": {
+            "id": "viz.area"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`oracle.database.memory.pgaMaxSizeInBytes`) as 'Max size' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-postgresqlinstance/definition.yml
+++ b/entity-types/infra-postgresqlinstance/definition.yml
@@ -5,3 +5,8 @@ goldenTags:
 configuration:
   entityExpirationTime: DAILY
   alertable: true
+
+dashboardTemplates:
+  # This should match the entity created from the ohi in the infra pipeline
+  newRelic:
+    template: newrelic_dashboard.json

--- a/entity-types/infra-postgresqlinstance/newrelic_dashboard.json
+++ b/entity-types/infra-postgresqlinstance/newrelic_dashboard.json
@@ -1,0 +1,210 @@
+{
+  "name": "PostgresqlInstanceSample",
+  "pages": [
+    {
+      "name": "PostgresqlInstanceSample",
+      "widgets": [
+        {
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Scheduled checkpoints",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`postgres.instance.bgwriter.checkpointsScheduledPerSecond`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 4,
+            "row": 1,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Requested checkpoints",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`postgres.instance.bgwriter.checkpointsRequestedPerSecond`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 7,
+            "row": 1,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Buffers written for checkpoint",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`postgres.instance.bgwriter.buffersWrittenForCheckpointsPerSecond`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 10,
+            "row": 1,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Buffers written by background writer",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`postgres.instance.bgwriter.buffersWrittenByBackgroundWriterPerSecond`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Background writer stops",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`postgres.instance.bgwriter.backgroundWriterStopsPerSecond`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 4,
+            "row": 4,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Buffers written per backend",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`postgres.instance.bgwriter.buffersWrittenByBackendPerSecond`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 7,
+            "row": 4,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Buffers allocated",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`postgres.instance.bgwriter.buffersAllocatedPerSecond`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 10,
+            "row": 4,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Backend fsync Calls",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`postgres.instance.bgwriter.backendFsyncCallsPerSecond`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Checkpoint write Time",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`postgres.instance.bgwriter.checkpointWriteTimeInMillisecondsPerSecond`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 4,
+            "row": 7,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Checkpoint sync Time",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`postgres.instance.bgwriter.checkpointSyncTimeInMillisecondsPerSecond`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-rabbitmqcluster/definition.yml
+++ b/entity-types/infra-rabbitmqcluster/definition.yml
@@ -5,3 +5,8 @@ goldenTags:
 configuration:
   entityExpirationTime: DAILY
   alertable: true
+
+dashboardTemplates:
+  # This should match the entity created from the ohi in the infra pipeline
+  newRelic:
+    template: newrelic_dashboard.json

--- a/entity-types/infra-rabbitmqcluster/newrelic_dashboard.json
+++ b/entity-types/infra-rabbitmqcluster/newrelic_dashboard.json
@@ -1,0 +1,90 @@
+{
+  "name": "RabbitmqNodeSample",
+  "pages": [
+    {
+      "name": "RabbitmqNodeSample",
+      "widgets": [
+        {
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Node health summary",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT uniqueCount(entity.name) as 'Total', filter(uniqueCount(entity.name), where `rabbitmq.node.running` = 1) as 'Running', filter(uniqueCount(entity.name), where `rabbitmq.node.hostMemoryAlarm` = 1) as 'Memory Alarms', filter(uniqueCount(entity.name), where `rabbitmq.node.diskAlarm` = 1) as 'Disk Alarms' FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 4,
+            "row": 1,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Total memory used",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`rabbitmq.node.totalMemoryUsedInBytes`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 7,
+            "row": 1,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Total file descriptors used",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`rabbitmq.node.fileDescriptorsTotalUsed`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 10,
+            "row": 1,
+            "width": 3,
+            "height": 3
+          },
+          "title": "File descriptors used as sockets",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`rabbitmq.node.fileDescriptorsUsedSockets`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-rabbitmqexchange/definition.yml
+++ b/entity-types/infra-rabbitmqexchange/definition.yml
@@ -5,3 +5,8 @@ goldenTags:
 configuration:
   entityExpirationTime: DAILY
   alertable: true
+
+dashboardTemplates:
+  # This should match the entity created from the ohi in the infra pipeline
+  newRelic:
+    template: newrelic_dashboard.json

--- a/entity-types/infra-rabbitmqexchange/newrelic_dashboard.json
+++ b/entity-types/infra-rabbitmqexchange/newrelic_dashboard.json
@@ -1,0 +1,70 @@
+{
+  "name": "RabbitMqExchangeSample",
+  "pages": [
+    {
+      "name": "RabbitMqExchangeSample",
+      "widgets": [
+        {
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 4
+          },
+          "title": "Number of bindings",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`rabbitmq.exchange.bindings`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 4
+          },
+          "title": "Messages published per channel",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`rabbitmq.exchange.messagesPublishedPerChannelPerSecond`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 4
+          },
+          "title": "Messages published into a queue",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`rabbitmq.exchange.messagesPublishedQueuePerSecond`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-rabbitmqnode/definition.yml
+++ b/entity-types/infra-rabbitmqnode/definition.yml
@@ -5,3 +5,8 @@ goldenTags:
 configuration:
   entityExpirationTime: DAILY
   alertable: true
+
+dashboardTemplates:
+  # This should match the entity created from the ohi in the infra pipeline
+  newRelic:
+    template: newrelic_dashboard.json

--- a/entity-types/infra-rabbitmqnode/newrelic_dashboard.json
+++ b/entity-types/infra-rabbitmqnode/newrelic_dashboard.json
@@ -1,0 +1,70 @@
+{
+  "name": "RabbitmqNodeSample",
+  "pages": [
+    {
+      "name": "RabbitmqNodeSample",
+      "widgets": [
+        {
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 4
+          },
+          "title": "Total used file descriptors",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`rabbitmq.node.fileDescriptorsTotalUsed`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 4
+          },
+          "title": "File descriptors used sockets",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`rabbitmq.node.fileDescriptorsUsedSockets`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 4
+          },
+          "title": "Total memory usage",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`rabbitmq.node.totalMemoryUsedInBytes`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-rabbitmqqueue/definition.yml
+++ b/entity-types/infra-rabbitmqqueue/definition.yml
@@ -5,3 +5,8 @@ goldenTags:
 configuration:
   entityExpirationTime: DAILY
   alertable: true
+
+dashboardTemplates:
+  # This should match the entity created from the ohi in the infra pipeline
+  newRelic:
+    template: newrelic_dashboard.json

--- a/entity-types/infra-rabbitmqqueue/newrelic_dashboard.json
+++ b/entity-types/infra-rabbitmqqueue/newrelic_dashboard.json
@@ -1,0 +1,150 @@
+{
+  "name": "RabbitmqQueueSample",
+  "pages": [
+    {
+      "name": "RabbitmqQueueSample",
+      "widgets": [
+        {
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Total messages",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`rabbitmq.queue.totalMessages`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Published messages",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`rabbitmq.queue.messagesPublished`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Published messages throughput",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`rabbitmq.queue.messagesPublishedPerSecond`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Total messages throughput",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`rabbitmq.queue.totalMessagesPerSecond`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Consumer messages",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`rabbitmq.queue.consumerMessageUtilizationPerSecond`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Bytes consumed",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`rabbitmq.queue.erlangBytesConsumedInBytes`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Consumers",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`rabbitmq.queue.consumers`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-varnishinstance/definition.yml
+++ b/entity-types/infra-varnishinstance/definition.yml
@@ -3,3 +3,8 @@ type: VARNISHINSTANCE
 configuration:
   entityExpirationTime: DAILY
   alertable: true
+
+dashboardTemplates:
+  # This should match the entity created from the ohi in the infra pipeline
+  newRelic:
+    template: newrelic_dashboard.json

--- a/entity-types/infra-varnishinstance/newrelic_dashboard.json
+++ b/entity-types/infra-varnishinstance/newrelic_dashboard.json
@@ -1,0 +1,250 @@
+{
+  "name": "VarnishSample",
+  "pages": [
+    {
+      "name": "VarnishSample",
+      "widgets": [
+        {
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Session connections",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`varnish.session.connections`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 7,
+            "row": 1,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Requests",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`varnish.net.requests`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Session drops",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`varnish.session.drops`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Expired objects",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`varnish.main.expiredMailed`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "title": "LRU purges",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`varnish.lru.nuked`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Cache hits",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`varnish.cache.hits`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 7,
+            "row": 7,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Cache misses",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`varnish.cache.misses`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 10,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Cache hits for pass",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`varnish.cache.passHits`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 5,
+            "row": 10,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Cache grace hits",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`varnish.cache.graceHits`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 9,
+            "row": 10,
+            "width": 4,
+            "height": 3
+          },
+          "title": "Cache hits for miss",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`varnish.cache.missHits`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 13,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Backend requests",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`varnish.backend.net.requests`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 7,
+            "row": 13,
+            "width": 6,
+            "height": 3
+          },
+          "title": "Backend connections",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`varnish.backend.connections`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-vspherecluster/definition.yml
+++ b/entity-types/infra-vspherecluster/definition.yml
@@ -8,3 +8,8 @@ goldenTags:
 configuration:
   entityExpirationTime: DAILY
   alertable: true
+
+dashboardTemplates:
+  # This should match the entity created from the ohi in the infra pipeline
+  newRelic:
+    template: newrelic_dashboard.json

--- a/entity-types/infra-vspherecluster/newrelic_dashboard.json
+++ b/entity-types/infra-vspherecluster/newrelic_dashboard.json
@@ -1,0 +1,130 @@
+{
+  "name": "VSphereClusterSample",
+  "pages": [
+    {
+      "name": "VSphereClusterSample",
+      "widgets": [
+        {
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Overall status",
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`vsphere.clusterOverallStatus`) FROM Metric "
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 4,
+            "row": 1,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Host and effective host count",
+          "visualization": {
+            "id": "viz.bar"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`vsphere.cluster.hosts`),latest(`vsphere.cluster.effectiveHosts`) FROM Metric "
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 7,
+            "row": 1,
+            "width": 3,
+            "height": 3
+          },
+          "title": "CPU total effective and total MHz",
+          "visualization": {
+            "id": "viz.area"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`vsphere.cluster.cpu.totalEffectiveMHz`),average(`vsphere.cluster.cpu.totalMhz`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 10,
+            "row": 1,
+            "width": 3,
+            "height": 3
+          },
+          "title": "CPU cores",
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`vsphere.cluster.cpu.cores`) FROM Metric "
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 3,
+            "height": 3
+          },
+          "title": "CPU threads",
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`vsphere.cluster.cpu.threads`) FROM Metric "
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 4,
+            "row": 4,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Memory effective size and total MiB",
+          "visualization": {
+            "id": "viz.area"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`vsphere.cluster.mem.effectiveSize`),average(`vsphere.cluster.mem.size`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-vspheredatacenter/definition.yml
+++ b/entity-types/infra-vspheredatacenter/definition.yml
@@ -4,3 +4,8 @@ goldenTags: []
 configuration:
   entityExpirationTime: DAILY
   alertable: true
+
+dashboardTemplates:
+  # This should match the entity created from the ohi in the infra pipeline
+  newRelic:
+    template: newrelic_dashboard.json

--- a/entity-types/infra-vspheredatacenter/newrelic_dashboard.json
+++ b/entity-types/infra-vspheredatacenter/newrelic_dashboard.json
@@ -1,0 +1,210 @@
+{
+  "name": "VSphereDatacenterSample",
+  "pages": [
+    {
+      "name": "VSphereDatacenterSample",
+      "widgets": [
+        {
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Datacenter resources count",
+          "visualization": {
+            "id": "viz.bar"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`vsphere.datacenter.hostCount`),latest(`vsphere.datacenter.vmCount`),latest(`vsphere.datacenter.clusters`),latest(`vsphere.datacenter.resourcePools`),latest(`vsphere.datacenter.datastores`),latest(`vsphere.datacenter.networks`) FROM Metric "
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 4,
+            "row": 1,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Overall status",
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`vsphere.datacenterOverallStatus`) FROM Metric "
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 7,
+            "row": 1,
+            "width": 3,
+            "height": 3
+          },
+          "title": "CPU cores",
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`vsphere.datacenter.cpu.cores`) FROM Metric "
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 10,
+            "row": 1,
+            "width": 3,
+            "height": 3
+          },
+          "title": "CPU overall usage and total MHz",
+          "visualization": {
+            "id": "viz.area"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`vsphere.datacenter.cpu.overallUsage`),average(`vsphere.datacenter.cpu.totalMhz`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 3,
+            "height": 3
+          },
+          "title": "CPU overall usage %",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`vsphere.datacenter.cpu.overallUsagePercentage`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 4,
+            "row": 4,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Datastore capacity GiB",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`vsphere.datacenter.datastore.totalGiB`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 7,
+            "row": 4,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Datastore used space GiB",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`vsphere.datacenter.datastore.totalUsedGiB`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 10,
+            "row": 4,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Datastore free space GiB",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`vsphere.datacenter.datastore.totalFreeGiB`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Memory usage %",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`vsphere.datacenter.mem.usagePercentage`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 4,
+            "row": 7,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Memory usage and size MiB",
+          "visualization": {
+            "id": "viz.area"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`vsphere.datacenter.mem.usage`),average(`vsphere.datacenter.mem.size`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-vspheredatastore/definition.yml
+++ b/entity-types/infra-vspheredatastore/definition.yml
@@ -4,3 +4,8 @@ goldenTags: []
 configuration:
   entityExpirationTime: DAILY
   alertable: true
+
+dashboardTemplates:
+  # This should match the entity created from the ohi in the infra pipeline
+  newRelic:
+    template: newrelic_dashboard.json

--- a/entity-types/infra-vspheredatastore/newrelic_dashboard.json
+++ b/entity-types/infra-vspheredatastore/newrelic_dashboard.json
@@ -1,0 +1,110 @@
+{
+  "name": "VSphereDatastoreSample",
+  "pages": [
+    {
+      "name": "VSphereDatastoreSample",
+      "widgets": [
+        {
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Host and virtual machines count",
+          "visualization": {
+            "id": "viz.bar"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`vsphere.datastore.hostCount`),latest(`vsphere.datastore.vmCount`) FROM Metric "
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 4,
+            "row": 1,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Accessible",
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`vsphere.datastoreAccessible`) FROM Metric "
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 7,
+            "row": 1,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Capacity GiB",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`vsphere.datastore.capacity`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 10,
+            "row": 1,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Uncommitted space GiB",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`vsphere.datastore.uncommitted`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Free space GiB",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`vsphere.datastore.freeSpace`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-vspherehost/definition.yml
+++ b/entity-types/infra-vspherehost/definition.yml
@@ -10,3 +10,8 @@ goldenTags:
 configuration:
   entityExpirationTime: DAILY
   alertable: true
+
+dashboardTemplates:
+  # This should match the entity created from the ohi in the infra pipeline
+  newRelic:
+    template: newrelic_dashboard.json

--- a/entity-types/infra-vspherehost/newrelic_dashboard.json
+++ b/entity-types/infra-vspherehost/newrelic_dashboard.json
@@ -1,0 +1,210 @@
+{
+  "name": "VSphereHostSample",
+  "pages": [
+    {
+      "name": "VSphereHostSample",
+      "widgets": [
+        {
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Connection state",
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`vsphere.hostConnectionState`) FROM Metric "
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 4,
+            "row": 1,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Overall status",
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`vsphere.hostOverallStatus`) FROM Metric "
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 7,
+            "row": 1,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Virtual machines count",
+          "visualization": {
+            "id": "viz.bar"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`vsphere.host.vmCount`) FROM Metric "
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 10,
+            "row": 1,
+            "width": 3,
+            "height": 3
+          },
+          "title": "CPU utilization %",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`vsphere.host.cpu.percent`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 3,
+            "height": 3
+          },
+          "title": "CPU available MHz",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`vsphere.host.cpu.available`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 4,
+            "row": 4,
+            "width": 3,
+            "height": 3
+          },
+          "title": "CPU overall usage and total MHz",
+          "visualization": {
+            "id": "viz.area"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`vsphere.host.cpu.overallUsage`),average(`vsphere.host.cpu.totalMhz`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 7,
+            "row": 4,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Memory utilization %",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`vsphere.host.mem.usage`)/average(`vsphere.host.mem.size`)*100 FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 10,
+            "row": 4,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Memory free MiB",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`vsphere.host.mem.free`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Memory usage and size MiB",
+          "visualization": {
+            "id": "viz.area"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`vsphere.host.mem.usage`),average(`vsphere.host.mem.size`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 4,
+            "row": 7,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Total capacity disk mounted MiB",
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`vsphere.host.disk.totalMiB`) FROM Metric "
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-vsphereresourcepool/definition.yml
+++ b/entity-types/infra-vsphereresourcepool/definition.yml
@@ -4,3 +4,8 @@ goldenTags: []
 configuration:
   entityExpirationTime: DAILY
   alertable: true
+
+dashboardTemplates:
+  # This should match the entity created from the ohi in the infra pipeline
+  newRelic:
+    template: newrelic_dashboard.json

--- a/entity-types/infra-vsphereresourcepool/newrelic_dashboard.json
+++ b/entity-types/infra-vsphereresourcepool/newrelic_dashboard.json
@@ -1,0 +1,150 @@
+{
+  "name": "VSphereResourcePoolSample",
+  "pages": [
+    {
+      "name": "VSphereResourcePoolSample",
+      "widgets": [
+        {
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Overall status",
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`overallStatus`) FROM Metric "
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 4,
+            "row": 1,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Virtual machines count",
+          "visualization": {
+            "id": "viz.bar"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`vsphere.resourcePool.vmCount`) FROM Metric "
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 7,
+            "row": 1,
+            "width": 3,
+            "height": 3
+          },
+          "title": "CPU overall usage and total MHz",
+          "visualization": {
+            "id": "viz.area"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`vsphere.resourcePool.cpu.overallUsage`),average(`vsphere.resourcePool.cpu.totalMhz`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 10,
+            "row": 1,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Memory usage and size MiB",
+          "visualization": {
+            "id": "viz.area"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`vsphere.resourcePool.mem.usage`),average(`vsphere.resourcePool.mem.size`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Memory free MiB",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`vsphere.resourcePool.mem.free`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 4,
+            "row": 4,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Memory ballooned MiB",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`vsphere.resourcePool.mem.ballooned`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 7,
+            "row": 4,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Memory swapped MiB",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`vsphere.resourcePool.mem.swapped`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-vspherevm/definition.yml
+++ b/entity-types/infra-vspherevm/definition.yml
@@ -10,3 +10,8 @@ goldenTags:
 configuration:
   entityExpirationTime: DAILY
   alertable: true
+
+dashboardTemplates:
+  # This should match the entity created from the ohi in the infra pipeline
+  newRelic:
+    template: newrelic_dashboard.json

--- a/entity-types/infra-vspherevm/newrelic_dashboard.json
+++ b/entity-types/infra-vspherevm/newrelic_dashboard.json
@@ -1,0 +1,170 @@
+{
+  "name": "VSphereVmSample",
+  "pages": [
+    {
+      "name": "VSphereVmSample",
+      "widgets": [
+        {
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Power state",
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`vsphere.vmPowerState`) FROM Metric "
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 4,
+            "row": 1,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Overall status",
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`vsphere.vmOverallStatus`) FROM Metric "
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 7,
+            "row": 1,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Host CPU utilization %",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`vsphere.vm.cpu.hostUsagePercent`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 10,
+            "row": 1,
+            "width": 3,
+            "height": 3
+          },
+          "title": "CPU overall usage and allocation limit MHz",
+          "visualization": {
+            "id": "viz.area"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`vsphere.vm.cpu.overallUsage`),filter(average(`vsphere.vm.cpu.allocationLimit`),WHERE vsphere.vm.cpu.allocationLimit[total] >= 0) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 3,
+            "height": 3
+          },
+          "title": "CPU cores",
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`vsphere.vm.cpu.cores`) FROM Metric "
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 4,
+            "row": 4,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Memory utilization %",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`vsphere.vm.mem.usage`) / average(`vsphere.vm.mem.size`) * 100 FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 7,
+            "row": 4,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Memory usage and size MiB",
+          "visualization": {
+            "id": "viz.area"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`vsphere.vm.mem.usage`),average(`vsphere.vm.mem.size`) FROM Metric  TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 10,
+            "row": 4,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Total storage space MiB",
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`vsphere.vm.disk.totalMiB`) FROM Metric "
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-win_service/definition.yml
+++ b/entity-types/infra-win_service/definition.yml
@@ -3,3 +3,8 @@ type: WIN_SERVICE
 configuration:
   entityExpirationTime: DAILY
   alertable: true
+
+dashboardTemplates:
+  # This should match the entity created from the ohi in the infra pipeline
+  newRelic:
+    template: newrelic_dashboard.json

--- a/entity-types/infra-win_service/newrelic_dashboard.json
+++ b/entity-types/infra-win_service/newrelic_dashboard.json
@@ -1,0 +1,157 @@
+{
+  "name": "Metric",
+  "pages": [
+    {
+      "name": "Metric",
+      "widgets": [
+        {
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 12,
+            "height": 3
+          },
+          "title": "'Running' state over time",
+          "visualization": {
+            "id": "viz.area"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT filter(latest(windows_service_state), where `state`='running') from Metric where `entity.guid` = '{{entity.id}}' TIMESERIES since 6 hours ago",
+                "offset": 300000
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Service current state",
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT latest(state) as 'Windows Service State' ",
+                "offset": 300000
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 4,
+            "row": 4,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Service parent process ID",
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT latest(process_id) as 'Windows Service Process ID' ",
+                "offset": 300000
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 7,
+            "row": 4,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Service name",
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT latest(service_name) as 'Windows Service Name' ",
+                "offset": 300000
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 10,
+            "row": 4,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Service start Mode",
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT latest(start_mode) as 'Windows Service Start Mode' ",
+                "offset": 300000
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Service hostname",
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT latest(hostname) as 'Windows Service Hostname' ",
+                "offset": 300000
+              }
+            ]
+          }
+        },
+        {
+          "layout": {
+            "column": 4,
+            "row": 7,
+            "width": 3,
+            "height": 3
+          },
+          "title": "Account name",
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT latest(run_as) as 'Windows Service Run As' ",
+                "offset": 300000
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Why
As a follow-up for this work #1181 we are migrating all our OHI dashboards from the infra-summary nerdlet to entity definitions allowing us to:
- Build more experiences for these entities from different sources in a unified place (adding otel receivers)
- Unify all our OHI dashboards in one public place to reduce complexity and add visibility. 

### How
After merging this PR nothing should happen since these entities still point to the infra-summary nerdlet, but it will allow us to check that this dashboards are shown as expected by accessing to `https://staging-one.newrelic.com/nr1-core/entity/overview/<Entity GUID>`.
Once that check is done we will modify the nerdlet id for these entities, same as we did for the Redis entity but in a bigger batch of entities.
 

