### PR TITLE
Remove metric queries from f5pool golden metrics

### DIFF
--- a/entity-types/infra-f5pool/golden_metrics.yml
+++ b/entity-types/infra-f5pool/golden_metrics.yml
@@ -3,25 +3,15 @@ requestsPerSecond:
   unit: REQUESTS_PER_SECOND
   queries:
     newRelic:
-      select: average(f5.pool.requestsPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(pool.requestsPerSecond)
       from: F5BigIpPoolSample
       eventId: entityGuid
       eventName: entityName
 connections:
   title: Connections
-  unit: COUNT 
+  unit: COUNT
   queries:
     newRelic:
-      select: average(f5.pool.connections)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(pool.connections)
       from: F5BigIpPoolSample
       eventId: entityGuid
@@ -31,11 +21,6 @@ packetsReceivedPerSecond:
   unit: OPERATIONS_PER_SECOND
   queries:
     newRelic:
-      select: average(f5.pool.packetsReceivedPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(pool.packetsReceivedPerSecond)
       from: F5BigIpPoolSample
       eventId: entityGuid
@@ -45,11 +30,6 @@ packetsSentPerSecond:
   unit: OPERATIONS_PER_SECOND
   queries:
     newRelic:
-      select: average(f5.pool.packetsSentPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(pool.packetsSentPerSecond)
       from: F5BigIpPoolSample
       eventId: entityGuid
@@ -59,11 +39,6 @@ poolActiveMembers:
   title: Pool active members
   queries:
     newRelic:
-      select: average(f5.pool.activeMembers)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(pool.activeMembers)
       from: F5BigIpPoolSample
       eventId: entityGuid
@@ -73,11 +48,6 @@ availability:
   unit: COUNT
   queries:
     newRelic:
-      select: average(f5.pool.availabilityState)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(pool.availabilityState)
       from: F5BigIpPoolSample
       eventId: entityGuid
@@ -87,12 +57,8 @@ poolConnections:
   title: Pool connections
   queries:
     newRelic:
-      select: average(f5.pool.connections)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(pool.connections)
       from: F5BigIpPoolSample
       eventId: entityGuid
       eventName: entityName
+


### PR DESCRIPTION
### Relevant information

Since we’re cancelling the infra DM migration, our curated UI needs to make all the queries using events.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.