### PR TITLE
feat: K8s job synthesis from ksm->otel

### DIFF
--- a/entity-types/infra-kubernetes_job/definition.yml
+++ b/entity-types/infra-kubernetes_job/definition.yml
@@ -11,3 +11,34 @@ goldenTags:
 - k8s.jobName
 - k8s.clusterName
 - k8s.namespaceName
+synthesis:
+  rules:
+    # kube-state-metrics data via opentelemetry prometheusReceiver 
+    - compositeIdentifier:
+        separator: ":"
+        attributes:
+          - k8s.cluster.name
+          - namespace
+          - job_name
+      encodeIdentifierInGUID: true
+      name: job_name
+      conditions:
+        # kube-state-metrics job prefix
+        - attribute: metricName
+          prefix: kube_job_
+        # identifier attributes
+        - attribute: job_name
+          present: true
+        - attribute: namespace
+          present: true
+        - attribute: k8s.cluster.name
+          present: true
+        # open telemetry
+        - attribute: newrelic.source
+          value: 'api.metrics.otlp'
+        # if service.name is present, it's a service
+        - attribute: service.name
+          present: false
+        # value added for test entities only
+        - attribute: newrelicOnly
+          value: "true"


### PR DESCRIPTION
### Relevant information
Adds synthesis of K8s Jobs from kube-state-metrics received via OTel endpoint.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
