### PR TITLE
Remove metric queries from kubernetes_job golden metrics

### DIFF
--- a/entity-types/infra-kubernetes_job/golden_metrics.yml
+++ b/entity-types/infra-kubernetes_job/golden_metrics.yml
@@ -3,11 +3,6 @@ completedAt:
   unit: TIMESTAMP
   queries:
     newRelic:
-      select: latest(k8s.job.completedAt) * 1000
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: latest(completedAt) * 1000
       from: K8sJobSample
       eventId: entityGuid
@@ -17,11 +12,6 @@ podsSucceeded:
   unit: COUNT
   queries:
     newRelic:
-      select: latest(k8s.job.succeededPods)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: latest(succeededPods)
       from: K8sJobSample
       eventId: entityGuid
@@ -31,11 +21,6 @@ podsActive:
   unit: COUNT
   queries:
     newRelic:
-      select: latest(k8s.job.activePods)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: latest(activePods)
       from: K8sJobSample
       eventId: entityGuid
@@ -45,12 +30,8 @@ podsFailed:
   unit: COUNT
   queries:
     newRelic:
-      select: latest(k8s.job.failedPods)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: latest(failedPods)
       from: K8sJobSample
       eventId: entityGuid
       eventName: entityName
+


### PR DESCRIPTION
### Relevant information

Since we’re cancelling the infra DM migration, our curated UI needs to make all the queries using events.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.