### PR TITLE
Remove metric queries from vsphereresourcepool golden metrics

### DIFF
--- a/entity-types/infra-vsphereresourcepool/golden_metrics.yml
+++ b/entity-types/infra-vsphereresourcepool/golden_metrics.yml
@@ -3,11 +3,6 @@ numberOfVmsInThisPool:
   unit: COUNT
   queries:
     newRelic:
-      select: average(vsphere.resourcePool.vmCount)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(vmCount)
       from: VSphereResourcePoolSample
       eventId: entityGuid
@@ -17,11 +12,6 @@ aggregatedCpuUsage:
   unit: PERCENTAGE
   queries:
     newRelic:
-      select: average(vsphere.resourcePool.cpu.overallUsage)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(cpu.overallUsage)
       from: VSphereResourcePoolSample
       eventId: entityGuid
@@ -31,11 +21,6 @@ memoryUsage:
   unit: BYTES
   queries:
     newRelic:
-      select: average(vsphere.resourcePool.mem.usage)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(mem.usage)
       from: VSphereResourcePoolSample
       eventId: entityGuid
@@ -45,11 +30,6 @@ memoryFree:
   unit: BYTES
   queries:
     newRelic:
-      select: average(vsphere.resourcePool.mem.free)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(mem.free)
       from: VSphereResourcePoolSample
       eventId: entityGuid
@@ -57,11 +37,6 @@ memoryFree:
 vmCount:
   queries:
     newRelic:
-      select: average(vsphere.resourcePool.vmCount)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(`vmCount`)
       from: VSphereResourcePoolSample
       eventId: entityGuid
@@ -71,14 +46,10 @@ vmCount:
 memSwapped:
   queries:
     newRelic:
-      select: average(vsphere.resourcePool.mem.swapped) * 1024 * 1204
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(`mem.swapped`) * 1024 * 1204
       from: VSphereResourcePoolSample
       eventId: entityGuid
       eventName: entityName
   unit: BYTES
   title: Memory swapped
+


### PR DESCRIPTION
### Relevant information

Ticket: https://new-relic.atlassian.net/browse/NR-212978

Since we’re cancelling the infra DM migration, our curated UI needs to make all the queries using events.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
