### PR TITLE
fix: Update infra-host entityExpirationTime from daily to 8 days

### DIFF
--- a/entity-types/infra-host/definition.yml
+++ b/entity-types/infra-host/definition.yml
@@ -180,5 +180,5 @@ synthesis:
           entityTagNames: [hostname]
         instrumentation.provider:
 configuration:
-  entityExpirationTime: DAILY
+  entityExpirationTime: EIGHT_DAYS
   alertable: true


### PR DESCRIPTION
### Relevant information

Updating `entityExpirationTime` for INFRA-HOST entities to 8 days.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
