### PR TITLE
Remove metric queries from kubernetes_apiserver golden metrics

### DIFF
--- a/entity-types/infra-kubernetes_apiserver/golden_metrics.yml
+++ b/entity-types/infra-kubernetes_apiserver/golden_metrics.yml
@@ -5,6 +5,7 @@ apiserverAuditEventTotal:
     select: sum(apiserver_audit_event_total)
 apiserverRequestCount:
   title: Number of apiserver requests
-  unit: COUNT  
+  unit: COUNT
   query:
     select: sum(apiserver_request_count)
+


### PR DESCRIPTION
### Relevant information

Ticket: https://new-relic.atlassian.net/browse/NR-212978

Since we’re cancelling the infra DM migration, our curated UI needs to make all the queries using events.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.