### PR TITLE
Remove metric queries from memcachedinstance golden metrics

### DIFF
--- a/entity-types/infra-memcachedinstance/golden_metrics.yml
+++ b/entity-types/infra-memcachedinstance/golden_metrics.yml
@@ -3,11 +3,6 @@ uptime:
   unit: SECONDS
   queries:
     newRelic:
-      select: (average(memcached.server.uptimeInMilliseconds)) / 1000
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: (average(`uptimeInMilliseconds`)) / 1000
       from: MemcachedSample
       eventId: entityGuid
@@ -17,11 +12,6 @@ connections:
   unit: REQUESTS_PER_SECOND
   queries:
     newRelic:
-      select: average(memcached.server.connectionRateServerPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(`connectionRateServerPerSecond`)
       from: MemcachedSample
       eventId: entityGuid
@@ -31,11 +21,6 @@ evictions:
   unit: OPERATIONS_PER_SECOND
   queries:
     newRelic:
-      select: average(memcached.server.evictionsPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       eventId: entityGuid
       from: MemcachedSample
       select: average(`evictionsPerSecond`)
@@ -45,12 +30,8 @@ hits:
   unit: OPERATIONS_PER_SECOND
   queries:
     newRelic:
-      select: average(memcached.server.getHitPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(`getHitPerSecond`)
       eventId: entityGuid
       from: MemcachedSample
       eventName: entityName
+


### PR DESCRIPTION
### Relevant information

Since we’re cancelling the infra DM migration, our curated UI needs to make all the queries using events.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.