### PR TITLE
Remove metric queries from host golden metrics

### DIFF
--- a/entity-types/infra-host/golden_metrics.yml
+++ b/entity-types/infra-host/golden_metrics.yml
@@ -3,11 +3,6 @@ cpuUsage:
   unit: PERCENTAGE
   queries:
     newRelic:
-      select: average(host.cpuPercent)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(cpuPercent)
       from: SystemSample
       eventId: entityGuid
@@ -55,11 +50,6 @@ memoryUsage:
   unit: PERCENTAGE
   queries:
     newRelic:
-      select: average(host.memoryUsedPercent)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(memoryUsedPercent)
       from: SystemSample
       eventId: entityGuid
@@ -80,11 +70,6 @@ storageUsage:
   unit: PERCENTAGE
   queries:
     newRelic:
-      select: average(host.disk.usedPercent)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(diskUsedPercent)
       from: StorageSample
       eventId: entityGuid
@@ -107,11 +92,6 @@ networkTrafficTx:
   unit: BYTES_PER_SECOND
   queries:
     newRelic:
-      select: average(host.net.transmitBytesPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(transmitBytesPerSecond)
       from: NetworkSample
       eventId: entityGuid
@@ -160,11 +140,6 @@ networkTrafficRx:
   unit: BYTES_PER_SECOND
   queries:
     newRelic:
-      select: average(host.net.receiveBytesPerSecond)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    newRelicSample:
       select: average(receiveBytesPerSecond)
       from: NetworkSample
       eventId: entityGuid


### PR DESCRIPTION
### Relevant information

Since we’re cancelling the infra DM migration, our curated UI needs to make all the queries using events.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
