### PR TITLE
Use apm.mobile.* metrics

### DIFF
--- a/entity-types/mobile-application/golden_metrics.yml
+++ b/entity-types/mobile-application/golden_metrics.yml
@@ -2,8 +2,7 @@ appLaunchCountMetric:
   title: App launches 
   unit: COUNT
   query:
-    select: count(newrelic.timeslice.value)
-    where: metricTimesliceName = 'Session/Start'
+    select: count(apm.mobile.application.launch.count)
     eventName: appName
 crashCount:
   title: Crash count
@@ -17,22 +16,19 @@ httpResponseTimeMsMetric:
   title: HTTP response time (ms)
   unit: MS
   query:
-    select: average(newrelic.timeslice.value) * 1000
-    where: metricTimesliceName = 'External/all'
+    select: average(apm.mobile.external.duration) * 1000
     eventName: appName
 networkFailuresCountMetric:
   title: Network failure count
   unit: COUNT
   query:
-    select: average(newrelic.timeslice.value)
-    where: metricTimesliceName = 'Mobile/FailedCallRate'
+    select: average(apm.mobile.failed.call.rate)
     eventName: appName
 httpErrorsRateMetric:
   title: HTTP error rate
   unit: PERCENTAGE
   query:
-    select: average(newrelic.timeslice.value)
-    where: metricTimesliceName = 'Mobile/StatusErrorRate'
+    select: average(apm.mobile.status.error.rate)
     eventName: appName
 requestsPerMinute:
   title: Requests per minute (req/min)


### PR DESCRIPTION
### Relevant information

Siva would like to use dimensional metrics (NRDB) instead of our legacy timeslice metrics that are exposed in NRQL through MTQW.  One of the easier products to update is mobile because many of the metrics are generated in backend service(s) instead of in agents.  Many mobile timeslice metrics have been mapped to dimensional metrics in MTQW:

https://source.datanerd.us/collector-collective/metric-timeslice-query-worker/blob/master/mtqw-dimensional-metrics/src/main/resources/com/newrelic/dimensionalmetricbridge/metricformat/mobile-dimensional-metrics.csv

https://source.datanerd.us/collector-collective/metric-timeslice-query-worker/blob/master/mtqw-dimensional-metrics/src/main/resources/com/newrelic/dimensionalmetricbridge/metricformat/mobile-exact-metrics.csv

This document provides more insight into the change: https://docs.google.com/document/d/1gE7JEARQniBps_vQSC9hrKyHH0Z-eBTGDwTZLWO4psU/edit#heading=h.i5fgbqns0ulf

Many parts of the mobile UI have already been updated to use the new mobile metric names.  We need to update golden signals as well.  For the golden signals pipeline, this will allow us to move away from the old timeslice metrics and use proper dimensional metrics.  The golden signals definitions are also used by alerting, so with this change, new alerts will be created using the new metric names.

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
