### PR TITLE
Remove metric queries from redisinstance golden metrics

### DIFF
--- a/entity-types/infra-redisinstance/golden_metrics.yml
+++ b/entity-types/infra-redisinstance/golden_metrics.yml
@@ -7,6 +7,9 @@ keyspaceHitsPerSecond:
       from: RedisSample
       eventId: entityGuid
       eventName: entityName
+    # defaulting to newRelic query for now since we cannot match value functions for OpenTelemetry cumulative metrics.
+    # opentelemetry:
+    #   select: rate(sum(redis.keyspace.hits), 1 second)
 keyspaceMissesPerSecond:
   title: Keyspace misses per second
   unit: OPERATIONS_PER_SECOND
@@ -16,15 +19,17 @@ keyspaceMissesPerSecond:
       from: RedisSample
       eventId: entityGuid
       eventName: entityName
+    # defaulting to newRelic query for now since we cannot match value functions for OpenTelemetry cumulative metrics.
+    # opentelemetry:
+    #   select: rate(sum(redis.keyspace.misses), 1 second)
 connectedClients:
   title: Connected clients
   unit: COUNT
   queries:
-    opentelemetry:
-      select: average(redis.clients.connected)
     newRelic:
       select: average(net.connectedClients)
       from: RedisSample
       eventId: entityGuid
       eventName: entityName
-
+    opentelemetry:
+      select: average(redis.clients.connected)

--- a/entity-types/infra-redisinstance/golden_metrics.yml
+++ b/entity-types/infra-redisinstance/golden_metrics.yml
@@ -3,48 +3,28 @@ keyspaceHitsPerSecond:
   unit: OPERATIONS_PER_SECOND
   queries:
     newRelic:
-      select: average(redis.instance.keyspaceHitsPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(db.keyspaceHitsPerSecond)
       from: RedisSample
       eventId: entityGuid
       eventName: entityName
-    # defaulting to newRelic query for now since we cannot match value functions for OpenTelemetry cumulative metrics.
-    # opentelemetry:
-    #   select: rate(sum(redis.keyspace.hits), 1 second)
 keyspaceMissesPerSecond:
   title: Keyspace misses per second
   unit: OPERATIONS_PER_SECOND
   queries:
     newRelic:
-      select: average(redis.instance.keyspaceMissesPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(db.keyspaceMissesPerSecond)
       from: RedisSample
       eventId: entityGuid
       eventName: entityName
-    # defaulting to newRelic query for now since we cannot match value functions for OpenTelemetry cumulative metrics.
-    # opentelemetry:
-    #   select: rate(sum(redis.keyspace.misses), 1 second)
 connectedClients:
   title: Connected clients
   unit: COUNT
   queries:
+    opentelemetry:
+      select: average(redis.clients.connected)
     newRelic:
-      select: average(redis.instance.net.connectedClients)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(net.connectedClients)
       from: RedisSample
       eventId: entityGuid
       eventName: entityName
-    opentelemetry:
-      select: average(redis.clients.connected)
+


### PR DESCRIPTION
### Relevant information

Since we’re cancelling the infra DM migration, our curated UI needs to make all the queries using events.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.