### PR TITLE
Remove metric queries from kubernetes_statefulset golden metrics

### DIFF
--- a/entity-types/infra-kubernetes_statefulset/golden_metrics.yml
+++ b/entity-types/infra-kubernetes_statefulset/golden_metrics.yml
@@ -3,11 +3,6 @@ podsDesired:
   unit: COUNT
   queries:
     newRelic:
-      select: latest(k8s.statefulset.podsDesired)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: latest(podsDesired)
       from: K8sStatefulsetSample
       eventId: entityGuid
@@ -17,26 +12,17 @@ podsReady:
   unit: COUNT
   queries:
     newRelic:
-      select: latest(k8s.statefulset.podsReady)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: latest(podsReady)
       from: K8sStatefulsetSample
       eventId: entityGuid
       eventName: entityName
 podsMissing:
   title: Pods missing over time
-  unit: COUNT      
+  unit: COUNT
   queries:
     newRelic:
-      select: latest(k8s.statefulset.podsMissing)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: latest(podsMissing)
       from: K8sStatefulsetSample
       eventId: entityGuid
       eventName: entityName
+


### PR DESCRIPTION
### Relevant information

Since we’re cancelling the infra DM migration, our curated UI needs to make all the queries using events.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.