### PR TITLE
Add rule for metric-stream EC2 instances

### DIFF
--- a/entity-types/infra-host/definition.yml
+++ b/entity-types/infra-host/definition.yml
@@ -179,6 +179,28 @@ synthesis:
         nodename:
           entityTagNames: [hostname]
         instrumentation.provider:
+    # metric-streams AWS EC2
+    - identifier: aws.ec2.InstanceId
+      name: aws.ec2.InstanceId
+      legacyFeatures:
+        overrideGuidType: true
+      encodeIdentifierInGUID: true
+      conditions:
+      - attribute: aws.Namespace
+        value: AWS/EC2
+      - attribute: metricName
+        prefix: aws.ec2.
+      - attribute: instrumentation.provider
+        value: "aws"
+      - attribute: newrelic.source
+        value: metricAPI
+      tags:
+        aws.ec2.InstanceId:
+          entityTagNames: [host.id]
+        newrelic.cloudIntegrations.providerAccountName:
+          entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
+        instrumentation.provider:        
+
 configuration:
   entityExpirationTime: DAILY
   alertable: true


### PR DESCRIPTION
### Relevant information

New rule to synthesize EC2 instances ingested with metric-stream as HOSTS

### Checklist

* [X] I've read the guidelines and understand the acceptance criteria.
* [X] The value of the attribute marked as `identifier` will be unique and valid. 
* [?] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
