### PR TITLE
Include short container id tag in candidate definition

### DIFF
--- a/relationships/candidates/CONTAINER.yml
+++ b/relationships/candidates/CONTAINER.yml
@@ -6,7 +6,7 @@ lookups:
     tags:
       matchingMode: ANY
       predicates:
-        - tagKeys: ["k8s.containerId", "docker.containerId"]
+        - tagKeys: ["k8s.containerId", "docker.containerId", "docker.shortContainerId"]
           field: containerId
     onMatch:
      onMultipleMatches: RELATE_ALL


### PR DESCRIPTION
### Relevant information

Include `docker.shortContainerId` tag in `CONTAINER`'s candidate definition.
This way we will be able to also find the container when the provided id is the short one.

By the way, I've checked that 100% of docker container entities that have the `docker.containerId` tag also have the `docker.shortContainerId` one.

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
