### PR TITLE
feat: Golden metrics for OS k8s daemonset

### DIFF
--- a/entity-types/infra-kubernetes_daemonset/golden_metrics.yml
+++ b/entity-types/infra-kubernetes_daemonset/golden_metrics.yml
@@ -7,6 +7,12 @@ podsDesired:
       from: K8sDaemonsetSample
       eventId: entityGuid
       eventName: entityName
+    opentelemetry:
+      select: latest(kube_daemonset_status_desired_number_scheduled)
+      where: metricName = 'kube_daemonset_status_desired_number_scheduled'
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
 podsReady:
   title: Pods ready over time
   unit: COUNT
@@ -16,6 +22,12 @@ podsReady:
       from: K8sDaemonsetSample
       eventId: entityGuid
       eventName: entityName
+    opentelemetry:
+      select: latest(kube_daemonset_status_number_ready)
+      where: metricName = 'kube_daemonset_status_number_ready'
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
 podsMissing:
   title: Pods missing over time
   unit: COUNT
@@ -25,4 +37,10 @@ podsMissing:
       from: K8sDaemonsetSample
       eventId: entityGuid
       eventName: entityName
+    opentelemetry:
+      select: latest(kube_daemonset_status_desired_number_scheduled) - latest(kube_daemonset_status_number_ready)
+      where: metricName = 'kube_daemonset_status_number_ready' OR metricName = 'kube_daemonset_status_desired_number_scheduled'
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
 

--- a/entity-types/infra-kubernetes_daemonset/golden_metrics.yml
+++ b/entity-types/infra-kubernetes_daemonset/golden_metrics.yml
@@ -37,10 +37,4 @@ podsMissing:
       from: K8sDaemonsetSample
       eventId: entityGuid
       eventName: entityName
-    opentelemetry:
-      select: latest(kube_daemonset_status_desired_number_scheduled) - latest(kube_daemonset_status_number_ready)
-      where: metricName = 'kube_daemonset_status_number_ready' OR metricName = 'kube_daemonset_status_desired_number_scheduled'
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
 


### PR DESCRIPTION
### Relevant information
Add Kubernetes daemonset golden metric queries for kube-state-metrics -> OpenTelemetry

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
