### PR TITLE
Change Issues visibility in Explorer & Navigator

### DIFF
--- a/entity-types/aiops-issue/definition.yml
+++ b/entity-types/aiops-issue/definition.yml
@@ -2,4 +2,4 @@ domain: AIOPS
 type: ISSUE
 configuration:
   entityExpirationTime: MANUAL
-  alertable: true
+  alertable: false


### PR DESCRIPTION
### Relevant information

By setting the `isAlertable` flag from true to false we're proposing to remove entities type of Issue from Explorer and Navigator. These entities will be still searchable in the Quick Find section and all Issues will be visible within the Alerts & AI Issues feed page.

Furthermore - Issues entities will continue to be colored according to the severity of the underlying set of issues.

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
