### PR TITLE
Remove metric queries from rabbitmqnode golden metrics

### DIFF
--- a/entity-types/infra-rabbitmqnode/golden_metrics.yml
+++ b/entity-types/infra-rabbitmqnode/golden_metrics.yml
@@ -3,11 +3,6 @@ totalMemoryUsedInBytes:
   units: BYTES
   queries:
     newRelic:
-      select: average(rabbitmq.node.totalMemoryUsedInBytes)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(node.totalMemoryUsedInBytes)
       from: RabbitmqNodeSample
       eventId: entityGuid
@@ -17,11 +12,6 @@ diskSpaceFreeInBytes:
   units: BYTES
   queries:
     newRelic:
-      select: average(rabbitmq.node.diskSpaceFreeInBytes)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(node.diskSpaceFreeInBytes)
       from: RabbitmqNodeSample
       eventId: entityGuid
@@ -31,11 +21,6 @@ fileDescriptorsTotalUsed:
   unit: COUNT
   queries:
     newRelic:
-      select: average(rabbitmq.node.fileDescriptorsTotalUsed)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(node.fileDescriptorsTotalUsed)
       from: RabbitmqNodeSample
       eventId: entityGuid
@@ -45,12 +30,8 @@ averageErlangProcessesWaiting:
   unit: OPERATIONS_PER_SECOND
   queries:
     newRelic:
-      select: average(rabbitmq.node.averageErlangProcessesWaiting)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(node.averageErlangProcessesWaiting)
       from: RabbitmqNodeSample
       eventId: entityGuid
       eventName: entityName
+


### PR DESCRIPTION
### Relevant information

Since we’re cancelling the infra DM migration, our curated UI needs to make all the queries using events.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.