### PR TITLE
Remove metric queries from ibmmq_queue golden metrics

### DIFF
--- a/entity-types/infra-ibmmq_queue/golden_metrics.yml
+++ b/entity-types/infra-ibmmq_queue/golden_metrics.yml
@@ -3,27 +3,24 @@ depth_count:
   unit: COUNT
   query:
     select: average(ibmmq_queue_depth) AS 'Depth'
-
 queue_get_messages:
   title: Get messages
   unit: COUNT
   query:
     select: average(ibmmq_queue_mqget_count) AS 'Get messages'
-
 queue_put_messages:
   title: Put messages
   unit: COUNT
   query:
     select: average(ibmmq_queue_mqput_mqput1_count) AS 'Put messages'
-
 queue_uncommitted_messages:
   title: Uncommitted messages
   unit: COUNT
   query:
     select: average(ibmmq_queue_uncommitted_messages) AS 'Uncommitted messages'
-
 queue_expired_messages:
   title: Expired messages
   unit: COUNT
   query:
     select: average(ibmmq_queue_expired_messages) AS 'Expired messages'
+


### PR DESCRIPTION
### Relevant information

Ticket: https://new-relic.atlassian.net/browse/NR-212978

Since we’re cancelling the infra DM migration, our curated UI needs to make all the queries using events.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.