### PR TITLE
Remove metric queries from kubernetes_daemonset golden metrics

### DIFF
--- a/entity-types/infra-kubernetes_daemonset/golden_metrics.yml
+++ b/entity-types/infra-kubernetes_daemonset/golden_metrics.yml
@@ -3,11 +3,6 @@ podsDesired:
   unit: COUNT
   queries:
     newRelic:
-      select: latest(k8s.daemonset.podsDesired)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: latest(podsDesired)
       from: K8sDaemonsetSample
       eventId: entityGuid
@@ -17,26 +12,17 @@ podsReady:
   unit: COUNT
   queries:
     newRelic:
-      select: latest(k8s.daemonset.podsReady)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: latest(podsReady)
       from: K8sDaemonsetSample
       eventId: entityGuid
       eventName: entityName
 podsMissing:
   title: Pods missing over time
-  unit: COUNT    
+  unit: COUNT
   queries:
     newRelic:
-      select: latest(k8s.daemonset.podsMissing)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: latest(podsMissing)
       from: K8sDaemonsetSample
       eventId: entityGuid
       eventName: entityName
+


### PR DESCRIPTION
### Relevant information

Ticket: https://new-relic.atlassian.net/browse/NR-212978

Since we’re cancelling the infra DM migration, our curated UI needs to make all the queries using events.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.