### PR TITLE
Remove metric queries from vspherehost golden metrics

### DIFF
--- a/entity-types/infra-vspherehost/golden_metrics.yml
+++ b/entity-types/infra-vspherehost/golden_metrics.yml
@@ -3,11 +3,6 @@ cpuUsage:
   unit: PERCENTAGE
   queries:
     newRelic:
-      select: average(vsphere.host.cpu.percent)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(cpu.percent)
       from: VSphereHostSample
       eventId: entityGuid
@@ -17,11 +12,6 @@ memoryFree:
   unit: BYTES
   queries:
     newRelic:
-      select: average(vsphere.host.mem.free)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(mem.free)
       from: VSphereHostSample
       eventId: entityGuid
@@ -31,11 +21,6 @@ memorySize:
   unit: BYTES
   queries:
     newRelic:
-      select: average(vsphere.host.mem.size)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(mem.size)
       from: VSphereHostSample
       eventId: entityGuid
@@ -45,11 +30,6 @@ diskUsageMib:
   unit: BYTES
   queries:
     newRelic:
-      select: average(vsphere.host.disk.totalMiB)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(disk.totalMiB)
       from: VSphereHostSample
       eventId: entityGuid
@@ -59,12 +39,8 @@ vmCount:
   title: Virtual machines count
   queries:
     newRelic:
-      select: latest(vsphere.host.vmCount)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: latest(`vmCount`)
       from: VSphereHostSample
       eventId: entityGuid
       eventName: entityName
+


### PR DESCRIPTION
### Relevant information

Since we’re cancelling the infra DM migration, our curated UI needs to make all the queries using events.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
