### PR TITLE
Revert "[NR-165879] Add matching rules for non-cloud hosts (#1263)"

### DIFF
--- a/relationships/candidates/HOST.yml
+++ b/relationships/candidates/HOST.yml
@@ -14,22 +14,3 @@ lookups:
       action: CREATE_UNINSTRUMENTED
       uninstrumented:
         type: HOST
-
-  - entityTypes:
-    - domain: INFRA
-      type: HOST
-    tags:
-      matchingMode: FIRST
-      predicates:
-        - tagKeys: ["displayname"]
-          field: displayName
-        - tagKeys: ["fullhostname"]
-          field: hostName
-        - tagKeys: ["hostname"]
-          field: hostName
-    onMatch:
-      onMultipleMatches: RELATE_ALL
-    onMiss:
-      action: CREATE_UNINSTRUMENTED
-      uninstrumented:
-        type: HOST


### PR DESCRIPTION
This reverts commit eebc9d00da19d11a46442d85ac19b37b7895f38a.

### Relevant information

Reverts add matching rules for non-cloud hosts.

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
