### PR TITLE
Updating prometheus golden metric definitions

### DIFF
--- a/entity-types/infra-host/golden_metrics.yml
+++ b/entity-types/infra-host/golden_metrics.yml
@@ -20,6 +20,7 @@ cpuUsage:
       eventName: entity.name
     prometheus:
       select: (filter(sum(node_cpu_seconds_total), where mode != 'idle') / sum(node_cpu_seconds_total)) * 100
+      where: node_cpu_seconds_total != 0
       from: Metric
       eventId: entity.guid
       eventName: entity.name

--- a/entity-types/infra-host/golden_metrics.yml
+++ b/entity-types/infra-host/golden_metrics.yml
@@ -54,7 +54,7 @@ memoryUsage:
       eventId: entity.guid
       eventName: entity.name
     prometheus:
-      select: 100 - (sum(node_memory_MemAvailable_bytes) / sum(node_memory_MemTotal_bytes)) * 100
+      select: average(node_memory_ratio)
       from: Metric
       eventId: entity.guid
       eventName: entity.name
@@ -80,9 +80,8 @@ storageUsage:
       eventId: entity.guid
       eventName: entity.name
     prometheus:
-      select: 100 - (sum(node_filesystem_avail_bytes) / sum(node_filesystem_size_bytes)) * 100
+      select: average(node_filesystem_ratio)
       from: Metric
-      where: fstype != 'tmpfs'
       eventId: entity.guid
       eventName: entity.name
 networkTrafficTx:


### PR DESCRIPTION
### Relevant information
This PR is to update several prometheus golden metrics so that these metrics will actually calculate values for customers.

Prometheus CPU usage golden metric had a condition where the value was used in a way that could lead to a divide by zero instance. Added a where clause to prevent this from occurring.

Prometheus memory usage and storage usage both needed to utilize two different metrics to compute the value. We have created a script that will precompute these values on the host and can be sent in via the prometheus node_exporter using a textfile collector. With this, both metrics can be simplified to a single value.

### Checklist

* [ x] I've read the guidelines and understand the acceptance criteria.
* [ x] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
