### PR TITLE
Remove metric queries from mongodb_instance golden metrics

### DIFF
--- a/entity-types/infra-mongodb_instance/golden_metrics.yml
+++ b/entity-types/infra-mongodb_instance/golden_metrics.yml
@@ -3,23 +3,21 @@ database_count:
   unit: COUNT
   query:
     select: uniqueCount(database) AS 'Databases'
-
 connections_count:
   title: Connections
   unit: COUNT
   query:
     select: average(mongodb_ss_connections) AS 'Connections'
     where: conn_type='active'
-
 query_operations_count:
   title: Query operations
   unit: COUNT
   query:
     select: average(mongodb_ss_opcounters) AS 'Query operations'
     where: legacy_op_type='query'
-
 document_operations_count:
   title: Document operations
   unit: COUNT
   query:
     select: latest(mongodb_ss_metrics_document) AS 'Document operations'
+


### PR DESCRIPTION
### Relevant information

Ticket: https://new-relic.atlassian.net/browse/NR-212978

Since we’re cancelling the infra DM migration, our curated UI needs to make all the queries using events.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.