### PR TITLE
Remove metric queries from kubernetes_persistentvolume golden metrics

### DIFF
--- a/entity-types/infra-kubernetes_persistentvolume/golden_metrics.yml
+++ b/entity-types/infra-kubernetes_persistentvolume/golden_metrics.yml
@@ -3,11 +3,6 @@ createdAt:
   unit: TIMESTAMP
   queries:
     newRelic:
-      select: latest(k8s.persistentvolume.createdAt) * 1000
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: latest(createdAt) * 1000
       from: K8sPersistentVolumeSample
       eventId: entityGuid
@@ -17,12 +12,8 @@ requestedStorageBytes:
   unit: BYTES
   queries:
     newRelic:
-      select: latest(k8s.persistentvolume.capacityBytes)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: latest(capacityBytes)
       from: K8sPersistentVolumeSample
       eventId: entityGuid
       eventName: entityName
+


### PR DESCRIPTION
### Relevant information

Since we’re cancelling the infra DM migration, our curated UI needs to make all the queries using events.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.