### PR TITLE
feat: K8s job-pod relation from ksm->otel

### DIFF
--- a/relationships/synthesis/INFRA-KUBERNETES_JOB-to-INFRA-KUBERNETES_POD.yml
+++ b/relationships/synthesis/INFRA-KUBERNETES_JOB-to-INFRA-KUBERNETES_POD.yml
@@ -34,3 +34,41 @@ relationships:
           attribute: entityGuid
           entityType:
             value: KUBERNETES_POD
+  - name: otelKsmK8sJobContainsPod
+    # use kube-state-metrics kube_pod_owner metric
+    version: "1"
+    origins: 
+      - OpenTelemetry
+    conditions:
+      - attribute: eventType
+        value: Metric
+      - attribute: metricName
+        value: kube_pod_owner
+      - attribute: owner_kind
+        value: Job
+      - attribute: newrelicOnly
+        value: "true"
+    relationship:
+      expires: P75M
+      relationshipType: CONTAINS
+      source:
+        buildGuid:
+          account:
+            lookup: yes  
+          domain:
+            value: INFRA
+          type:
+            value: KUBERNETES_JOB
+          identifier:
+            fragments:
+              - attribute: k8s.cluster.name
+              - value: ":"
+              - attribute: namespace
+              - value: ":"
+              - attribute: owner_name
+            hashAlgorithm: FARM_HASH
+      target:
+        extractGuid:
+          attribute: entityGuid
+          entityType:
+            value: KUBERNETES_POD


### PR DESCRIPTION
### Relevant information
Adds synthesis of K8s Job-Pod relationship from kube-state-metrics received via OTel endpoint.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
