### PR TITLE
Remove metric queries from cassandranode golden metrics

### DIFF
--- a/entity-types/infra-cassandranode/golden_metrics.yml
+++ b/entity-types/infra-cassandranode/golden_metrics.yml
@@ -3,11 +3,6 @@ readRequestsPerSecond:
   unit: OPERATIONS_PER_SECOND
   queries:
     newRelic:
-      select: average(cassandra.node.query.readRequestsPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(query.readRequestsPerSecond)
       from: CassandraSample
       eventId: entityGuid
@@ -17,11 +12,6 @@ writeRequestsPerSecond:
   unit: OPERATIONS_PER_SECOND
   queries:
     newRelic:
-      select: average(cassandra.node.query.writeRequestsPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(query.writeRequestsPerSecond)
       from: CassandraSample
       eventId: entityGuid
@@ -31,11 +21,6 @@ readLatency99Percentile:
   unit: SECONDS
   queries:
     newRelic:
-      select: average(cassandra.node.query.readLatency99ThPercentileMilliseconds)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(query.readLatency99thPercentileMilliseconds)
       from: CassandraSample
       eventId: entityGuid
@@ -43,11 +28,6 @@ readLatency99Percentile:
 hits:
   queries:
     newRelic:
-      select: average(cassandra.node.query.keyCacheHitRate)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(`db.keyCacheHitRate`)
       from: CassandraSample
       eventId: entityGuid
@@ -57,11 +37,6 @@ hits:
 loadBytes:
   queries:
     newRelic:
-      select: average(cassandra.node.query.loadBytes)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(`db.loadBytes`)
       from: CassandraSample
       eventId: entityGuid
@@ -71,14 +46,10 @@ loadBytes:
 activePooltasks:
   queries:
     newRelic:
-      select: average(cassandra.node.query.threadpool.poolActiveTasks)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(`db.threadpool.poolActiveTasks`)
       from: CassandraSample
       eventId: entityGuid
       eventName: entityName
   unit: COUNT
   title: Active tasks
+


### PR DESCRIPTION
### Relevant information

Since we’re cancelling the infra DM migration, our curated UI needs to make all the queries using events.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.