### PR TITLE
Remove metric queries from elasticsearchnode golden metrics

### DIFF
--- a/entity-types/infra-elasticsearchnode/golden_metrics.yml
+++ b/entity-types/infra-elasticsearchnode/golden_metrics.yml
@@ -3,11 +3,6 @@ activeSearches:
   unit: COUNT
   queries:
     newRelic:
-      select: sum(elasticsearch.node.activeSearches)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: sum(activeSearches)
       from: ElasticsearchNodeSample
       eventId: entityGuid
@@ -17,11 +12,6 @@ missingDocumentRequests:
   unit: COUNT
   queries:
     newRelic:
-      select: sum(elasticsearch.node.get.requestsDocumentMissing)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: sum(get.requestsDocumentMissing)
       from: ElasticsearchNodeSample
       eventId: entityGuid
@@ -31,11 +21,6 @@ fileStoreIOOperations:
   unit: COUNT
   queries:
     newRelic:
-      select: sum(elasticsearch.node.fs.ioOperations)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: sum(fs.iOOperations)
       from: ElasticsearchNodeSample
       eventId: entityGuid
@@ -43,10 +28,6 @@ fileStoreIOOperations:
 activeMerges:
   queries:
     newRelic:
-      eventId: entity.guid
-      select: average(`elasticsearch.node.merges.currentActive`)
-      from: Metric
-    newRelicSample:
       eventId: entityGuid
       eventName: entityName
       from: ElasticsearchNodeSample
@@ -58,11 +39,8 @@ totalQueries:
   unit: COUNT
   queries:
     newRelic:
-      from: Metric
-      select: average(`elasticsearch.node.queriesTotal`)
-      eventId: entity.guid
-    newRelicSample:
       eventId: entityGuid
       eventName: entityName
       select: average(`queriesTotal`)
       from: ElasticsearchNodeSample
+


### PR DESCRIPTION
### Relevant information

Since we’re cancelling the infra DM migration, our curated UI needs to make all the queries using events.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.