### PR TITLE
infra-host: add host.id tag

### DIFF
--- a/entity-types/infra-host/definition.yml
+++ b/entity-types/infra-host/definition.yml
@@ -44,6 +44,7 @@ synthesis:
         cloud.region:
         cloud.availability_zone:
         cloud.platform:
+        host.id:
         host.name:
         host.type:
         host.arch:
@@ -74,6 +75,7 @@ synthesis:
         cloud.region:
         cloud.availability_zone:
         cloud.platform:
+        host.id:
         host.name:
         host.type:
         host.arch:
@@ -102,6 +104,7 @@ synthesis:
         cloud.region:
         cloud.availability_zone:
         cloud.platform:
+        host.id:
         host.name:
         host.type:
         host.arch:
@@ -117,6 +120,7 @@ synthesis:
         - attribute: SAP_ETYPE
           value: HOST
       tags:
+        host.id:
         host.name:
         instrumentation.provider:
 


### PR DESCRIPTION
### Relevant information

The PR is adding the host.id tag, that is the unique identifier of the HOST needed for creating relationships when the otel-collector is deployed in a Cloud VM (ie. EC2)



### Checklist

* [X] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
