### PR TITLE
Convert dashboard back to sample

### DIFF
--- a/entity-types/infra-cassandranode/newrelic_dashboard.json
+++ b/entity-types/infra-cassandranode/newrelic_dashboard.json
@@ -1,250 +1,199 @@
 {
-  "name": "CassandraSample",
-  "pages": [
-    {
-      "name": "CassandraSample",
-      "widgets": [
-        {
-          "layout": {
-            "column": 1,
-            "row": 1,
-            "width": 12,
-            "height": 3
-          },
-          "title": "Client request rates",
-          "visualization": {
-            "id": "viz.line"
-          },
-          "rawConfiguration": {
-            "nrqlQueries": [
-              {
-                "accountId": 0,
-                "query": "SELECT average(`cassandra.node.query.casWriteRequestsPerSecond`) AS 'CAS write', average(`cassandra.node.query.casReadRequestsPerSecond`) AS 'CAS read', average(`cassandra.node.query.viewWriteRequestsPerSecond`) AS 'View write', average(`cassandra.node.query.rangeSliceRequestsPerSecond`) AS 'Range slice', average(`cassandra.node.query.readRequestsPerSecond`) AS 'Read', average(`cassandra.node.query.writeRequestsPerSecond`) AS 'Write' FROM Metric  TIMESERIES auto"
-              }
-            ]
-          }
-        },
-        {
-          "layout": {
-            "column": 1,
-            "row": 4,
-            "width": 6,
-            "height": 3
-          },
-          "title": "Pending request pool tasks",
-          "visualization": {
-            "id": "viz.line"
-          },
-          "rawConfiguration": {
-            "nrqlQueries": [
-              {
-                "accountId": 0,
-                "query": "SELECT average(`cassandra.node.threadPool.counterMutationStage.pendingTasks`) AS 'Counter mutation stage', average(`cassandra.node.threadPool.viewMutationStage.pendingTasks`) AS 'View mutation stage', average(`cassandra.node.threadPool.readRepairStage.pendingTasks`) AS 'Read repair stage', average(`cassandra.node.threadPool.readStage.pendingTasks`) AS 'Read stage', average(`cassandra.node.threadPool.requestResponseStage.pendingTasks`) AS 'Request response stage', average(`cassandra.node.threadPool.mutationStage.pendingTasks`) AS 'Mutation stage' FROM Metric  TIMESERIES auto"
-              }
-            ]
-          }
-        },
-        {
-          "layout": {
-            "column": 7,
-            "row": 4,
-            "width": 6,
-            "height": 3
-          },
-          "title": "Active request pool threads",
-          "visualization": {
-            "id": "viz.line"
-          },
-          "rawConfiguration": {
-            "nrqlQueries": [
-              {
-                "accountId": 0,
-                "query": "SELECT average(`cassandra.node.threadPool.counterMutationStage.activeTasks`) AS 'Counter mutation stage', average(`cassandra.node.threadPool.viewMutationStage.activeTasks`) AS 'View mutation stage', average(`cassandra.node.threadPool.readRepairStage.activeTasks`) AS 'Read repair stage', average(`cassandra.node.threadPool.readStage.activeTasks`) AS 'Read stage', average(`cassandra.node.threadPool.requestResponseStage.activeTasks`) AS 'Request response stage', average(`cassandra.node.threadPool.mutationStage.activeTasks`) AS 'Mutation stage' FROM Metric  TIMESERIES auto"
-              }
-            ]
-          }
-        },
-        {
-          "layout": {
-            "column": 1,
-            "row": 7,
-            "width": 4,
-            "height": 3
-          },
-          "title": "Pending read tasks",
-          "visualization": {
-            "id": "viz.area"
-          },
-          "rawConfiguration": {
-            "nrqlQueries": [
-              {
-                "accountId": 0,
-                "query": "SELECT max(`cassandra.node.threadPool.readStage.pendingTasks`) AS 'Read stage' FROM Metric  TIMESERIES auto"
-              }
-            ]
-          }
-        },
-        {
-          "layout": {
-            "column": 5,
-            "row": 7,
-            "width": 4,
-            "height": 3
-          },
-          "title": "Active read tasks",
-          "visualization": {
-            "id": "viz.area"
-          },
-          "rawConfiguration": {
-            "nrqlQueries": [
-              {
-                "accountId": 0,
-                "query": "SELECT max(`cassandra.node.threadPool.readStage.activeTasks`) AS 'Read stage' FROM Metric  TIMESERIES auto"
-              }
-            ]
-          }
-        },
-        {
-          "layout": {
-            "column": 9,
-            "row": 7,
-            "width": 4,
-            "height": 3
-          },
-          "title": "Write latency (ms)",
-          "visualization": {
-            "id": "viz.line"
-          },
-          "rawConfiguration": {
-            "nrqlQueries": [
-              {
-                "accountId": 0,
-                "query": "SELECT average(`cassandra.node.query.writeLatency50ThPercentileMilliseconds`) as '50th', average(`cassandra.node.query.writeLatency75ThPercentileMilliseconds`) as '75th', average(`cassandra.node.query.writeLatency95ThPercentileMilliseconds`) as '95th', average(`cassandra.node.query.writeLatency98ThPercentileMilliseconds`) as '98th', average(`cassandra.node.query.writeLatency99ThPercentileMilliseconds`) as '99th' FROM Metric  TIMESERIES auto"
-              }
-            ]
-          }
-        },
-        {
-          "layout": {
-            "column": 1,
-            "row": 10,
-            "width": 8,
-            "height": 3
-          },
-          "title": "Active internal threadpool tasks",
-          "visualization": {
-            "id": "viz.line"
-          },
-          "rawConfiguration": {
-            "nrqlQueries": [
-              {
-                "accountId": 0,
-                "query": "SELECT average(`cassandra.node.threadPool.antiEntropyStage.activeTasks`) AS 'AntiEntropyStage', average(`cassandra.node.threadPool.cacheCleanupExecutor.activeTasks`) AS 'CacheCleanupExecutor', average(`cassandra.node.threadPool.compactionExecutor.activeTasks`) AS 'CompactionExecutor', average(`cassandra.node.threadPool.gossipStage.activeTasks`) AS 'GossipStage', average(`cassandra.node.threadPool.hintsDispatcher.activeTasks`) AS 'HintsDispatcher', average(`cassandra.node.threadPool.internalResponseStage.activeTasks`) AS 'InternalResponseStage', average(`cassandra.node.threadPool.memtableFlushWriter.activeTasks`) AS 'MemtableFlushWriter', average(`cassandra.node.threadPool.memtablePostFlush.activeTasks`) AS 'MemtablePostFlush', average(`cassandra.node.threadPool.memtableReclaimMemory.activeTasks`) AS 'MemtableReclaimMemory', average(`cassandra.node.threadPool.migrationStage.activeTasks`) AS 'MigrationStage', average(`cassandra.node.threadPool.miscStage.activeTasks`) AS 'MiscStage', average(`cassandra.node.threadPool.pendingRangeCalculator.activeTasks`) AS 'PendingRangeCalculator', average(`cassandra.node.threadPool.sampler.activeTasks`) AS 'Sampler', average(`cassandra.node.threadPool.secondaryIndexManagement.activeTasks`) AS 'SecondaryIndexManagement', average(`cassandra.node.threadPool.validationExecutor.activeTasks`) AS 'ValidationExecutor' FROM Metric  TIMESERIES auto"
-              }
-            ]
-          }
-        },
-        {
-          "layout": {
-            "column": 9,
-            "row": 10,
-            "width": 4,
-            "height": 3
-          },
-          "title": "Read latency (ms)",
-          "visualization": {
-            "id": "viz.line"
-          },
-          "rawConfiguration": {
-            "nrqlQueries": [
-              {
-                "accountId": 0,
-                "query": "SELECT average(`cassandra.node.query.readLatency50ThPercentileMilliseconds`) as '50th', average(`cassandra.node.query.readLatency75ThPercentileMilliseconds`) as '75th', average(`cassandra.node.query.readLatency95ThPercentileMilliseconds`) as '95th',average(`cassandra.node.query.readLatency98ThPercentileMilliseconds`) as '98th', average(`cassandra.node.query.readLatency99ThPercentileMilliseconds`) as '99th' FROM Metric  TIMESERIES auto"
-              }
-            ]
-          }
-        },
-        {
-          "layout": {
-            "column": 1,
-            "row": 13,
-            "width": 8,
-            "height": 3
-          },
-          "title": "Pending internal threadpool tasks",
-          "visualization": {
-            "id": "viz.line"
-          },
-          "rawConfiguration": {
-            "nrqlQueries": [
-              {
-                "accountId": 0,
-                "query": "SELECT average(`cassandra.node.threadPool.antiEntropyStage.pendingTasks`) AS 'AntiEntropyStage', average(`cassandra.node.threadPool.cacheCleanupExecutor.activeTasks`) AS 'CacheCleanupExecutor', average(`cassandra.node.threadPool.compactionExecutor.activeTasks`) AS 'CompactionExecutor', average(`cassandra.node.threadPool.gossipStage.activeTasks`) AS 'GossipStage', average(`cassandra.node.threadPool.hintsDispatcher.activeTasks`) AS 'HintsDispatcher', average(`cassandra.node.threadPool.internalResponseStage.activeTasks`) AS 'InternalResponseStage', average(`cassandra.node.threadPool.memtableFlushWriter.activeTasks`) AS 'MemtableFlushWriter', average(`cassandra.node.threadPool.memtablePostFlush.activeTasks`) AS 'MemtablePostFlush', average(`cassandra.node.threadPool.memtableReclaimMemory.activeTasks`) AS 'MemtableReclaimMemory', average(`cassandra.node.threadPool.migrationStage.activeTasks`) AS 'MigrationStage', average(`cassandra.node.threadPool.miscStage.activeTasks`) AS 'MiscStage', average(`cassandra.node.threadPool.pendingRangeCalculator.activeTasks`) AS 'PendingRangeCalculator', average(`cassandra.node.threadPool.sampler.activeTasks`) AS 'Sampler', average(`cassandra.node.threadPool.secondaryIndexManagement.activeTasks`) AS 'SecondaryIndexManagement', average(`cassandra.node.threadPool.validationExecutor.activeTasks`) AS 'ValidationExecutor' FROM Metric  TIMESERIES auto"
-              }
-            ]
-          }
-        },
-        {
-          "layout": {
-            "column": 9,
-            "row": 13,
-            "width": 4,
-            "height": 3
-          },
-          "title": "Dropped messages per second",
-          "visualization": {
-            "id": "viz.line"
-          },
-          "rawConfiguration": {
-            "nrqlQueries": [
-              {
-                "accountId": 0,
-                "query": "SELECT average(`cassandra.node.droppedBatchRemoveMessagesPerSecond`) AS 'Batch remove', average(`cassandra.node.droppedBatchStoreMessagesPerSecond`) AS 'Batch store', average(`cassandra.node.droppedCounterMutationMessagesPerSecond`) AS 'Counter mutation', average(`cassandra.node.droppedHintMessagesPerSecond`) AS 'Hint', average(`cassandra.node.droppedMutationMessagesPerSecond`) AS 'Mutation', average(`cassandra.node.droppedPagedRangeMessagesPerSecond`) AS 'Paged range', average(`cassandra.node.droppedRangeSliceMessagesPerSecond`) AS 'Range slice', average(`cassandra.node.droppedReadMessagesPerSecond`) AS 'Read', average(`cassandra.node.droppedReadRepairMessagesPerSecond`) AS 'Read repair', average(`cassandra.node.droppedRequestResponseMessagesPerSecond`) AS 'Request response', average(`cassandra.node.droppedTraceMessagesPerSecond`) AS 'Trace' FROM Metric  TIMESERIES auto"
-              }
-            ]
-          }
-        },
-        {
-          "layout": {
-            "column": 1,
-            "row": 16,
-            "width": 6,
-            "height": 3
-          },
-          "title": "Memtable sizes",
-          "visualization": {
-            "id": "viz.line"
-          },
-          "rawConfiguration": {
-            "nrqlQueries": [
-              {
-                "accountId": 0,
-                "query": "SELECT average(`cassandra.node.allMemtablesOnHeapSizeBytes`) AS 'On heap', average(`cassandra.node.allMemtablesOffHeapSizeBytes`) AS 'Off heap' FROM Metric  TIMESERIES auto"
-              }
-            ]
-          }
-        },
-        {
-          "layout": {
-            "column": 7,
-            "row": 16,
-            "width": 6,
-            "height": 3
-          },
-          "title": "Hints in progress.",
-          "visualization": {
-            "id": "viz.area"
-          },
-          "rawConfiguration": {
-            "nrqlQueries": [
-              {
-                "accountId": 0,
-                "query": "SELECT average(`cassandra.node.totalHintsInProgress`) AS 'In progress' FROM Metric  TIMESERIES auto"
-              }
-            ]
-          }
-        }
-      ]
-    }
-  ]
+  "name" : "CassandraSample",
+  "pages" : [ {
+    "name" : "CassandraSample",
+    "widgets" : [ {
+      "visualization" : {
+        "id" : "viz.line"
+      },
+      "layout" : {
+        "column" : 1,
+        "row" : 1,
+        "height" : 3,
+        "width" : 12
+      },
+      "title" : "Client request rates",
+      "rawConfiguration" : {
+        "nrqlQueries" : [ {
+          "query" : "SELECT average(query.CASWriteRequestsPerSecond) AS `CAS write`, average(query.CASReadRequestsPerSecond) AS `CAS read`, average(query.viewWriteRequestsPerSecond) AS `View write`, average(query.rangeSliceRequestsPerSecond) AS `Range slice`, average(query.readRequestsPerSecond) AS `Read`, average(query.writeRequestsPerSecond) AS `Write` FROM CassandraSample TIMESERIES AUTO",
+          "accountId": 0} ]
+      }
+    }, {
+      "visualization" : {
+        "id" : "viz.line"
+      },
+      "layout" : {
+        "column" : 1,
+        "row" : 4,
+        "height" : 3,
+        "width" : 6
+      },
+      "title" : "Pending request pool tasks",
+      "rawConfiguration" : {
+        "nrqlQueries" : [ {
+          "query" : "SELECT average(db.threadpool.requestCounterMutationStagePendingTasks) AS `Counter mutation stage`, average(db.threadpool.requestViewMutationStagePendingTasks) AS `View mutation stage`, average(db.threadpool.requestReadRepairStagePendingTasks) AS `Read repair stage`, average(db.threadpool.requestReadStagePendingTasks) AS `Read stage`, average(db.threadpool.requestRequestResponseStagePendingTasks) AS `Request response stage`, average(db.threadpool.requestMutationStagePendingTasks) AS `Mutation stage` FROM CassandraSample TIMESERIES AUTO",
+          "accountId": 0} ]
+      }
+    }, {
+      "visualization" : {
+        "id" : "viz.line"
+      },
+      "layout" : {
+        "column" : 7,
+        "row" : 4,
+        "height" : 3,
+        "width" : 6
+      },
+      "title" : "Active request pool threads",
+      "rawConfiguration" : {
+        "nrqlQueries" : [ {
+          "query" : "SELECT average(db.threadpool.requestCounterMutationStageActiveTasks) AS `Counter mutation stage`, average(db.threadpool.requestViewMutationStageActiveTasks) AS `View mutation stage`, average(db.threadpool.requestReadRepairStageActiveTasks) AS `Read repair stage`, average(db.threadpool.requestReadStageActiveTasks) AS `Read stage`, average(db.threadpool.requestRequestResponseStageActiveTasks) AS `Request response stage`, average(db.threadpool.requestMutationStageActiveTasks) AS `Mutation stage` FROM CassandraSample TIMESERIES AUTO",
+          "accountId": 0} ]
+      }
+    }, {
+      "visualization" : {
+        "id" : "viz.area"
+      },
+      "layout" : {
+        "column" : 1,
+        "row" : 7,
+        "height" : 3,
+        "width" : 4
+      },
+      "title" : "Pending read tasks",
+      "rawConfiguration" : {
+        "nrqlQueries" : [ {
+          "query" : "SELECT max(db.threadpool.requestReadStagePendingTasks) AS `Read stage` FROM CassandraSample TIMESERIES AUTO",
+          "accountId": 0} ]
+      }
+    }, {
+      "visualization" : {
+        "id" : "viz.area"
+      },
+      "layout" : {
+        "column" : 5,
+        "row" : 7,
+        "height" : 3,
+        "width" : 4
+      },
+      "title" : "Active read tasks",
+      "rawConfiguration" : {
+        "nrqlQueries" : [ {
+          "query" : "SELECT max(db.threadpool.requestReadStageActiveTasks) AS `Read stage` FROM CassandraSample TIMESERIES AUTO",
+          "accountId": 0} ]
+      }
+    }, {
+      "visualization" : {
+        "id" : "viz.line"
+      },
+      "layout" : {
+        "column" : 9,
+        "row" : 7,
+        "height" : 3,
+        "width" : 4
+      },
+      "title" : "Write latency (ms)",
+      "rawConfiguration" : {
+        "nrqlQueries" : [ {
+          "query" : "SELECT average(query.writeLatency50thPercentileMilliseconds) AS `50th`, average(query.writeLatency75thPercentileMilliseconds) AS `75th`, average(query.writeLatency95thPercentileMilliseconds) AS `95th`, average(query.writeLatency98thPercentileMilliseconds) AS `98th`, average(query.writeLatency99thPercentileMilliseconds) AS `99th` FROM CassandraSample TIMESERIES AUTO",
+          "accountId": 0} ]
+      }
+    }, {
+      "visualization" : {
+        "id" : "viz.line"
+      },
+      "layout" : {
+        "column" : 1,
+        "row" : 10,
+        "height" : 3,
+        "width" : 8
+      },
+      "title" : "Active internal threadpool tasks",
+      "rawConfiguration" : {
+        "nrqlQueries" : [ {
+          "query" : "SELECT average(db.threadpool.internalAntiEntropyStageActiveTasks) AS `AntiEntropyStage`, average(db.threadpool.internalCacheCleanupExecutorActiveTasks) AS `CacheCleanupExecutor`, average(db.threadpool.internalCompactionExecutorActiveTasks) AS `CompactionExecutor`, average(db.threadpool.internalGossipStageActiveTasks) AS `GossipStage`, average(db.threadpool.internalHintsDispatcherActiveTasks) AS `HintsDispatcher`, average(db.threadpool.internalInternalResponseStageActiveTasks) AS `InternalResponseStage`, average(db.threadpool.internalMemtableFlushWriterActiveTasks) AS `MemtableFlushWriter`, average(db.threadpool.internalMemtablePostFlushActiveTasks) AS `MemtablePostFlush`, average(db.threadpool.internalMemtableReclaimMemoryActiveTasks) AS `MemtableReclaimMemory`, average(db.threadpool.internalMigrationStageActiveTasks) AS `MigrationStage`, average(db.threadpool.internalMiscStageActiveTasks) AS `MiscStage`, average(db.threadpool.internalPendingRangeCalculatorActiveTasks) AS `PendingRangeCalculator`, average(db.threadpool.internalSamplerActiveTasks) AS `Sampler`, average(db.threadpool.internalSecondaryIndexManagementActiveTasks) AS `SecondaryIndexManagement`, average(db.threadpool.internalValidationExecutorActiveTasks) AS `ValidationExecutor` FROM CassandraSample TIMESERIES AUTO",
+          "accountId": 0} ]
+      }
+    }, {
+      "visualization" : {
+        "id" : "viz.line"
+      },
+      "layout" : {
+        "column" : 9,
+        "row" : 10,
+        "height" : 3,
+        "width" : 4
+      },
+      "title" : "Read latency (ms)",
+      "rawConfiguration" : {
+        "nrqlQueries" : [ {
+          "query" : "SELECT average(query.readLatency50thPercentileMilliseconds) AS `50th`, average(query.readLatency75thPercentileMilliseconds) AS `75th`, average(query.readLatency95thPercentileMilliseconds) AS `95th`, average(query.readLatency98thPercentileMilliseconds) AS `98th`, average(query.readLatency99thPercentileMilliseconds) AS `99th` FROM CassandraSample TIMESERIES AUTO",
+          "accountId": 0} ]
+      }
+    }, {
+      "visualization" : {
+        "id" : "viz.line"
+      },
+      "layout" : {
+        "column" : 1,
+        "row" : 13,
+        "height" : 3,
+        "width" : 8
+      },
+      "title" : "Pending internal threadpool tasks",
+      "rawConfiguration" : {
+        "nrqlQueries" : [ {
+          "query" : "SELECT average(db.threadpool.internalAntiEntropyStagePendingTasks) AS `AntiEntropyStage`, average(db.threadpool.internalCacheCleanupExecutorActiveTasks) AS `CacheCleanupExecutor`, average(db.threadpool.internalCompactionExecutorActiveTasks) AS `CompactionExecutor`, average(db.threadpool.internalGossipStageActiveTasks) AS `GossipStage`, average(db.threadpool.internalHintsDispatcherActiveTasks) AS `HintsDispatcher`, average(db.threadpool.internalInternalResponseStageActiveTasks) AS `InternalResponseStage`, average(db.threadpool.internalMemtableFlushWriterActiveTasks) AS `MemtableFlushWriter`, average(db.threadpool.internalMemtablePostFlushActiveTasks) AS `MemtablePostFlush`, average(db.threadpool.internalMemtableReclaimMemoryActiveTasks) AS `MemtableReclaimMemory`, average(db.threadpool.internalMigrationStageActiveTasks) AS `MigrationStage`, average(db.threadpool.internalMiscStageActiveTasks) AS `MiscStage`, average(db.threadpool.internalPendingRangeCalculatorActiveTasks) AS `PendingRangeCalculator`, average(db.threadpool.internalSamplerActiveTasks) AS `Sampler`, average(db.threadpool.internalSecondaryIndexManagementActiveTasks) AS `SecondaryIndexManagement`, average(db.threadpool.internalValidationExecutorActiveTasks) AS `ValidationExecutor` FROM CassandraSample TIMESERIES AUTO",
+          "accountId": 0} ]
+      }
+    }, {
+      "visualization" : {
+        "id" : "viz.line"
+      },
+      "layout" : {
+        "column" : 9,
+        "row" : 13,
+        "height" : 3,
+        "width" : 4
+      },
+      "title" : "Dropped messages per second",
+      "rawConfiguration" : {
+        "nrqlQueries" : [ {
+          "query" : "SELECT average(db.droppedBatchRemoveMessagesPerSecond) AS `Batch remove`, average(db.droppedBatchStoreMessagesPerSecond) AS `Batch store`, average(db.droppedCounterMutationMessagesPerSecond) AS `Counter mutation`, average(db.droppedHintMessagesPerSecond) AS `Hint`, average(db.droppedMutationMessagesPerSecond) AS `Mutation`, average(db.droppedPagedRangeMessagesPerSecond) AS `Paged range`, average(db.droppedRangeSliceMessagesPerSecond) AS `Range slice`, average(db.droppedReadMessagesPerSecond) AS `Read`, average(db.droppedReadRepairMessagesPerSecond) AS `Read repair`, average(db.droppedRequestResponseMessagesPerSecond) AS `Request response`, average(db.droppedTraceMessagesPerSecond) AS `Trace` FROM CassandraSample TIMESERIES AUTO",
+          "accountId": 0} ]
+      }
+    }, {
+      "visualization" : {
+        "id" : "viz.line"
+      },
+      "layout" : {
+        "column" : 1,
+        "row" : 16,
+        "height" : 3,
+        "width" : 6
+      },
+      "title" : "Memtable sizes",
+      "rawConfiguration" : {
+        "nrqlQueries" : [ {
+          "query" : "SELECT average(db.allMemtablesOnHeapSizeBytes) AS `On heap`, average(db.allMemtablesOffHeapSizeBytes) AS `Off heap` FROM CassandraSample TIMESERIES AUTO",
+          "accountId": 0} ]
+      }
+    }, {
+      "visualization" : {
+        "id" : "viz.area"
+      },
+      "layout" : {
+        "column" : 7,
+        "row" : 16,
+        "height" : 3,
+        "width" : 6
+      },
+      "title" : "Hints in progress.",
+      "rawConfiguration" : {
+        "nrqlQueries" : [ {
+          "query" : "SELECT average(db.totalHintsInProgress) AS `In progress` FROM CassandraSample TIMESERIES AUTO",
+          "accountId": 0} ]
+      }
+    } ]
+  } ]
 }


### PR DESCRIPTION
### Relevant information

This PR updates the Cassandra dashboard to use the CassandraSample instead of Metric.

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
