### PR TITLE
fix: updated Isilon failedDriveCount to uniqueCount and added failedD…

### DIFF
--- a/entity-types/ext-isilon/dashboard.json
+++ b/entity-types/ext-isilon/dashboard.json
@@ -316,7 +316,34 @@
               "zero": true
             }
           }
+        },
+        {
+          "visualization": {
+            "id": "viz.table"
+          },
+          "layout": {
+            "column": 5,
+            "row": 12,
+            "width": 4,
+            "height": 3
+          },          
+          "title": "Failed Drive",
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "From IsilonDrives SELECT latest(devname), latest(entity.name), latest(lnn), latest(baynum),latest(uiState) where devname is NOT NULL and uiState != 'HEALTHY' and uiState != 'EMPTY' and serial != '' facet serial"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
         }
+
       ]
     }
   ]

--- a/entity-types/ext-isilon/golden_metrics.yml
+++ b/entity-types/ext-isilon/golden_metrics.yml
@@ -26,7 +26,7 @@ failedDriveCount:
   title: Drive Failures
   unit: COUNT
   query:
-    select: count(uiState)
+    select: uniqueCount(serial)
     from: IsilonDrives
-    where: "devname is NOT NULL and uiState != 'HEALTHY' and uiState != 'EMPTY'"
+    where: "devname is NOT NULL and uiState != 'HEALTHY' and uiState != 'EMPTY'" and serial!=''
     eventId: entity.guid

--- a/entity-types/ext-isilon/golden_metrics.yml
+++ b/entity-types/ext-isilon/golden_metrics.yml
@@ -28,5 +28,6 @@ failedDriveCount:
   query:
     select: uniqueCount(serial)
     from: IsilonDrives
-    where: "devname is NOT NULL and uiState != 'HEALTHY' and uiState != 'EMPTY'" and serial!=''
+    where: "devname is NOT NULL and uiState != 'HEALTHY' and uiState != 'EMPTY' and serial !=''"
     eventId: entity.guid
+


### PR DESCRIPTION
### Relevant information
- updated  entity-type `ext-isilon` golden_metrics query for `failedDriveCount` to uniqueCount
   The query was using `count` previously which produced duplicate counting of the same failed drive multiple time for the duration.

- added Failed Drive widget to the dashboard


<!--
  Contributions to this repository are reviewed at least twice a week

  There's no further action required once the PR has been created.
 -->

