### PR TITLE
feat: K8s cluster-statefulset relation from ksm->otel

### DIFF
--- a/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_STATEFULSET.yml
+++ b/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_STATEFULSET.yml
@@ -28,3 +28,35 @@ relationships:
           attribute: entityGuid
           entityType:
             value: KUBERNETES_STATEFULSET
+  - name: otelKsmK8sClusterContainsStatefulSet
+    # use kube-state-metrics kube_statefulset_created metrics
+    version: "1"
+    origins: 
+      - OpenTelemetry
+    conditions:
+      - attribute: eventType
+        value: Metric
+      - attribute: metricName
+        value: kube_statefulset_created     
+      - attribute: newrelicOnly
+        value: "true"
+    relationship:
+      expires: P75M
+      relationshipType: CONTAINS
+      source:
+        buildGuid:
+          account:
+            lookup: yes  
+          domain:
+            value: INFRA
+          type:
+            value: KUBERNETESCLUSTER
+          identifier:
+            fragments:
+              - attribute: k8s.cluster.name            
+            hashAlgorithm: FARM_HASH
+      target:  
+        extractGuid:
+          attribute: entityGuid
+          entityType:
+            value: KUBERNETES_STATEFULSET


### PR DESCRIPTION
### Relevant information
Adds synthesis of K8s Cluster-Statefulset relationship from kube-state-metrics received via OTel endpoint.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
