### PR TITLE
Remove metric queries from f5system golden metrics

### DIFF
--- a/entity-types/infra-f5system/golden_metrics.yml
+++ b/entity-types/infra-f5system/golden_metrics.yml
@@ -19,3 +19,4 @@ memoryUsed:
     from: F5BigIpSystemSample
   unit: BYTES
   title: Total memory use
+


### PR DESCRIPTION
### Relevant information

Ticket: https://new-relic.atlassian.net/browse/NR-212978

Since we’re cancelling the infra DM migration, our curated UI needs to make all the queries using events.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.