### PR TITLE
Xpipes/remove metric queries from vspherevm golden metrics

### DIFF
--- a/entity-types/aiops-issue/definition.yml
+++ b/entity-types/aiops-issue/definition.yml
@@ -2,4 +2,4 @@ domain: AIOPS
 type: ISSUE
 configuration:
   entityExpirationTime: MANUAL
-  alertable: false
+  alertable: true

--- a/entity-types/infra-vspherevm/golden_metrics.yml
+++ b/entity-types/infra-vspherevm/golden_metrics.yml
@@ -1,63 +1,44 @@
-cpuUsage:
-  title: CPU usage (%)
-  unit: PERCENTAGE
-  queries:
-    newRelic:
-      select: average(vsphere.vm.cpu.hostUsagePercent)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(cpu.hostUsagePercent)
-      from: VSphereVmSample
-      eventId: entityGuid
-      eventName: entityName
-memoryUsage:
-  title: Memory usage (MiB)
-  unit: BYTES
-  queries:
-    newRelic:
-      select: average(vsphere.vm.mem.usage)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(mem.usage)
-      from: VSphereVmSample
-      eventId: entityGuid
-      eventName: entityName
-memorySize:
-  title: Memory size (MiB)
-  unit: BYTES
-  queries:
-    newRelic:
-      select: average(vsphere.vm.mem.size)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(mem.size)
-      from: VSphereVmSample
-      eventId: entityGuid
-      eventName: entityName
-diskUsageMib:
-  title: Disk usage (MiB)
-  unit: BYTES
-  queries:
-    newRelic:
-      select: average(vsphere.vm.disk.totalMiB)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
-      select: average(disk.totalMiB)
-      from: VSphereVmSample
-      eventId: entityGuid
-      eventName: entityName
 cpuAllocationlimit:
   query:
     eventId: entityGuid
-    select: (latest(`cpu.allocationLimit`)) * 1000 * 1000
     from: VSphereVmSample
-  unit: HERTZ
+    select: (latest(`cpu.allocationLimit`)) * 1000 * 1000
   title: CPU allocation limit
+  unit: HERTZ
+cpuUsage:
+  queries:
+    newRelic:
+      eventId: entityGuid
+      eventName: entityName
+      from: VSphereVmSample
+      select: average(cpu.hostUsagePercent)
+  title: CPU usage (%)
+  unit: PERCENTAGE
+diskUsageMib:
+  queries:
+    newRelic:
+      eventId: entityGuid
+      eventName: entityName
+      from: VSphereVmSample
+      select: average(disk.totalMiB)
+  title: Disk usage (MiB)
+  unit: BYTES
+memorySize:
+  queries:
+    newRelic:
+      eventId: entityGuid
+      eventName: entityName
+      from: VSphereVmSample
+      select: average(mem.size)
+  title: Memory size (MiB)
+  unit: BYTES
+memoryUsage:
+  queries:
+    newRelic:
+      eventId: entityGuid
+      eventName: entityName
+      from: VSphereVmSample
+      select: average(mem.usage)
+  title: Memory usage (MiB)
+  unit: BYTES
+


### PR DESCRIPTION
### Relevant information
Ticket: https://new-relic.atlassian.net/browse/NR-212978
Since we’re cancelling the infra dimensional metrics migration, the UI needs to make all the queries using events.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
