### PR TITLE
Remove metric queries from kubernetes_cronjob golden metrics

### DIFF
--- a/entity-types/infra-kubernetes_cronjob/golden_metrics.yml
+++ b/entity-types/infra-kubernetes_cronjob/golden_metrics.yml
@@ -3,11 +3,6 @@ isSuspended:
   unit: COUNT
   queries:
     newRelic:
-      select: latest(k8s.cronjob.isSuspended)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: latest(isSuspended)
       from: K8sCronjobSample
       eventId: entityGuid
@@ -17,11 +12,6 @@ isActive:
   unit: COUNT
   queries:
     newRelic:
-      select: latest(k8s.cronjob.isActive)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: latest(isActive)
       from: K8sCronjobSample
       eventId: entityGuid
@@ -31,12 +21,8 @@ lastScheduled:
   unit: TIMESTAMP
   queries:
     newRelic:
-      select: latest(k8s.cronjob.lastScheduledTime) * 1000
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: latest(lastScheduledTime) * 1000
       from: K8sCronjobSample
       eventId: entityGuid
       eventName: entityName
+


### PR DESCRIPTION
### Relevant information

Since we’re cancelling the infra DM migration, our curated UI needs to make all the queries using events.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.