### PR TITLE
fix-infra-rabbitmq-golden-metric-opentelemetry

### DIFF
--- a/entity-types/infra-rabbitmqqueue/golden_metrics.yml
+++ b/entity-types/infra-rabbitmqqueue/golden_metrics.yml
@@ -12,8 +12,7 @@ consumers:
       from: RabbitmqQueueSample
       eventId: entityGuid
       eventName: entityName
-    opentelemetry:
-      select: average(rabbitmq.consumer.count)
+
 messagesDelivered:
   title: Messages delivered
   unit: COUNT
@@ -28,8 +27,7 @@ messagesDelivered:
       from: RabbitmqQueueSample
       eventId: entityGuid
       eventName: entityName
-    opentelemetry:
-      select: average(rabbitmq.message.delivered)
+
 messagesDeliveredPerSecond:
   title: Messages delivered per second
   unit: OPERATIONS_PER_SECOND
@@ -59,8 +57,6 @@ messagesPublished:
       from: RabbitmqQueueSample
       eventId: entityGuid
       eventName: entityName
-    opentelemetry:
-      select: average(rabbitmq.message.published)
 
 messagesPublishedPerSecond:
   title: Messages published per second


### PR DESCRIPTION
### Relevant information

Remove new `infra-rabbitmqqueue` golden-metric `opentelemetry` that was wrongly merged from this previous PR: https://github.com/newrelic/entity-definitions/pull/1300

cc @lazyplatypus 

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
