### PR TITLE
Remove metric queries from squid_cachemgr golden metrics

### DIFF
--- a/entity-types/infra-squid_cachemgr/golden_metrics.yml
+++ b/entity-types/infra-squid_cachemgr/golden_metrics.yml
@@ -3,15 +3,14 @@ requests_count:
   unit: COUNT
   query:
     select: sum(squid_client_http_requests_total) AS 'Requests'
-
 cache_hit_count:
   title: Cache hit rate (%)
   unit: PERCENTAGE
   query:
     select: sum(squid_client_http_hits_total)/sum(squid_client_http_requests_total)*100
-
 error_rate:
   title: Error rate (%)
   unit: PERCENTAGE
   query:
     select: sum(squid_client_http_errors_total)/sum(squid_client_http_requests_total)*100
+


### PR DESCRIPTION
### Relevant information

Ticket: https://new-relic.atlassian.net/browse/NR-212978

Since we’re cancelling the infra DM migration, our curated UI needs to make all the queries using events.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.