### PR TITLE
Add providerAccountName when metric has newrelic.cloudIntegrations.providerAccountName

### DIFF
--- a/entity-types/infra-azureapimanagementservice/definition.yml
+++ b/entity-types/infra-azureapimanagementservice/definition.yml
@@ -9,6 +9,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azureappconfiguration/definition.yml
+++ b/entity-types/infra-azureappconfiguration/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azureapplicationgateway/definition.yml
+++ b/entity-types/infra-azureapplicationgateway/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azureapplicationinsight/definition.yml
+++ b/entity-types/infra-azureapplicationinsight/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azureappserviceenvironment/definition.yml
+++ b/entity-types/infra-azureappserviceenvironment/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azureappserviceplan/definition.yml
+++ b/entity-types/infra-azureappserviceplan/definition.yml
@@ -4,6 +4,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName] 
   rules:
     - identifier: azure.resourceId
       name: displayName

--- a/entity-types/infra-azureautomationaccount/definition.yml
+++ b/entity-types/infra-azureautomationaccount/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azurebatchaccount/definition.yml
+++ b/entity-types/infra-azurebatchaccount/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azurebingsearch/definition.yml
+++ b/entity-types/infra-azurebingsearch/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
     - identifier: azure.resourceId
       name: displayName

--- a/entity-types/infra-azurecdnprofile/definition.yml
+++ b/entity-types/infra-azurecdnprofile/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azurecloudservice/definition.yml
+++ b/entity-types/infra-azurecloudservice/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azurecognitivesearch/definition.yml
+++ b/entity-types/infra-azurecognitivesearch/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azurecognitiveservice/definition.yml
+++ b/entity-types/infra-azurecognitiveservice/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
     - identifier: azure.resourceId
       name: displayName

--- a/entity-types/infra-azurecontainersinstancegroup/definition.yml
+++ b/entity-types/infra-azurecontainersinstancegroup/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azurecontainersmanagedcluster/definition.yml
+++ b/entity-types/infra-azurecontainersmanagedcluster/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azurecontainersregistry/definition.yml
+++ b/entity-types/infra-azurecontainersregistry/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azurecosmosdbaccount/definition.yml
+++ b/entity-types/infra-azurecosmosdbaccount/definition.yml
@@ -9,6 +9,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
     - identifier: azure.resourceId
       name: displayName

--- a/entity-types/infra-azuredataboxedge/definition.yml
+++ b/entity-types/infra-azuredataboxedge/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azuredataexplorer/definition.yml
+++ b/entity-types/infra-azuredataexplorer/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azuredatafactorydatafactory/definition.yml
+++ b/entity-types/infra-azuredatafactorydatafactory/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azuredatafactoryfactory/definition.yml
+++ b/entity-types/infra-azuredatafactoryfactory/definition.yml
@@ -4,6 +4,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azuredatalakeanalytic/definition.yml
+++ b/entity-types/infra-azuredatalakeanalytic/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azuredatalakestorage/definition.yml
+++ b/entity-types/infra-azuredatalakestorage/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azuredatashare/definition.yml
+++ b/entity-types/infra-azuredatashare/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azuredeviceprovisioningservice/definition.yml
+++ b/entity-types/infra-azuredeviceprovisioningservice/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azurediskstorage/definition.yml
+++ b/entity-types/infra-azurediskstorage/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azurednszone/definition.yml
+++ b/entity-types/infra-azurednszone/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azureeventgriddomain/definition.yml
+++ b/entity-types/infra-azureeventgriddomain/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azureeventgridpartnernamespace/definition.yml
+++ b/entity-types/infra-azureeventgridpartnernamespace/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azureeventgridpartnertopic/definition.yml
+++ b/entity-types/infra-azureeventgridpartnertopic/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azureeventgridsubscription/definition.yml
+++ b/entity-types/infra-azureeventgridsubscription/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azureeventgridsystemtopic/definition.yml
+++ b/entity-types/infra-azureeventgridsystemtopic/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azureeventgridtopic/definition.yml
+++ b/entity-types/infra-azureeventgridtopic/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azureeventhubcluster/definition.yml
+++ b/entity-types/infra-azureeventhubcluster/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azureeventhubnamespace/definition.yml
+++ b/entity-types/infra-azureeventhubnamespace/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azureexpressroutecircuit/definition.yml
+++ b/entity-types/infra-azureexpressroutecircuit/definition.yml
@@ -4,6 +4,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azureexpressrouteconnection/definition.yml
+++ b/entity-types/infra-azureexpressrouteconnection/definition.yml
@@ -4,6 +4,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azureexpressroutegateway/definition.yml
+++ b/entity-types/infra-azureexpressroutegateway/definition.yml
@@ -4,6 +4,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azurefirewall/definition.yml
+++ b/entity-types/infra-azurefirewall/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azurefrontdoorfrontdoor/definition.yml
+++ b/entity-types/infra-azurefrontdoorfrontdoor/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azurefunctionsworkflow/definition.yml
+++ b/entity-types/infra-azurefunctionsworkflow/definition.yml
@@ -10,6 +10,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
     - identifier: azure.resourceId
       name: displayName

--- a/entity-types/infra-azurehdinsight/definition.yml
+++ b/entity-types/infra-azurehdinsight/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azureintegrationserviceenvironment/definition.yml
+++ b/entity-types/infra-azureintegrationserviceenvironment/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azureiotcentralapplication/definition.yml
+++ b/entity-types/infra-azureiotcentralapplication/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azureiothub/definition.yml
+++ b/entity-types/infra-azureiothub/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azurekeyvaultvault/definition.yml
+++ b/entity-types/infra-azurekeyvaultvault/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azureloadbalancer/definition.yml
+++ b/entity-types/infra-azureloadbalancer/definition.yml
@@ -9,6 +9,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
     - identifier: azure.resourceId
       name: displayName

--- a/entity-types/infra-azurelogicappsintegrationserviceenvironment/definition.yml
+++ b/entity-types/infra-azurelogicappsintegrationserviceenvironment/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azurelogicappsworkflow/definition.yml
+++ b/entity-types/infra-azurelogicappsworkflow/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azuremachinelearningdeployment/definition.yml
+++ b/entity-types/infra-azuremachinelearningdeployment/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azuremachinelearningendpoints/definition.yml
+++ b/entity-types/infra-azuremachinelearningendpoints/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azuremachinelearningworkspace/definition.yml
+++ b/entity-types/infra-azuremachinelearningworkspace/definition.yml
@@ -4,6 +4,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azuremap/definition.yml
+++ b/entity-types/infra-azuremap/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azuremariadbserver/definition.yml
+++ b/entity-types/infra-azuremariadbserver/definition.yml
@@ -11,6 +11,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
     - identifier: azure.resourceId
       name: displayName

--- a/entity-types/infra-azuremediaservice/definition.yml
+++ b/entity-types/infra-azuremediaservice/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azuremediaservicesliveevent/definition.yml
+++ b/entity-types/infra-azuremediaservicesliveevent/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azuremediaservicesstreamingendpoint/definition.yml
+++ b/entity-types/infra-azuremediaservicesstreamingendpoint/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azuremediaservicesvideoanalyzer/definition.yml
+++ b/entity-types/infra-azuremediaservicesvideoanalyzer/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azuremysqlflexibleserver/definition.yml
+++ b/entity-types/infra-azuremysqlflexibleserver/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azuremysqlserver/definition.yml
+++ b/entity-types/infra-azuremysqlserver/definition.yml
@@ -11,6 +11,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
     - identifier: azure.resourceId
       name: displayName

--- a/entity-types/infra-azurenetappcapacitypool/definition.yml
+++ b/entity-types/infra-azurenetappcapacitypool/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azurenetappfile/definition.yml
+++ b/entity-types/infra-azurenetappfile/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azurenetworkwatcher/definition.yml
+++ b/entity-types/infra-azurenetworkwatcher/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azurenotificationhub/definition.yml
+++ b/entity-types/infra-azurenotificationhub/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azurepeering/definition.yml
+++ b/entity-types/infra-azurepeering/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azurepeeringservice/definition.yml
+++ b/entity-types/infra-azurepeeringservice/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azurepostgresqlflexibleserver/definition.yml
+++ b/entity-types/infra-azurepostgresqlflexibleserver/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azurepostgresqlserver/definition.yml
+++ b/entity-types/infra-azurepostgresqlserver/definition.yml
@@ -11,6 +11,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
     - identifier: azure.resourceId
       name: displayName

--- a/entity-types/infra-azurepowerbidedicatedcapacity/definition.yml
+++ b/entity-types/infra-azurepowerbidedicatedcapacity/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azureprivatednszone/definition.yml
+++ b/entity-types/infra-azureprivatednszone/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azurepurview/definition.yml
+++ b/entity-types/infra-azurepurview/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azurerediscache/definition.yml
+++ b/entity-types/infra-azurerediscache/definition.yml
@@ -4,6 +4,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
     - identifier: azure.resourceId
       name: displayName

--- a/entity-types/infra-azurerelay/definition.yml
+++ b/entity-types/infra-azurerelay/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azureservicebusnamespace/definition.yml
+++ b/entity-types/infra-azureservicebusnamespace/definition.yml
@@ -10,6 +10,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
     - identifier: azure.resourceId
       name: displayName

--- a/entity-types/infra-azuresignalr/definition.yml
+++ b/entity-types/infra-azuresignalr/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azurespringapp/definition.yml
+++ b/entity-types/infra-azurespringapp/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azuresqldatabase/definition.yml
+++ b/entity-types/infra-azuresqldatabase/definition.yml
@@ -13,6 +13,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azuresqlelasticpool/definition.yml
+++ b/entity-types/infra-azuresqlelasticpool/definition.yml
@@ -4,6 +4,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
     - identifier: azure.resourceId
       name: displayName

--- a/entity-types/infra-azuresqlmanagedinstance/definition.yml
+++ b/entity-types/infra-azuresqlmanagedinstance/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azurestorageaccount/definition.yml
+++ b/entity-types/infra-azurestorageaccount/definition.yml
@@ -11,6 +11,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
     - identifier: azure.resourceId
       name: displayName

--- a/entity-types/infra-azurestoragesync/definition.yml
+++ b/entity-types/infra-azurestoragesync/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azurestreamanalytic/definition.yml
+++ b/entity-types/infra-azurestreamanalytic/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azuresynapseanalytic/definition.yml
+++ b/entity-types/infra-azuresynapseanalytic/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azuretimeseriesinsight/definition.yml
+++ b/entity-types/infra-azuretimeseriesinsight/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azuretrafficmanager/definition.yml
+++ b/entity-types/infra-azuretrafficmanager/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azurevirtualhub/definition.yml
+++ b/entity-types/infra-azurevirtualhub/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azurevirtualmachinescaleset/definition.yml
+++ b/entity-types/infra-azurevirtualmachinescaleset/definition.yml
@@ -9,6 +9,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azurevirtualnetworks/definition.yml
+++ b/entity-types/infra-azurevirtualnetworks/definition.yml
@@ -4,6 +4,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
     - identifier: azure.resourceId
       name: displayName

--- a/entity-types/infra-azurevirtualnetworksnetworkinterface/definition.yml
+++ b/entity-types/infra-azurevirtualnetworksnetworkinterface/definition.yml
@@ -4,6 +4,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: false
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
     - identifier: azure.resourceId
       name: displayName

--- a/entity-types/infra-azurevirtualnetworkspublicipaddress/definition.yml
+++ b/entity-types/infra-azurevirtualnetworkspublicipaddress/definition.yml
@@ -4,6 +4,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
     - identifier: azure.resourceId
       name: displayName

--- a/entity-types/infra-azurevpngateway/definition.yml
+++ b/entity-types/infra-azurevpngateway/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
     - identifier: azure.resourceId
       name: displayName

--- a/entity-types/infra-azurevpngatewaysvpngateway/definition.yml
+++ b/entity-types/infra-azurevpngatewaysvpngateway/definition.yml
@@ -4,6 +4,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName

--- a/entity-types/infra-azurewebapp/definition.yml
+++ b/entity-types/infra-azurewebapp/definition.yml
@@ -7,6 +7,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
   - identifier: azure.resourceId
     name: displayName


### PR DESCRIPTION
### Relevant information
Rename newrelic.cloudIntegrations.providerAccountName to providerAccountName and keep newrelic.cloudIntegrations.providerAccountName

Azure polling provides the tag providerAccountName, while Azure Monitor newrelic.cloudIntegrations.providerAccountName

This is a similar PR to #1249, but intended for most Azure entities.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
