### PR TITLE
feat: K8s daemonset synthesis from ksm->otel

### DIFF
--- a/entity-types/infra-kubernetes_daemonset/definition.yml
+++ b/entity-types/infra-kubernetes_daemonset/definition.yml
@@ -7,3 +7,34 @@ goldenTags:
 - k8s.daemonsetName
 - k8s.clusterName
 - k8s.namespaceName
+synthesis:
+  rules:
+    # kube-state-metrics data via opentelemetry prometheusReceiver 
+    - compositeIdentifier:
+        separator: ":"
+        attributes:
+          - k8s.cluster.name
+          - namespace
+          - daemonset
+      encodeIdentifierInGUID: true
+      name: daemonset
+      conditions:
+        # kube-state-metrics daemonset prefix
+        - attribute: metricName
+          prefix: kube_daemonset_
+        # identifier attributes
+        - attribute: daemonset
+          present: true
+        - attribute: namespace
+          present: true
+        - attribute: k8s.cluster.name
+          present: true
+        # open telemetry
+        - attribute: newrelic.source
+          value: 'api.metrics.otlp'
+        # if service.name is present, it's a service
+        - attribute: service.name
+          present: false
+        # value added for test entities only
+        - attribute: newrelicOnly
+          value: "true"


### PR DESCRIPTION
### Relevant information

Adds synthesis of K8s Containers from kube-state-metrics received via OTel endpoint.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
