### PR TITLE
Remove metric queries from apacheserver golden metrics

### DIFF
--- a/entity-types/infra-apacheserver/golden_metrics.yml
+++ b/entity-types/infra-apacheserver/golden_metrics.yml
@@ -3,11 +3,6 @@ requestsPerSecond:
   unit: REQUESTS_PER_SECOND
   queries:
     newRelic:
-      select: average(apache.server.net.requestsPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(net.requestsPerSecond)
       from: ApacheSample
       eventId: entityGuid
@@ -17,11 +12,6 @@ totalBytesSentPerSecond:
   unit: BYTES_PER_SECOND
   queries:
     newRelic:
-      select: average(apache.server.net.bytesPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(net.bytesPerSecond)
       from: ApacheSample
       eventId: entityGuid
@@ -31,11 +21,6 @@ busyWorkers:
   unit: COUNT
   queries:
     newRelic:
-      select: average(apache.server.busyWorkers)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(server.busyWorkers)
       from: ApacheSample
       eventId: entityGuid
@@ -45,12 +30,8 @@ idleWorkers:
   unit: COUNT
   queries:
     newRelic:
-      select: average(apache.server.idleWorkers)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(server.idleWorkers)
       from: ApacheSample
       eventId: entityGuid
       eventName: entityName
+


### PR DESCRIPTION
### Relevant information

Since we’re cancelling the infra DM migration, our curated UI needs to make all the queries using events.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.