### PR TITLE
Use the convert function for newrelic-opentelemetry data

### DIFF
--- a/entity-types/ext-service/golden_metrics.yml
+++ b/entity-types/ext-service/golden_metrics.yml
@@ -47,7 +47,7 @@ responseTimeMs:
       from: Span
       where: span.kind LIKE 'server' OR span.kind LIKE 'consumer' OR kind LIKE 'server' OR kind LIKE 'consumer'
     newrelic-opentelemetry:
-      select: average(apm.service.transaction.duration * 1000)
+      select: average(convert(apm.service.transaction.duration, unit, 'ms'))
       from: Metric
     kamon-agent:
       select: average(http.server.requests)


### PR DESCRIPTION
### Relevant information

This updates one golden metrics query to use the new NRDB `convert` function to convert the measurement to `ms` instead of assuming the unit is in `s`.  This only applies when the `instrumentation.provider` is `newrelic.opentelemetry`.  We do not have any production agents reporting this configuration.  We are started to alpha test this with a small handful of customers.  The risk is very low.

Before deploying this change to production, we need to verify that the NRDB team has enabled the `convert` function in the production environment.

https://docs.google.com/document/d/1nuRiK9HM-x2d52mtMLuiPUkSUzONfKFtTFFmRpOocoU/edit?usp=sharing

### Checklist

* [X] I've read the guidelines and understand the acceptance criteria.
* [X] The value of the attribute marked as `identifier` will be unique and valid. 
* [X] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
