### PR TITLE
Remove metric queries from postgresqlinstance golden metrics

### DIFF
--- a/entity-types/infra-postgresqlinstance/golden_metrics.yml
+++ b/entity-types/infra-postgresqlinstance/golden_metrics.yml
@@ -3,11 +3,6 @@ scheduledCheckpoints:
   unit: OPERATIONS_PER_SECOND
   queries:
     newRelic:
-      select: average(postgres.instance.bgwriter.checkpointsScheduledPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(bgwriter.checkpointsScheduledPerSecond)
       from: PostgresqlInstanceSample
       eventId: entityGuid
@@ -17,26 +12,17 @@ requestedCheckpoints:
   unit: OPERATIONS_PER_SECOND
   queries:
     newRelic:
-      select: average(postgres.instance.bgwriter.checkpointsRequestedPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(bgwriter.checkpointsRequestedPerSecond)
       from: PostgresqlInstanceSample
       eventId: entityGuid
       eventName: entityName
 buffersAllocated:
   title: Buffers allocated
-  unit: OPERATIONS_PER_SECOND      
+  unit: OPERATIONS_PER_SECOND
   queries:
     newRelic:
-      select: average(postgres.instance.bgwriter.buffersAllocatedPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(bgwriter.buffersAllocatedPerSecond)
       from: PostgresqlInstanceSample
       eventId: entityGuid
       eventName: entityName
+


### PR DESCRIPTION
### Relevant information

Since we’re cancelling the infra DM migration, our curated UI needs to make all the queries using events.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.