### PR TITLE
Remove metric queries from ibmmq_manager golden metrics

### DIFF
--- a/entity-types/infra-ibmmq_manager/golden_metrics.yml
+++ b/entity-types/infra-ibmmq_manager/golden_metrics.yml
@@ -3,21 +3,20 @@ connections_count:
   unit: COUNT
   query:
     select: average(ibmmq_qmgr_connection_count) AS 'Connections'
-
 put_messages_count:
   title: Put messages
   unit: COUNT
   query:
     select: average(ibmmq_qmgr_interval_mqput_mqput1_total_count) AS 'Put messages'
-
 get_messages_count:
   title: Get messages
   unit: COUNT
   query:
     select: average(ibmmq_qmgr_interval_destructive_get_total_count) AS 'Get messages'
-
 published_messages_count:
   title: Published messages
   unit: COUNT
   query:
-    select: average(ibmmq_qmgr_published_to_subscribers_message_count) AS 'Published messages'
+    select: average(ibmmq_qmgr_published_to_subscribers_message_count) AS 'Published
+      messages'
+


### PR DESCRIPTION
### Relevant information

Ticket: https://new-relic.atlassian.net/browse/NR-212978

Since we’re cancelling the infra DM migration, our curated UI needs to make all the queries using events.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.