### PR TITLE
feat: Golden metrics for OS k8s cronjob

### DIFF
--- a/entity-types/infra-kubernetes_cronjob/golden_metrics.yml
+++ b/entity-types/infra-kubernetes_cronjob/golden_metrics.yml
@@ -7,6 +7,12 @@ isSuspended:
       from: K8sCronjobSample
       eventId: entityGuid
       eventName: entityName
+    opentelemetry:
+      select: latest(kube_cronjob_spec_suspend = 1)
+      where: metricName = 'kube_cronjob_spec_suspend'
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
 isActive:
   title: Active
   unit: COUNT
@@ -16,6 +22,12 @@ isActive:
       from: K8sCronjobSample
       eventId: entityGuid
       eventName: entityName
+    opentelemetry:
+      select: latest(kube_cronjob_status_active > 0)
+      where: metricName = 'kube_cronjob_status_active'
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
 lastScheduled:
   title: Last Scheduled
   unit: TIMESTAMP
@@ -25,4 +37,10 @@ lastScheduled:
       from: K8sCronjobSample
       eventId: entityGuid
       eventName: entityName
+    opentelemetry:
+      select: latest(kube_cronjob_status_last_schedule_time) * 1000
+      where: metricName = 'kube_cronjob_status_last_schedule_time'
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
 


### PR DESCRIPTION
### Relevant information
Add Kubernetes cronjob golden metric queries for kube-state-metrics -> OpenTelemetry

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
