### PR TITLE
Remove metric queries from vspheredatacenter golden metrics

### DIFF
--- a/entity-types/infra-vspheredatacenter/golden_metrics.yml
+++ b/entity-types/infra-vspheredatacenter/golden_metrics.yml
@@ -3,11 +3,6 @@ cpuUsage:
   unit: PERCENTAGE
   queries:
     newRelic:
-      select: average(vsphere.datacenter.cpu.overallUsagePercentage)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(cpu.overallUsagePercentage)
       from: VSphereDatacenterSample
       eventId: entityGuid
@@ -17,11 +12,6 @@ memoryUsage:
   unit: PERCENTAGE
   queries:
     newRelic:
-      select: average(vsphere.datacenter.mem.usagePercentage)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(mem.usagePercentage)
       from: VSphereDatacenterSample
       eventId: entityGuid
@@ -31,11 +21,6 @@ memoryTotal:
   unit: BYTES
   queries:
     newRelic:
-      select: (average(vsphere.datacenter.mem.usage)) * 1024 * 1204
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: (average(`mem.usage`)) * 1024 * 1204
       from: VSphereDatacenterSample
       eventId: entityGuid
@@ -45,12 +30,8 @@ datastoreCapacityUtilizationGib:
   unit: BYTES
   queries:
     newRelic:
-      select: average(vsphere.datacenter.datastore.totalUsedGiB)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(datastore.totalUsedGiB)
       from: VSphereDatacenterSample
       eventId: entityGuid
       eventName: entityName
+


### PR DESCRIPTION
### Relevant information

Since we’re cancelling the infra DM migration, our curated UI needs to make all the queries using events.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.