### PR TITLE
Remove metric queries from vspherevm golden metrics

### DIFF
--- a/entity-types/infra-vspherevm/golden_metrics.yml
+++ b/entity-types/infra-vspherevm/golden_metrics.yml
@@ -3,11 +3,6 @@ cpuUsage:
   unit: PERCENTAGE
   queries:
     newRelic:
-      select: average(vsphere.vm.cpu.hostUsagePercent)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(cpu.hostUsagePercent)
       from: VSphereVmSample
       eventId: entityGuid
@@ -17,11 +12,6 @@ memoryUsage:
   unit: BYTES
   queries:
     newRelic:
-      select: average(vsphere.vm.mem.usage)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(mem.usage)
       from: VSphereVmSample
       eventId: entityGuid
@@ -31,11 +21,6 @@ memorySize:
   unit: BYTES
   queries:
     newRelic:
-      select: average(vsphere.vm.mem.size)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(mem.size)
       from: VSphereVmSample
       eventId: entityGuid
@@ -45,11 +30,6 @@ diskUsageMib:
   unit: BYTES
   queries:
     newRelic:
-      select: average(vsphere.vm.disk.totalMiB)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(disk.totalMiB)
       from: VSphereVmSample
       eventId: entityGuid
@@ -61,3 +41,4 @@ cpuAllocationlimit:
     from: VSphereVmSample
   unit: HERTZ
   title: CPU allocation limit
+


### PR DESCRIPTION
### Relevant information

Since we’re cancelling the infra DM migration, our curated UI needs to make all the queries using events.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
