### PR TITLE
Remove metric queries from mongodb_collection golden metrics

### DIFF
--- a/entity-types/infra-mongodb_collection/golden_metrics.yml
+++ b/entity-types/infra-mongodb_collection/golden_metrics.yml
@@ -3,15 +3,14 @@ objects_count:
   unit: COUNT
   query:
     select: rate(sum(mongodb_collstats_storageStats_count),1 minute ) AS 'Objects'
-
 indexes_count:
   title: Indexes
   unit: COUNT
   query:
     select: latest(mongodb_collstats_storageStats_nindexes) AS 'Indexes'
-
 storage_size:
   title: Storage size
   unit: BYTES
   query:
     select: latest(mongodb_collstats_storageStats_totalSize) AS 'Storage size'
+


### PR DESCRIPTION
### Relevant information

Ticket: https://new-relic.atlassian.net/browse/NR-212978

Since we’re cancelling the infra DM migration, our curated UI needs to make all the queries using events.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.