### PR TITLE
[NR-165879] Add matching rules for non-cloud hosts

### DIFF
--- a/relationships/candidates/HOST.yml
+++ b/relationships/candidates/HOST.yml
@@ -15,6 +15,7 @@ lookups:
       uninstrumented:
         type: HOST
 
+  - entityTypes:
     - domain: INFRA
       type: HOST
     tags:

--- a/relationships/candidates/HOST.yml
+++ b/relationships/candidates/HOST.yml
@@ -14,3 +14,19 @@ lookups:
       action: CREATE_UNINSTRUMENTED
       uninstrumented:
         type: HOST
+
+    - domain: INFRA
+      type: HOST
+    tags:
+      matchingMode: FIRST
+      predicates:
+        - tagKeys: ["displayname","fullhostname","hostname"]
+          field: displayName
+        - tagKeys: ["displayname","fullhostname","hostname"]
+          field: hostName
+    onMatch:
+      onMultipleMatches: RELATE_ALL
+    onMiss:
+      action: CREATE_UNINSTRUMENTED
+      uninstrumented:
+        type: HOST

--- a/relationships/candidates/HOST.yml
+++ b/relationships/candidates/HOST.yml
@@ -21,9 +21,11 @@ lookups:
     tags:
       matchingMode: FIRST
       predicates:
-        - tagKeys: ["displayname","fullhostname","hostname"]
+        - tagKeys: ["displayname"]
           field: displayName
-        - tagKeys: ["displayname","fullhostname","hostname"]
+        - tagKeys: ["fullhostname"]
+          field: hostName
+        - tagKeys: ["hostname"]
           field: hostName
     onMatch:
       onMultipleMatches: RELATE_ALL


### PR DESCRIPTION
### Relevant information

Add matching rules for non-cloud hosts.

It is part of the effort to collect more metrics on uninstrumented relationships. 

Based on the reference definition from the hardcoded rules ([link](https://source.datanerd.us/entity-platform/entity-fingerprint-definitions/blob/master/src/main/resources/fingerprints/hosts.yml#L17)).

Internal links:
- https://issues.newrelic.com/browse/NR-165879

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
