### PR TITLE
Remove metric queries from mysqlnode golden metrics

### DIFF
--- a/entity-types/infra-mysqlnode/golden_metrics.yml
+++ b/entity-types/infra-mysqlnode/golden_metrics.yml
@@ -3,11 +3,6 @@ queriesPerSecond:
   unit: OPERATIONS_PER_SECOND
   queries:
     newRelic:
-      select: average(mysql.node.query.queriesPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(query.queriesPerSecond)
       from: MysqlSample
       eventId: entityGuid
@@ -17,11 +12,6 @@ slowQueriesPerMinute:
   unit: REQUESTS_PER_MINUTE
   queries:
     newRelic:
-      select: average(mysql.node.query.slowQueriesPerSecond) * 60
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(query.slowQueriesPerSecond) * 60
       from: MysqlSample
       eventId: entityGuid
@@ -31,11 +21,6 @@ connectionsPerSecond:
   unit: COUNT
   queries:
     newRelic:
-      select: average(mysql.node.net.connectionsPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(net.connectionsPerSecond)
       from: MysqlSample
       eventId: entityGuid
@@ -43,11 +28,6 @@ connectionsPerSecond:
 queriesQuestions:
   queries:
     newRelic:
-      select: average(mysql.node.query.questionsPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       eventId: entityGuid
       select: average(`query.questionsPerSecond`)
       from: MysqlSample
@@ -57,13 +37,10 @@ queriesQuestions:
 threads:
   queries:
     newRelic:
-      from: Metric
-      eventId: entity.guid
-      select: latest(`mysql.node.net.threadsConnected`)
-    newRelicSample:
       eventId: entityGuid
       eventName: entityName
       select: latest(`net.threadsConnected`)
       from: MysqlSample
   unit: COUNT
   title: Threads connected
+


### PR DESCRIPTION
### Relevant information

Since we’re cancelling the infra DM migration, our curated UI needs to make all the queries using events.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.