### PR TITLE
Remove metric queries from powerdns_authoritative golden metrics

### DIFF
--- a/entity-types/infra-powerdns_authoritative/golden_metrics.yml
+++ b/entity-types/infra-powerdns_authoritative/golden_metrics.yml
@@ -4,18 +4,17 @@ queries_total:
   query:
     select: sum(powerdns_authoritative_queries_total)
     from: Metric
-    where: "proto='tcp' OR proto='udp'"
-
+    where: proto='tcp' OR proto='udp'
 update_queries_total:
   title: Total number of DNS update queries by status.
   unit: COUNT
   query:
     select: sum(powerdns_authoritative_dnsupdate_queries_total)
     from: Metric
-
 exceptions_total:
   title: Total number of exceptions by error.
   unit: COUNT
   query:
     select: (sum(powerdns_authoritative_exceptions_total))
     from: Metric
+


### PR DESCRIPTION
### Relevant information

Ticket: https://new-relic.atlassian.net/browse/NR-212978

Since we’re cancelling the infra DM migration, our curated UI needs to make all the queries using events.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.