### PR TITLE
Remove metric queries from rabbitmqqueue golden metrics

### DIFF
--- a/entity-types/infra-rabbitmqqueue/golden_metrics.yml
+++ b/entity-types/infra-rabbitmqqueue/golden_metrics.yml
@@ -3,72 +3,44 @@ consumers:
   unit: COUNT
   queries:
     newRelic:
-      select: average(rabbitmq.queue.consumers)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(queue.consumers)
       from: RabbitmqQueueSample
       eventId: entityGuid
       eventName: entityName
-
 messagesDelivered:
   title: Messages delivered
   unit: COUNT
   queries:
     newRelic:
-      select: sum(rabbitmq.queue.sumMessagesDelivered)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: sum(queue.sumMessagesDelivered)
       from: RabbitmqQueueSample
       eventId: entityGuid
       eventName: entityName
-
 messagesDeliveredPerSecond:
   title: Messages delivered per second
   unit: OPERATIONS_PER_SECOND
   queries:
     newRelic:
-      select: average(rabbitmq.queue.sumMessagesDeliveredPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(queue.sumMessagesDeliveredPerSecond)
       from: RabbitmqQueueSample
       eventId: entityGuid
       eventName: entityName
-
 messagesPublished:
   title: Messages published
   unit: COUNT
   queries:
     newRelic:
-      select: sum(rabbitmq.queue.messagesPublished)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: sum(queue.messagesPublished)
       from: RabbitmqQueueSample
       eventId: entityGuid
       eventName: entityName
-
 messagesPublishedPerSecond:
   title: Messages published per second
-  unit: OPERATIONS_PER_SECOND        
+  unit: OPERATIONS_PER_SECOND
   queries:
     newRelic:
-      select: average(rabbitmq.queue.messagesPublishedPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(queue.messagesPublishedPerSecond)
       from: RabbitmqQueueSample
       eventId: entityGuid
       eventName: entityName
+


### PR DESCRIPTION
### Relevant information

Since we’re cancelling the infra DM migration, our curated UI needs to make all the queries using events.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.