### PR TITLE
Add origin for RDS relationship

### DIFF
--- a/relationships/synthesis/INFRA-AWSRDSDBCLUSTER-to-INFRA-AWSRDSDBINSTANCE.yml
+++ b/relationships/synthesis/INFRA-AWSRDSDBCLUSTER-to-INFRA-AWSRDSDBINSTANCE.yml
@@ -3,6 +3,7 @@ relationships:
     version: 1
     origins:
       - AWS Integration
+      - Metric API
     conditions:
       - attribute: eventType
         anyOf: [ "MetricRaw" ]


### PR DESCRIPTION
### Relevant information

Add metric Api as origin for the rds relationship.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
