### PR TITLE
Remove metric queries from mssqlinstance golden metrics

### DIFF
--- a/entity-types/infra-mssqlinstance/golden_metrics.yml
+++ b/entity-types/infra-mssqlinstance/golden_metrics.yml
@@ -3,11 +3,6 @@ connections:
   unit: COUNT
   queries:
     newRelic:
-      select: average(mssql.instance.stats.connections)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(stats.connections)
       from: MssqlInstanceSample
       eventId: entityGuid
@@ -17,11 +12,6 @@ blockedProcesses:
   unit: COUNT
   queries:
     newRelic:
-      select: max(mssql.instance.instance.blockedProcessesCount)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: max(instance.blockedProcessesCount)
       from: MssqlInstanceSample
       eventId: entityGuid
@@ -31,11 +21,6 @@ waitTimeMs:
   unit: MS
   queries:
     newRelic:
-      select: average(mssql.instance.system.waitTimeInMillisecondsPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(system.waitTimeInMillisecondsPerSecond)
       from: MssqlInstanceSample
       eventId: entityGuid
@@ -43,11 +28,6 @@ waitTimeMs:
 availability:
   queries:
     newRelic:
-      select: average(mssql.instance.activeConnections)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(activeConnections)
       from: MssqlInstanceSample
       eventId: entityGuid
@@ -57,11 +37,6 @@ availability:
 monitorStatus:
   queries:
     newRelic:
-      select: average(mssql.instance.instance.transactionsPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(`instance.transactionsPerSecond`)
       from: MssqlInstanceSample
       eventId: entityGuid
@@ -71,14 +46,10 @@ monitorStatus:
 sessionStatus:
   queries:
     newRelic:
-      select: average(mssql.instance.stats.sqlCompilations)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(`stats.sqlCompilations`)
       from: MssqlInstanceSample
       eventId: entityGuid
       eventName: entityName
   unit: COUNT
   title: SQL (re-)compilations
+


### PR DESCRIPTION
### Relevant information

Since we’re cancelling the infra DM migration, our curated UI needs to make all the queries using events.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.