### PR TITLE
Remove metric queries from nginxserver golden metrics

### DIFF
--- a/entity-types/infra-nginxserver/golden_metrics.yml
+++ b/entity-types/infra-nginxserver/golden_metrics.yml
@@ -3,25 +3,15 @@ requests:
   unit: OPERATIONS_PER_SECOND
   queries:
     newRelic:
-      select: average(nginx.server.net.requestsPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(net.requestsPerSecond)
       from: NginxSample
       eventId: entityGuid
       eventName: entityName
 activeConnections:
   title: Active connections
-  unit: OPERATIONS_PER_SECOND    
+  unit: OPERATIONS_PER_SECOND
   queries:
     newRelic:
-      select: average(nginx.server.net.connectionsActive)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(net.connectionsActive)
       from: NginxSample
       eventId: entityGuid
@@ -29,11 +19,6 @@ activeConnections:
 connectionsAccepted:
   queries:
     newRelic:
-      select: average(nginx.server.net.connectionsAcceptedPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(net.connectionsAcceptedPerSecond)
       from: NginxSample
       eventId: entityGuid
@@ -43,14 +28,10 @@ connectionsAccepted:
 connectionsDropped:
   queries:
     newRelic:
-      select: average(nginx.server.net.connectionsDroppedPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(net.connectionsDroppedPerSecond)
       from: NginxSample
       eventId: entityGuid
       eventName: entityName
   unit: OPERATIONS_PER_SECOND
   title: Connections dropped
+


### PR DESCRIPTION
### Relevant information

Since we’re cancelling the infra DM migration, our curated UI needs to make all the queries using events.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.