### PR TITLE
Revert "[NR-165879] Add matching rules for non-cloud hosts (#1275)"

### DIFF
--- a/relationships/candidates/HOST.yml
+++ b/relationships/candidates/HOST.yml
@@ -14,22 +14,3 @@ lookups:
       action: CREATE_UNINSTRUMENTED
       uninstrumented:
         type: HOST
-
-  - entityTypes:
-    - domain: INFRA
-      type: HOST
-    tags:
-      matchingMode: FIRST
-      predicates:
-        - tagKeys: ["displayname"]
-          field: displayName
-        - tagKeys: ["fullhostname"]
-          field: hostName
-        - tagKeys: ["hostname"]
-          field: hostName
-    onMatch:
-      onMultipleMatches: RELATE_ALL
-    onMiss:
-      action: CREATE_UNINSTRUMENTED
-      uninstrumented:
-        type: HOST


### PR DESCRIPTION
This reverts commit 3839662fc01e4a2c2ec9090d93307d7b050a3a64.

### Relevant information

Remove hosts non-cloud rule included here: https://github.com/newrelic/entity-definitions/pull/1275

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
