### PR TITLE
Remove metric queries from f5node golden metrics

### DIFF
--- a/entity-types/infra-f5node/golden_metrics.yml
+++ b/entity-types/infra-f5node/golden_metrics.yml
@@ -3,11 +3,6 @@ availability:
   unit: COUNT
   queries:
     newRelic:
-      select: average(f5.node.availabilityState)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(`node.availabilityState`)
       from: F5BigIpNodeSample
       eventId: entityGuid
@@ -17,11 +12,6 @@ monitorStatus:
   unit: COUNT
   queries:
     newRelic:
-      select: average(f5.node.monitorStatus)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(`node.monitorStatus`)
       from: F5BigIpNodeSample
       eventId: entityGuid
@@ -31,12 +21,8 @@ sessionStatus:
   unit: COUNT
   queries:
     newRelic:
-      select: average(f5.node.sessionStatus)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(`node.sessionStatus`)
       from: F5BigIpNodeSample
       eventId: entityGuid
       eventName: ENTITY_GUIDS
+


### PR DESCRIPTION
### Relevant information

Since we’re cancelling the infra DM migration, our curated UI needs to make all the queries using events.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.