### PR TITLE
Remove metric queries from f5poolmember golden metrics

### DIFF
--- a/entity-types/infra-f5poolmember/golden_metrics.yml
+++ b/entity-types/infra-f5poolmember/golden_metrics.yml
@@ -3,11 +3,6 @@ connections:
   unit: COUNT
   queries:
     newRelic:
-      select: average(f5.poolMember.connections)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(member.connections)
       from: F5BigIpPoolMemberSample
       eventId: entityGuid
@@ -17,11 +12,6 @@ sessions:
   unit: COUNT
   queries:
     newRelic:
-      select: average(f5.poolMember.sessions)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(member.sessions)
       from: F5BigIpPoolMemberSample
       eventId: entityGuid
@@ -31,11 +21,6 @@ packetsReceivedPerSecond:
   unit: OPERATIONS_PER_SECOND
   queries:
     newRelic:
-      select: average(f5.poolMember.packetsReceivedPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(member.packetsReceivedPerSecond)
       from: F5BigIpPoolMemberSample
       eventId: entityGuid
@@ -45,11 +30,6 @@ packetsSentPerSecond:
   unit: OPERATIONS_PER_SECOND
   queries:
     newRelic:
-      select: average(f5.poolMember.packetsSentPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(member.packetsSentPerSecond)
       from: F5BigIpPoolMemberSample
       eventId: entityGuid
@@ -59,11 +39,6 @@ availability:
   unit: COUNT
   queries:
     newRelic:
-      select: average(f5.node.availabilityState)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(node.availabilityState)
       from: F5BigIpPoolMemberSample
       eventId: entityGuid
@@ -73,11 +48,6 @@ monitorStatus:
   unit: COUNT
   queries:
     newRelic:
-      select: average(f5.node.monitorStatus)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(node.monitorStatus)
       from: F5BigIpPoolMemberSample
       eventId: entityGuid
@@ -87,12 +57,8 @@ sessionStatus:
   unit: COUNT
   queries:
     newRelic:
-      select: average(f5.node.sessionStatus)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(node.sessionStatus)
       from: F5BigIpPoolMemberSample
       eventId: entityGuid
       eventName: entityName
+


### PR DESCRIPTION
### Relevant information

Ticket: https://new-relic.atlassian.net/browse/NR-212978

Since we’re cancelling the infra DM migration, our curated UI needs to make all the queries using events.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.