### PR TITLE
Add entity.type with underscores for rds definition

### DIFF
--- a/relationships/synthesis/INFRA-AWSRDSDBCLUSTER-to-INFRA-AWSRDSDBINSTANCE.yml
+++ b/relationships/synthesis/INFRA-AWSRDSDBCLUSTER-to-INFRA-AWSRDSDBINSTANCE.yml
@@ -7,7 +7,7 @@ relationships:
       - attribute: eventType
         anyOf: [ "MetricRaw" ]
       - attribute: entity.type
-        anyOf: [ "AWSRDSDBINSTANCE" ]
+        anyOf: [ "AWSRDSDBINSTANCE", "AWS_RDS_DB_INSTANCE" ]
     relationship:
       expires: P75M
       relationshipType: CONTAINS


### PR DESCRIPTION
### Relevant information

Added underscore entity.type for rds cluster <> instance relationship.


### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
