### PR TITLE
Fixes #1239, correct tag renaming

### DIFF
--- a/entity-types/infra-azurefunctionsapp/definition.yml
+++ b/entity-types/infra-azurefunctionsapp/definition.yml
@@ -11,8 +11,8 @@ configuration:
   alertable: true
 synthesis:
   tags:
-    providerAccountName:
-      entityTagNames: [providerAccountName, newrelic.cloudIntegrations.providerAccountName]
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
     - identifier: azure.resourceId
       name: displayName


### PR DESCRIPTION
Create tag providerAccountName and newrelic.cloudIntegrations.providerAccountName from newrelic.cloudIntegrations.providerAccountName:

### Relevant information

Rename newrelic.cloudIntegrations.providerAccountName to providerAccountName and keep newrelic.cloudIntegrations.providerAccountName

Azure polling provides the tag providerAccountName, while Azure Monitor newrelic.cloudIntegrations.providerAccountName

This tag rename aims to have both values tagged as providerAccountName. It should apply to all rules.