### PR TITLE
Feat: overrideGuidType for prometheus hosts

### DIFF
--- a/entity-types/infra-host/definition.yml
+++ b/entity-types/infra-host/definition.yml
@@ -124,6 +124,8 @@ synthesis:
     # AWS by taskArn
     - identifier: taskarn
       name: taskarn
+      legacyFeatures:
+        overrideGuidType: true
       encodeIdentifierInGUID: true
       conditions:
       - attribute: instanceid
@@ -145,6 +147,8 @@ synthesis:
     # AWS EC2 by instanceid
     - identifier: instanceid
       name: instanceid
+      legacyFeatures:
+        overrideGuidType: true
       encodeIdentifierInGUID: true
       conditions:
       - attribute: instance
@@ -165,6 +169,8 @@ synthesis:
     # On a host
     - identifier: instance
       name: instance
+      legacyFeatures:
+        overrideGuidType: true
       encodeIdentifierInGUID: true
       conditions:
       - attribute: metricName


### PR DESCRIPTION
### Relevant information
As per [this thread](https://newrelic.slack.com/archives/C05888HE0QK/p1702999430090749?thread_ts=1702498776.806249&cid=C05888HE0QK) we're adding `overrideGuidType` for prometheus hosts.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
