### PR TITLE
Remove metric queries from powerdns_recursor golden metrics

### DIFF
--- a/entity-types/infra-powerdns_recursor/golden_metrics.yml
+++ b/entity-types/infra-powerdns_recursor/golden_metrics.yml
@@ -4,17 +4,16 @@ concurrent_queries:
   query:
     select: average(powerdns_recursor_concurrent_queries)
     from: Metric
-
 cache_size:
   title: Number of entries in the cache
   unit: COUNT
   query:
     select: average(powerdns_recursor_cache_size)
     from: Metric
-
 exceptions_total:
   title: Total number of exceptions by error
   unit: COUNT
   query:
     select: sum(powerdns_recursor_exceptions_total)
     from: Metric
+


### PR DESCRIPTION
### Relevant information

Ticket: https://new-relic.atlassian.net/browse/NR-212978

Since we’re cancelling the infra DM migration, our curated UI needs to make all the queries using events.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.