### PR TITLE
Remove metric queries from oracledbinstance golden metrics

### DIFF
--- a/entity-types/infra-oracledbinstance/golden_metrics.yml
+++ b/entity-types/infra-oracledbinstance/golden_metrics.yml
@@ -3,11 +3,6 @@ hostCpuUtilization:
   unit: PERCENTAGE
   queries:
     newRelic:
-      select: average(oracle.database.hostCpuUtilization)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(db.hostCpuUtilization)
       from: OracleDatabaseSample
       eventId: entityGuid
@@ -17,11 +12,6 @@ ioMegabytesPerSecond:
   unit: BYTES_PER_SECOND
   queries:
     newRelic:
-      select: average(oracle.database.network.ioMegabytesPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(network.ioMegabytesPerSecond)
       from: OracleDatabaseSample
       eventId: entityGuid
@@ -31,25 +21,15 @@ sessions:
   unit: COUNT
   queries:
     newRelic:
-      select: latest(oracle.database.sessionCount)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: latest(db.sessionCount)
       from: OracleDatabaseSample
       eventId: entityGuid
       eventName: entityName
 executionsPerSecond:
   title: Executions per second
-  unit: OPERATIONS_PER_SECOND        
+  unit: OPERATIONS_PER_SECOND
   queries:
     newRelic:
-      select: average(oracle.database.executionsPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(db.executionsPerSecond)
       from: OracleDatabaseSample
       eventId: entityGuid
@@ -57,11 +37,6 @@ executionsPerSecond:
 longTableScans:
   queries:
     newRelic:
-      select: average(oracle.database.longTableScansPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(`db.longTableScansPerSecond`)
       from: OracleDatabaseSample
       eventId: entityGuid
@@ -71,14 +46,10 @@ longTableScans:
 softParseRatio:
   queries:
     newRelic:
-      select: average(oracle.database.softParseRatio)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(`db.softParseRatio`)
       from: OracleDatabaseSample
       eventId: entityGuid
       eventName: entityName
   unit: COUNT
   title: Soft parse ratio
+


### PR DESCRIPTION
### Relevant information

Since we’re cancelling the infra DM migration, our curated UI needs to make all the queries using events.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.