### PR TITLE
Include log events as part of rservicev2

### DIFF
--- a/entity-types/ext-rservicev2/definition.yml
+++ b/entity-types/ext-rservicev2/definition.yml
@@ -17,6 +17,21 @@ synthesis:
     - attribute: application
       prefix: 'bacon.'
 
+  - compositeIdentifier: 
+      separator: ":"
+      attributes:
+      - rfc190_environment
+      - application
+    name: application
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: service_name
+      present: true
+    - attribute: rfc190Scope
+      present: true
+    - attribute: application
+      prefix: 'bacon.'
+
   tags:
     rfc190_component:
     rfc190_datacenter:


### PR DESCRIPTION
### Relevant information

Initially, as part of the ext-rservicev2 entities, only raw metrics were declared - this PR will also include logs as well.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
