### PR TITLE
Remove metric queries from kafkabroker golden metrics

### DIFF
--- a/entity-types/infra-kafkabroker/golden_metrics.yml
+++ b/entity-types/infra-kafkabroker/golden_metrics.yml
@@ -3,11 +3,6 @@ incomingMessagesPerSecond:
   unit: OPERATIONS_PER_SECOND
   queries:
     newRelic:
-      select: average(kafka.broker.messagesInPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(broker.messagesInPerSecond)
       from: KafkaBrokerSample
       eventId: entityGuid
@@ -17,25 +12,15 @@ produceRequestDuration99PercentileS:
   unit: OPERATIONS_PER_SECOND
   queries:
     newRelic:
-      select: average(kafka.broker.request.produceTime99Percentile)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(request.produceTime99Percentile)
       from: KafkaBrokerSample
       eventId: entityGuid
       eventName: entityName
 failedProduceRequestsPerSecond:
   title: Failed produce requests per second
-  unit: OPERATIONS_PER_SECOND      
+  unit: OPERATIONS_PER_SECOND
   queries:
     newRelic:
-      select: average(kafka.broker.request.produceRequestsFailedPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(request.produceRequestsFailedPerSecond)
       from: KafkaBrokerSample
       eventId: entityGuid
@@ -43,11 +28,6 @@ failedProduceRequestsPerSecond:
 bytesWritten:
   queries:
     newRelic:
-      select: average(kafka.broker.bytesWrittenToTopicPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(`broker.bytesWrittenToTopicPerSecond`)
       from: KafkaBrokerSample
       eventId: entityGuid
@@ -57,14 +37,10 @@ bytesWritten:
 leaderElectionRate:
   queries:
     newRelic:
-      select: average(kafka.replication.leaderElectionPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(`replication.leaderElectionPerSecond`)
       from: KafkaBrokerSample
       eventId: entityGuid
       eventName: entityName
   unit: OPERATIONS_PER_SECOND
   title: Leader election rate
+


### PR DESCRIPTION
### Relevant information

Since we’re cancelling the infra DM migration, our curated UI needs to make all the queries using events.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.