### PR TITLE
Remove metric queries from kubernetes_deployment golden metrics

### DIFF
--- a/entity-types/infra-kubernetes_deployment/golden_metrics.yml
+++ b/entity-types/infra-kubernetes_deployment/golden_metrics.yml
@@ -3,40 +3,26 @@ podsDesired:
   unit: COUNT
   queries:
     newRelic:
-      select: latest(k8s.deployment.podsDesired)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: latest(podsDesired)
       from: K8sDeploymentSample
       eventId: entityGuid
       eventName: entityName
 podsAvailable:
   title: Pods ready over time
-  unit: COUNT 
+  unit: COUNT
   queries:
     newRelic:
-      select: latest(k8s.deployment.podsAvailable)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: latest(podsAvailable)
       from: K8sDeploymentSample
       eventId: entityGuid
       eventName: entityName
 podsMissing:
   title: Pods missing over time
-  unit: COUNT   
+  unit: COUNT
   queries:
     newRelic:
-      select: latest(k8s.deployment.podsMissing)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: latest(podsMissing)
       from: K8sDeploymentSample
       eventId: entityGuid
       eventName: entityName
+


### PR DESCRIPTION
### Relevant information

Since we’re cancelling the infra DM migration, our curated UI needs to make all the queries using events.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.