### PR TITLE
feat: Add renaming for golden tags in OS K8s entities

### DIFF
--- a/entity-types/infra-kubernetes_cronjob/definition.yml
+++ b/entity-types/infra-kubernetes_cronjob/definition.yml
@@ -42,3 +42,10 @@ synthesis:
         # value added for test entities only
         - attribute: newrelicOnly
           value: "true"
+      tags:
+        cronjob:
+          entityTagNames: [k8s.cronjobName]
+        namespace:
+          entityTagNames: [k8s.namespaceName]
+        k8s.cluster.name:
+          entityTagNames: [k8s.clusterName]

--- a/entity-types/infra-kubernetes_daemonset/definition.yml
+++ b/entity-types/infra-kubernetes_daemonset/definition.yml
@@ -38,3 +38,10 @@ synthesis:
         # value added for test entities only
         - attribute: newrelicOnly
           value: "true"
+      tags:
+        daemonset:
+          entityTagNames: [k8s.daemonsetName]
+        namespace:
+          entityTagNames: [k8s.namespaceName]
+        k8s.cluster.name:
+          entityTagNames: [k8s.clusterName]

--- a/entity-types/infra-kubernetes_deployment/definition.yml
+++ b/entity-types/infra-kubernetes_deployment/definition.yml
@@ -38,4 +38,10 @@ synthesis:
         # value added for test entities only
         - attribute: newrelicOnly
           value: "true"
-
+      tags:
+        deployment:
+          entityTagNames: [k8s.deploymentName]
+        namespace:
+          entityTagNames: [k8s.namespaceName]
+        k8s.cluster.name:
+          entityTagNames: [k8s.clusterName]

--- a/entity-types/infra-kubernetes_job/definition.yml
+++ b/entity-types/infra-kubernetes_job/definition.yml
@@ -42,3 +42,10 @@ synthesis:
         # value added for test entities only
         - attribute: newrelicOnly
           value: "true"
+      tags:
+        job_name:
+          entityTagNames: [k8s.jobName]
+        namespace:
+          entityTagNames: [k8s.namespaceName]
+        k8s.cluster.name:
+          entityTagNames: [k8s.clusterName]

--- a/entity-types/infra-kubernetes_persistentvolume/definition.yml
+++ b/entity-types/infra-kubernetes_persistentvolume/definition.yml
@@ -41,3 +41,8 @@ synthesis:
         # value added for test entities only
         - attribute: newrelicOnly
           value: "true"
+      tags:
+        persistentvolume:
+          entityTagNames: [k8s.volumeName]
+        k8s.cluster.name:
+          entityTagNames: [k8s.clusterName]

--- a/entity-types/infra-kubernetes_persistentvolumeclaim/definition.yml
+++ b/entity-types/infra-kubernetes_persistentvolumeclaim/definition.yml
@@ -42,3 +42,10 @@ synthesis:
         # value added for test entities only
         - attribute: newrelicOnly
           value: "true"
+      tags:
+        persistentvolumeclaim:
+          entityTagNames: [k8s.pvcName]
+        namespace:
+          entityTagNames: [k8s.pvcNamespace]
+        k8s.cluster.name:
+          entityTagNames: [k8s.clusterName]

--- a/entity-types/infra-kubernetes_statefulset/definition.yml
+++ b/entity-types/infra-kubernetes_statefulset/definition.yml
@@ -38,3 +38,10 @@ synthesis:
         # value added for test entities only
         - attribute: newrelicOnly
           value: "true"
+      tags:
+        statefulset:
+          entityTagNames: [k8s.statefulsetName]
+        namespace:
+          entityTagNames: [k8s.namespaceName]
+        k8s.cluster.name:
+          entityTagNames: [k8s.clusterName]


### PR DESCRIPTION
### Relevant information
A tag remapping for golden tag on OS instrumented K8s workloads, persistentvolume, pvc.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
