### PR TITLE
Add back relationship for AWS RDS Cluster/Instance (#1146)

### DIFF
--- a/relationships/candidates/AWSRDSDBCLUSTER.yml
+++ b/relationships/candidates/AWSRDSDBCLUSTER.yml
@@ -1,0 +1,18 @@
+category: AWSRDSDBCLUSTER
+lookups:
+  - entityTypes:
+      - domain: INFRA
+        type: AWSRDSDBCLUSTER
+    tags:
+      matchingMode: ALL
+      predicates:
+        - tagKeys: ["aws.accountId"]
+          field: awsAccountId
+        - tagKeys: ["aws.region"]
+          field: awsRegion
+        - tagKeys: ["aws.rds.dbClusterIdentifier", "aws.rds.DbClusterIdentifier", "aws.rds.DBClusterIdentifier"]
+          field: awsRdsClusterIdentifier
+    onMatch:
+      onMultipleMatches: RELATE_ALL
+    onMiss:
+      action: NO_OP

--- a/relationships/synthesis/INFRA-AWSRDSDBCLUSTER-to-INFRA-AWS_RDS_DB_INSTANCE.yml
+++ b/relationships/synthesis/INFRA-AWSRDSDBCLUSTER-to-INFRA-AWS_RDS_DB_INSTANCE.yml
@@ -1,0 +1,28 @@
+relationships:
+  - name: awsRdsClusterContainsRdsInstance
+    version: 1
+    origins:
+      - AWS Integration
+    conditions:
+      - attribute: eventType
+        anyOf: [ "MetricRaw" ]
+      - attribute: entity.type
+        anyOf: [ "AWS_RDS_DB_INSTANCE" ]
+    relationship:
+      expires: P75M
+      relationshipType: CONTAINS
+      source:
+        lookupGuid:
+          candidateCategory: AWSRDSDBCLUSTER
+          fields:
+            - field: awsAccountId
+              attribute: aws.accountId
+            - field: awsRegion
+              attribute: aws.region
+            - field: awsRdsClusterIdentifier
+              attribute: aws.rds.dbClusterIdentifier
+      target:
+        extractGuid:
+          attribute: entity.guid
+          entityType:
+            value: AWS_RDS_DB_INSTANCE


### PR DESCRIPTION
This reverts commit 0c8c576674e5144de0292cce0a386936e57e1e4c.

### Relevant information

Adds back relationships for AWS RDS Cluster/Instance: https://github.com/newrelic/entity-definitions/pull/1146

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
