### PR TITLE
Entity relationship synthesis with the `New Relic eBPF agent`

### DIFF
--- a/entity-types/ebpf-client/definition.yml
+++ b/entity-types/ebpf-client/definition.yml
@@ -1,0 +1,16 @@
+domain: EBPF
+type: CLIENT
+synthesis:
+  rules:
+    # Client Entity for Client-Captured Spans (kind == client)
+    - name: local_addr
+      identifier: local_addr
+      encodeIdentifierInGUID: true
+      conditions:
+      - attribute: instrumentation.provider
+        value: nr_ebpf_agent
+      - attribute: kind
+        value: "client"
+      tags:
+        local_addr:
+          entityTagName: "ip"

--- a/entity-types/ebpf-client/tests/Span.json
+++ b/entity-types/ebpf-client/tests/Span.json
@@ -1,0 +1,11 @@
+[
+  {
+    "redis.req_cmd": "HMGET",
+    "instrumentation.provider": "nr_ebpf_agent",
+    "kind": "client",
+    "local_addr": "192.xxx.x.xx",
+    "local_port": "92" ,
+    "remote_addr": "198.xxx.x.xx",
+    "remote_port": "98"
+  }
+]

--- a/entity-types/ebpf-redis_server/definition.yml
+++ b/entity-types/ebpf-redis_server/definition.yml
@@ -1,0 +1,24 @@
+domain: EBPF
+type: REDIS_SERVER
+synthesis:
+  rules:
+  # Server Entity for Server-Captured Spans (kind == server)
+  - compositeIdentifier:
+        separator: ":"
+        attributes:
+          - local_addr
+          - local_port
+    name: local_addr
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: redis.req_cmd
+      present: true
+    - attribute: instrumentation.provider
+      value: "nr_ebpf_agent"
+    - attribute: kind
+      value: "server"
+    tags:
+      local_addr:
+        entityTagName: "ip"
+      local_port:
+        entityTagName: "port"

--- a/entity-types/ebpf-redis_server/tests/Span.json
+++ b/entity-types/ebpf-redis_server/tests/Span.json
@@ -1,0 +1,11 @@
+[
+  {
+    "redis.req_cmd": "HMGET",
+    "instrumentation.provider": "nr_ebpf_agent",
+    "kind": "server",
+    "local_addr": "198.xxx.x.xx",
+    "local_port": "98",
+    "remote_addr": "192.xxx.x.xx",
+    "remote_port": "92" 
+  }
+]

--- a/relationships/candidates/EBPFCLIENT.yml
+++ b/relationships/candidates/EBPFCLIENT.yml
@@ -1,0 +1,16 @@
+category: EBPFCLIENT
+lookups:
+  - entityTypes:
+    - domain: EBPF
+      type: CLIENT
+    tags:
+      matchingMode: ANY
+      predicates:
+        - tagKeys: ["ip"]
+          field: ip
+    onMatch:
+     onMultipleMatches: RELATE_ALL
+    onMiss:
+      action: CREATE_UNINSTRUMENTED
+      uninstrumented:
+        type: EBPFCLIENT

--- a/relationships/candidates/EBPFSERVER.yml
+++ b/relationships/candidates/EBPFSERVER.yml
@@ -1,0 +1,18 @@
+category: EBPFSERVER
+lookups:
+  - entityTypes:
+    - domain: EBPF
+      type: REDIS_SERVER
+    tags:
+      matchingMode: ALL
+      predicates:
+        - tagKeys: ["ip"]
+          field: ip
+        - tagKeys: ["port"]
+          field: port
+    onMatch:
+     onMultipleMatches: RELATE_ALL
+    onMiss:
+      action: CREATE_UNINSTRUMENTED
+      uninstrumented:
+        type: EBPFSERVER

--- a/relationships/synthesis/EBPF-CLIENT-to-EBPF_REDIS.yml
+++ b/relationships/synthesis/EBPF-CLIENT-to-EBPF_REDIS.yml
@@ -1,0 +1,52 @@
+relationships:
+  - name: clientCallsRedisServerFromServerSpan
+    version: "1"
+    origins:
+      - Distributed Tracing
+    conditions:
+      - attribute: eventType
+        anyOf: [ "Span" ]
+      - attribute: entity.type
+        anyOf: [ "REDIS_SERVER" ]
+      - attribute: kind
+        value: "server"
+    relationship:
+      expires: P75M
+      relationshipType: CALLS
+      source:
+        lookupGuid:
+          candidateCategory: EBPFCLIENT
+          fields:
+            - field: ip
+              attribute: remote_addr # clientIP from server's perspective
+      target:
+        extractGuid:
+          attribute: entity.guid
+
+  - name: clientCallsRedisServerFromClientSpan
+    version: "1"
+    origins:
+      - Distributed Tracing
+    conditions:
+      - attribute: eventType
+        anyOf: [ "Span" ]
+      - attribute: entity.type
+        anyOf: [ "EBPF_CLIENT" ]
+      - attribute: kind
+        value: "client"
+      - attribute: redis.req_cmd
+        present: true
+    relationship:
+      expires: P75M
+      relationshipType: CALLS
+      source:
+        extractGuid:
+          attribute: entity.guid
+      target:
+        lookupGuid:
+          candidateCategory: EBPFSERVER
+          fields:
+            - field: ip
+              attribute: remote_addr # serverIP from client's perspective
+            - field: port
+              attribute: remote_port # serverPort from client's perspective


### PR DESCRIPTION
### Relevant information

This PR provides initial prototype entity definitions for the eBPF agent.

Main ideas:
1. Construct guid from self information, e.g. the “local” IP addr., port, and pid.
2. Enable relationship synthesis from tags that include local IP addr. and port, i.e. because those columns will be available as “remote IP addr. & port”

Note that in the agent, one span represents both a request and response. Currently, *we cannot create two entities from a single span with NR synthesis rules*. We can, however, trace a span from the client’s perspective and from the server’s point of view, as long as the ebpf agent is deployed on all hosts. Thus for entity and relationship synthesis, we can connect these two spans, one client-side and one server-side. If one side of the connection is missing, we create an uninstrumented entity for it. Ideally, we'd want to create both entities from one span, but we cannot have two rules that match the same thing with current NR entity synthesis rules. 

### In the current prototype, we create a `server` entity from the server-captured span, and a `client` entity from the client-captured span.

# Cases:
## 1. Both client and server-side spans present

<img width="807" alt="image" src="https://github.com/newrelic/entity-definitions/assets/47846691/b9fff1b4-306b-404d-a4d6-9648e93e852c">

```mermaid
%%{init: {'mirrorActors': true, 'height':38, 'width': 35}}%%
flowchart TD
    C[Server-side Span] -->|Definition rule| D(Server entity)
    A[Client-side Span] -->|Definition rule| B(Client entity)
    D -->|remoteIP = clientIP| E[Relationship Synthesis]
    B <--> |lookup via ClientIP| E
```

```mermaid

```

Note that the direction of the connection is arbitrary, we could flip it and see the same result.

<img width="804" alt="image" src="https://github.com/newrelic/entity-definitions/assets/47846691/4ba8fd03-746d-45ce-9f1e-7e4627018252">

Likewise, if the client and server are on the same host, the ebpf agent will still provide two spans.

<img width="805" alt="image" src="https://github.com/newrelic/entity-definitions/assets/47846691/e9351ecc-d81e-4a9b-aa9e-4967c0db7c46">

## 2. Span missing on the client-side

If we fail to capture a client-side span because, for instance, there is no ebpf agent deployed on that host, then we create a server entity from the server-side span, and an uninstrumented entity for the client.

<img width="802" alt="image" src="https://github.com/newrelic/entity-definitions/assets/47846691/21519747-ed4c-42a9-bef1-d4b85a1049e8">

```mermaid
%%{init: {'mirrorActors': true, 'height':38, 'width': 35}}%%
flowchart TD
    C[Server-side Span] -->|Definition rule| D(Server entity)
    D -->|remoteIP = clientIP| E[Relationship Synthesis]
    B[Uninstrumented client entity] <--> |lookup via ClientIP| E
```

## 3. Span missing on the server-side

If the server-side span is missing, then we create a client entity from the client-side span, and an uninstrumented entity for the server.

<img width="806" alt="image" src="https://github.com/newrelic/entity-definitions/assets/47846691/2f4fc6e1-a4cf-420b-8443-ded782259594">

```mermaid
%%{init: {'mirrorActors': true, 'height':38, 'width': 35}}%%
flowchart TD
    C[Client-side Span] -->|Definition rule| D(Client entity)
    D -->|remoteIP = serverIP, remotePort = serverPort| E[Relationship Synthesis]
    B[Uninstrumented server entity] <--> |lookup via serverIP, serverPort| E
```

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
