### PR TITLE
feat: K8s pod synthesis from ksm->otel

### DIFF
--- a/entity-types/infra-kubernetes_pod/definition.yml
+++ b/entity-types/infra-kubernetes_pod/definition.yml
@@ -10,3 +10,38 @@ goldenTags:
 - k8s.nodeName
 - k8s.createdBy
 - k8s.createdKind
+synthesis:
+  rules:
+  # kube-state-metrics data via opentelemetry prometheusReceiver 
+  - compositeIdentifier:
+      separator: ":"
+      attributes:
+        - k8s.cluster.name
+        - namespace
+        - pod
+    encodeIdentifierInGUID: true
+    name: pod
+    conditions:
+      # kube-state-metrics pod prefix
+      - attribute: metricName
+        prefix: kube_pod_
+      # exclude kube_pod_container_*
+      - attribute: container
+        present: false
+      # identifier attributes
+      - attribute: pod
+        present: true
+      - attribute: namespace
+        present: true
+      - attribute: k8s.cluster.name
+        present: true
+      # open telemetry
+      - attribute: newrelic.source
+        value: 'api.metrics.otlp'
+      # if service.name is present, handle as one
+      - attribute: service.name
+        present: false
+      # value added for test entities only
+      - attribute: newrelicOnly
+        value: "true"
+


### PR DESCRIPTION
### Relevant information

Adds synthesis of K8s Pods from kube-state-metrics received via OTel endpoint.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
