### PR TITLE
New entity-type for products with different golden metric sources

### DIFF
--- a/entity-types/ext-rservicev2/dashboard.json
+++ b/entity-types/ext-rservicev2/dashboard.json
@@ -1,0 +1,486 @@
+{
+  "name": "RServiceV2",
+  "description": null,
+  "pages": [
+    {
+      "name": "RServiceV2",
+      "description": null,
+      "widgets": [
+        {
+          "title": "",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 3,
+            "height": 1
+          },
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(sum(`Http.RequestReceived.Rate.Rate1`), 1 minute ) AS 'Throughput (rpm)' \nFROM Metric "
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "",
+          "layout": {
+            "column": 4,
+            "row": 1,
+            "width": 3,
+            "height": 1
+          },
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`Http.RequestReceived.Duration.Histogram.Mean`) AS 'Response time (ms)'\nFROM Metric"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "",
+          "layout": {
+            "column": 7,
+            "row": 1,
+            "width": 3,
+            "height": 1
+          },
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`Http.RequestReceived.Duration.Histogram.Percentile99`) AS 'Response time P99 (ms)'\nFROM Metric "
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "",
+          "layout": {
+            "column": 10,
+            "row": 1,
+            "width": 3,
+            "height": 1
+          },
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT ((filter(sum(`Http.RequestReceived.Rate.Rate1`), where StatusCode LIKE '5%')) / (filter(sum(`Http.RequestReceived.Rate.Rate1`), where StatusCode LIKE '2%') + filter(sum(`Http.RequestReceived.Rate.Rate1`), where StatusCode LIKE '5%'))) * 100 AS 'Error Rate' \nFROM Metric "
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "Throughput (rpm)",
+          "layout": {
+            "column": 1,
+            "row": 2,
+            "width": 3,
+            "height": 1
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(sum(`Http.RequestReceived.Rate.Rate1`), 1 minute) AS 'Throughput (rpm)' \nFROM Metric\nTIMESERIES 1 minute SLIDE BY MAX"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Response time (ms)",
+          "layout": {
+            "column": 4,
+            "row": 2,
+            "width": 3,
+            "height": 1
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`Http.RequestReceived.Duration.Histogram.Mean`) AS 'Response time (ms)'\nFROM Metric \nTIMESERIES 1 minute SLIDE BY MAX"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Response time P99 (ms)",
+          "layout": {
+            "column": 7,
+            "row": 2,
+            "width": 3,
+            "height": 1
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`Http.RequestReceived.Duration.Histogram.Percentile99`) AS 'Response time P99 (ms)' \nFROM Metric\nTIMESERIES 1 minute SLIDE BY MAX"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Error Rate",
+          "layout": {
+            "column": 10,
+            "row": 2,
+            "width": 3,
+            "height": 1
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT ((filter(sum(`Http.RequestReceived.Rate.Rate1`), where StatusCode LIKE '5%')) / (filter(sum(`Http.RequestReceived.Rate.Rate1`), where StatusCode LIKE '2%') + filter(sum(`Http.RequestReceived.Rate.Rate1`), where StatusCode LIKE '5%'))) * 100 AS 'Error Rate' \nFROM Metric \nTIMESERIES 1 minute SLIDE BY MAX"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Summary breakdown",
+          "layout": {
+            "column": 1,
+            "row": 3,
+            "width": 12,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.table"
+          },
+          "rawConfiguration": {
+            "dataFormatters": [
+              {
+                "name": "Response time P99 (ms)",
+                "precision": 2,
+                "type": "decimal"
+              },
+              {
+                "name": "Response time (ms)",
+                "precision": 2,
+                "type": "decimal"
+              }
+            ],
+            "facet": {
+              "showOtherSeries": false
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(sum(`Http.RequestReceived.Rate.Rate1`), 1 minute) AS 'Throughput (rpm)', average(`Http.RequestReceived.Duration.Histogram.Mean`) AS 'Response time (ms)', average(`Http.RequestReceived.Duration.Histogram.Percentile99`) AS 'Response time P99 (ms)', ((filter(sum(`Http.RequestReceived.Rate.Rate1`), where StatusCode LIKE '5%')) / (filter(sum(`Http.RequestReceived.Rate.Rate1`), where StatusCode LIKE '2%') + filter(sum(`Http.RequestReceived.Rate.Rate1`), where StatusCode LIKE '5%'))) * 100 AS 'Error Rate' \nFROM Metric  facet rfc190_datacenter, rfc190_deployment "
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "Host breakdown",
+          "layout": {
+            "column": 1,
+            "row": 6,
+            "width": 5,
+            "height": 4
+          },
+          "visualization": {
+            "id": "viz.table"
+          },
+          "rawConfiguration": {
+            "dataFormatters": [
+              {
+                "name": "Response time P99 (ms)",
+                "precision": 2,
+                "type": "decimal"
+              },
+              {
+                "name": "Response time (ms)",
+                "precision": 2,
+                "type": "decimal"
+              }
+            ],
+            "facet": {
+              "showOtherSeries": false
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(sum(`Http.RequestReceived.Rate.Rate1`), 1 minute) AS 'Throughput (rpm)', average(`Http.RequestReceived.Duration.Histogram.Mean`) AS 'Response time (ms)', average(`Http.RequestReceived.Duration.Histogram.Percentile99`) AS 'Response time P99 (ms)', ((filter(sum(`Http.RequestReceived.Rate.Rate1`), where StatusCode LIKE '5%')) / (filter(sum(`Http.RequestReceived.Rate.Rate1`), where StatusCode LIKE '2%') + filter(sum(`Http.RequestReceived.Rate.Rate1`), where StatusCode LIKE '5%'))) * 100 AS 'Error Rate' \nFROM Metric facet rfc460Hostname since 12 hours ago LIMIT MAX"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "Host throughput",
+          "layout": {
+            "column": 6,
+            "row": 6,
+            "width": 7,
+            "height": 2
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(sum(`Http.RequestReceived.Rate.Rate1`), 1 minute) AS 'Throughput (rpm)'\nFROM Metric facet rfc460Hostname TIMESERIES 1 minute SLIDE BY MAX"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Host avg response time",
+          "layout": {
+            "column": 6,
+            "row": 8,
+            "width": 7,
+            "height": 2
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`Http.RequestReceived.Duration.Histogram.Mean`) AS 'Response time (ms)', average(`Http.RequestReceived.Duration.Histogram.Percentile99`) AS 'Response time P99 (ms)' \nFROM Metric facet rfc460Hostname TIMESERIES 1 minute SLIDE BY MAX"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "API breakdown",
+          "layout": {
+            "column": 1,
+            "row": 10,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.table"
+          },
+          "rawConfiguration": {
+            "dataFormatters": [
+              {
+                "name": "Response time P99 (ms)",
+                "precision": 2,
+                "type": "decimal"
+              },
+              {
+                "name": "Response time (ms)",
+                "precision": 2,
+                "type": "decimal"
+              }
+            ],
+            "facet": {
+              "showOtherSeries": false
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "WITH aparse(metricName, '*.*.*.*') AS (FirstLevel, Contract, Api, GoldenSignal)\nSELECT rate(sum(`Http.RequestReceived.Rate.Rate1`), 1 minute ) AS 'Throughput (rpm)', average(`Http.RequestReceived.Duration.Histogram.Mean`) AS 'Response time (ms)', average(`Http.RequestReceived.Duration.Histogram.Percentile99`) AS 'Response time P99 (ms)' \nFROM Metric FACET Operation, HttpMethod LIMIT MAX"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "API avg response ",
+          "layout": {
+            "column": 7,
+            "row": 10,
+            "width": 3,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "WITH aparse(metricName, '*.*.*.*') AS (FirstLevel, Contract, Api, GoldenSignal)\nSELECT rate(sum(`Http.RequestReceived.Duration.Histogram.Mean`), 1 minute )\nFROM Metric FACET Operation, HttpMethod\nTIMESERIES 1 minute SLIDE BY MAX"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "API avg P99 response",
+          "layout": {
+            "column": 10,
+            "row": 10,
+            "width": 3,
+            "height": 3
+          },          
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "WITH aparse(metricName, '*.*.*.*') AS (FirstLevel, Contract, Api, GoldenSignal)\nSELECT rate(sum(`Http.RequestReceived.Duration.Histogram.Percentile99`), 1 minute )\nFROM Metric FACET Operation, HttpMethod\nTIMESERIES 1 minute SLIDE BY MAX"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/ext-rservicev2/definition.yml
+++ b/entity-types/ext-rservicev2/definition.yml
@@ -1,0 +1,33 @@
+domain: EXT
+type: RSERVICEV2
+synthesis:
+  rules:
+  - compositeIdentifier: 
+      separator: ":"
+      attributes:
+      - rfc190_environment
+      - application
+    name: application
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: metricName
+      present: true
+    - attribute: rfc190Scope
+      present: true
+    - attribute: application
+      prefix: 'bacon.'
+
+  tags:
+    rfc190_component:
+    rfc190_datacenter:
+    rfc190_environment:
+    rfc190_product:
+    newrelic.source:
+
+dashboardTemplates:
+  newRelic:
+    template: dashboard.json
+
+configuration:
+  entityExpirationTime: EIGHT_DAYS
+  alertable: true

--- a/entity-types/ext-rservicev2/golden_metrics.yml
+++ b/entity-types/ext-rservicev2/golden_metrics.yml
@@ -1,0 +1,24 @@
+responseTimeMs:
+  title: Response time (ms)
+  unit: MS
+  query: 
+    select: average(`Http.RequestReceived.Duration.Histogram.Mean`) AS 'Response time (ms)'
+    from: Metric 
+responseTimeP99Ms:
+  title: Response time P99 (ms)
+  unit: MS
+  query:
+    select: average(`Http.RequestReceived.Duration.Histogram.Percentile99`) AS 'Response time P99 (ms)'
+    from: Metric 
+throughput:
+  title: Throughput (RPM)
+  unit: REQUESTS_PER_MINUTE
+  query:
+    select: rate(sum(`Http.RequestReceived.Rate.Rate1`), 1 minute ) AS 'Throughput (rpm)'
+    from: Metric 
+errorRate:
+  title: Error rate
+  unit: PERCENTAGE
+  query:
+    select: 100 * (filter(sum(`Http.RequestReceived.Rate.Rate1`), where StatusCode LIKE '5%')) / (filter(sum(`Http.RequestReceived.Rate.Rate1`), where StatusCode LIKE '2%') + filter(sum(`Http.RequestReceived.Rate.Rate1`), where StatusCode LIKE '5%')) as 'Error Rate'
+    from: Metric

--- a/entity-types/ext-rservicev2/summary_metrics.yml
+++ b/entity-types/ext-rservicev2/summary_metrics.yml
@@ -1,0 +1,12 @@
+responseTimeMs:
+  goldenMetric: responseTimeMs
+  title: Response time
+  unit: MS
+throughput:
+  goldenMetric: throughput
+  title: Throughput
+  unit: REQUESTS_PER_MINUTE
+errorRate:
+  goldenMetric: errorRate
+  title: Error rate
+  unit: PERCENTAGE


### PR DESCRIPTION
### Relevant information

New entity-type (similar to entity ext-rservice) for specific services that have a different source for its golden metrics.


### Checklist

* [x ] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
