### PR TITLE
feat: K8s cluster-pvc relation from ksm->otel

### DIFF
--- a/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_PERSISTENTVOLUMECLAIM.yml
+++ b/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_PERSISTENTVOLUMECLAIM.yml
@@ -28,3 +28,35 @@ relationships:
           attribute: entityGuid
           entityType:
             value: KUBERNETES_PERSISTENTVOLUMECLAIM
+  - name: otelKsmK8sClusterContainsPersistentVolumeClaim
+    # use kube-state-metrics kube_persistentvolumeclaim_created metric
+    version: "1"
+    origins: 
+      - OpenTelemetry
+    conditions:
+      - attribute: eventType
+        value: Metric
+      - attribute: metricName
+        value: kube_persistentvolumeclaim_created     
+      - attribute: newrelicOnly
+        value: "true"
+    relationship:
+      expires: P75M
+      relationshipType: CONTAINS
+      source:
+        buildGuid:
+          account:
+            lookup: yes  
+          domain:
+            value: INFRA
+          type:
+            value: KUBERNETESCLUSTER
+          identifier:
+            fragments:
+              - attribute: k8s.cluster.name            
+            hashAlgorithm: FARM_HASH
+      target:  
+        extractGuid:
+          attribute: entityGuid
+          entityType:
+            value: KUBERNETES_PERSISTENTVOLUMECLAIM


### PR DESCRIPTION
### Relevant information
Adds synthesis of K8s Cluster-PeristentVolumeClaim relationship from kube-state-metrics received via OTel endpoint.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
