### PR TITLE
fix: update tag name for SM

### DIFF
--- a/entity-types/ext-kentik_ping/summary_metrics.yml
+++ b/entity-types/ext-kentik_ping/summary_metrics.yml
@@ -2,4 +2,4 @@ ipAddress:
   title: IP address
   unit: STRING
   tag:
-    key: src_addr
+    key: device_ip


### PR DESCRIPTION
fixing a tag name on the summary metric for `EXT-KENTIK_PING` 