### PR TITLE
Remove metric queries from kubernetes_persistentvolumeclaim golden me…

### DIFF
--- a/entity-types/infra-kubernetes_persistentvolumeclaim/golden_metrics.yml
+++ b/entity-types/infra-kubernetes_persistentvolumeclaim/golden_metrics.yml
@@ -3,11 +3,6 @@ createdAt:
   unit: TIMESTAMP
   queries:
     newRelic:
-      select: latest(k8s.persistentvolumeclaim.createdAt) * 1000
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: latest(createdAt) * 1000
       from: K8sPersistentVolumeClaimSample
       eventId: entityGuid
@@ -17,12 +12,8 @@ requestedStorageBytes:
   unit: BYTES
   queries:
     newRelic:
-      select: latest(k8s.persistentvolumeclaim.requestedStorageBytes)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: latest(requestedStorageBytes)
       from: K8sPersistentVolumeClaimSample
       eventId: entityGuid
       eventName: entityName
+


### PR DESCRIPTION
### Relevant information

Since we’re cancelling the infra DM migration, our curated UI needs to make all the queries using events.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.