### PR TITLE
fix: Prometheus cpuUsage query select

### DIFF
--- a/entity-types/infra-host/golden_metrics.yml
+++ b/entity-types/infra-host/golden_metrics.yml
@@ -19,7 +19,7 @@ cpuUsage:
       eventId: entity.guid
       eventName: entity.name
     prometheus:
-      select: (filter(sum(node_cpu_seconds_total), where mode != 'idle') / sum(node_cpu_seconds_total)) * 100
+      select: (filter(sum(node_cpu_seconds_total), where mode != 'idle') * 100) / sum(node_cpu_seconds_total)
       where: node_cpu_seconds_total != 0
       from: Metric
       eventId: entity.guid


### PR DESCRIPTION
### Relevant information
Updated prometheus select based on recommendations in this [slack thread](https://newrelic.slack.com/archives/C0446Q75V7E/p1704810845334949?thread_ts=1703005436.571799&cid=C0446Q75V7E). Should resolve an issue where the order of operations within the select were causing incorrect calculations.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
