### PR TITLE
Remove metric queries from rabbitmqexchange golden metrics

### DIFF
--- a/entity-types/infra-rabbitmqexchange/golden_metrics.yml
+++ b/entity-types/infra-rabbitmqexchange/golden_metrics.yml
@@ -2,11 +2,6 @@ bindings:
   title: Bindings
   queries:
     newRelic:
-      select: average(rabbitmq.exchange.bindings)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(exchange.bindings)
       from: RabbitmqExchangeSample
       eventId: entityGuid
@@ -15,11 +10,6 @@ messagesPublishedPerChannel:
   title: Messages published per channel
   queries:
     newRelic:
-      select: sum(rabbitmq.exchange.messagesPublishedPerChannel)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: sum(exchange.messagesPublishedPerChannel)
       from: RabbitmqExchangeSample
       eventId: entityGuid
@@ -28,11 +18,6 @@ messagesPublishedPerChannelPerSecond:
   title: Messages published per channel per second
   queries:
     newRelic:
-      select: average(rabbitmq.exchange.messagesPublishedPerChannelPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(exchange.messagesPublishedPerChannelPerSecond)
       from: RabbitmqExchangeSample
       eventId: entityGuid
@@ -41,11 +26,6 @@ messagesPublishedQueue:
   title: Messages published queue
   queries:
     newRelic:
-      select: sum(rabbitmq.exchange.messagesPublishedQueue)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: sum(exchange.messagesPublishedQueue)
       from: RabbitmqExchangeSample
       eventId: entityGuid
@@ -54,12 +34,8 @@ messagesPublishedQueuePerSecond:
   title: Messages published queue per second
   queries:
     newRelic:
-      select: average(rabbitmq.exchange.messagesPublishedQueuePerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(exchange.messagesPublishedQueuePerSecond)
       from: RabbitmqExchangeSample
       eventId: entityGuid
       eventName: entityName
+


### PR DESCRIPTION
### Relevant information

Since we’re cancelling the infra DM migration, our curated UI needs to make all the queries using events.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.