### PR TITLE
Remove metric queries from f5virtualserver golden metrics

### DIFF
--- a/entity-types/infra-f5virtualserver/golden_metrics.yml
+++ b/entity-types/infra-f5virtualserver/golden_metrics.yml
@@ -3,11 +3,6 @@ requestsPerSecond:
   unit: OPERATIONS_PER_SECOND
   queries:
     newRelic:
-      select: average(f5.virtualserver.requestsPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(virtualserver.requestsPerSecond)
       from: F5BigIpVirtualServerSample
       eventId: entityGuid
@@ -17,11 +12,6 @@ connections:
   unit: COUNT
   queries:
     newRelic:
-      select: latest(f5.virtualserver.connections)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: latest(virtualserver.connections)
       from: F5BigIpVirtualServerSample
       eventId: entityGuid
@@ -31,11 +21,6 @@ bytesPerSecondIn:
   unit: BYTES
   queries:
     newRelic:
-      select: average(f5.virtualserver.inDataInBytesPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(virtualserver.inDataInBytesPerSecond)
       from: F5BigIpVirtualServerSample
       eventId: entityGuid
@@ -45,11 +30,6 @@ bytesPerSecondOut:
   unit: BYTES
   queries:
     newRelic:
-      select: average(f5.virtualserver.outDataInBytesPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(virtualserver.outDataInBytesPerSecond)
       from: F5BigIpVirtualServerSample
       eventId: entityGuid
@@ -59,11 +39,6 @@ availability:
   unit: COUNT
   queries:
     newRelic:
-      select: average(f5.virtualserver.avaibilityState)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(virtualserver.avaibilityState)
       from: F5BigIpVirtualServerSample
       eventId: entityGuid
@@ -73,11 +48,6 @@ connectionsClientside:
   title: Connections through client side
   queries:
     newRelic:
-      select: average(f5.virtualserver.clientsideConnectionsPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(virtualserver.clientsideConnectionsPerSecond)
       from: F5BigIpVirtualServerSample
       eventId: entityGuid
@@ -87,12 +57,8 @@ usageRatio:
   title: Usage ratio
   queries:
     newRelic:
-      select: average(f5.virtualserver.usageRatio)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(virtualserver.usageRatio)
       from: F5BigIpVirtualServerSample
       eventId: entityGuid
       eventName: entityName
+


### PR DESCRIPTION
### Relevant information

Since we’re cancelling the infra DM migration, our curated UI needs to make all the queries using events.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.