### PR TITLE
Remove metric queries from vspherecluster golden metrics

### DIFF
--- a/entity-types/infra-vspherecluster/golden_metrics.yml
+++ b/entity-types/infra-vspherecluster/golden_metrics.yml
@@ -3,11 +3,6 @@ hostsCount:
   unit: COUNT
   queries:
     newRelic:
-      select: latest(vsphere.cluster.hosts)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: latest(`hosts`)
       from: VSphereClusterSample
       eventId: entityGuid
@@ -17,11 +12,6 @@ totalEffectiveMHz:
   unit: HERTZ
   queries:
     newRelic:
-      select: latest(vsphere.cluster.cpu.totalEffectiveMHz)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: latest(`cpu.totalEffectiveMHz`)
       from: VSphereClusterSample
       eventId: entityGuid
@@ -31,11 +21,6 @@ totalMHz:
   unit: HERTZ
   queries:
     newRelic:
-      select: latest(vsphere.cluster.cpu.totalMhz)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: latest(`cpu.totalMHz`)
       from: VSphereClusterSample
       eventId: entityGuid
@@ -43,14 +28,10 @@ totalMHz:
 effectiveHosts:
   queries:
     newRelic:
-      select: latest(vsphere.cluster.effectiveHosts)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: latest(`effectiveHosts`)
       from: VSphereClusterSample
       eventId: entityGuid
       eventName: entityName
   unit: COUNT
   title: Effective hosts
+


### PR DESCRIPTION
### Relevant information

Since we’re cancelling the infra DM migration, our curated UI needs to make all the queries using events.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.