### PR TITLE
Feat: Enable Prometheus hosts in production

### DIFF
--- a/entity-types/infra-host/definition.yml
+++ b/entity-types/infra-host/definition.yml
@@ -134,9 +134,6 @@ synthesis:
         prefix: "node_"
       - attribute: instrumentation.provider
         value: "prometheus"
-      # Value added for test entities only
-      - attribute: newrelicOnly
-        value: "true"
       tags:
         taskArn:
         nodename:
@@ -153,9 +150,6 @@ synthesis:
         prefix: "node_"
       - attribute: instrumentation.provider
         value: "prometheus"
-      # Value added for test entities only
-      - attribute: newrelicOnly
-        value: "true"
       tags:
         instanceid:
           entityTagNames: [host.id, instanceid]
@@ -171,9 +165,6 @@ synthesis:
         prefix: "node_"
       - attribute: instrumentation.provider
         value: "prometheus"
-      # Value added for test entities only
-      - attribute: newrelicOnly
-        value: "true"
       tags:
         instance:
         nodename:


### PR DESCRIPTION
### Relevant information

Removed the `newrelicOnly` attribute from the entity synthesis conditions for Prometheus hosts. This should enable Prometheus hosts in production

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
