### PR TITLE
feat: Golden metrics for OS k8s persistentvolume

### DIFF
--- a/entity-types/infra-kubernetes_persistentvolume/golden_metrics.yml
+++ b/entity-types/infra-kubernetes_persistentvolume/golden_metrics.yml
@@ -7,6 +7,12 @@ createdAt:
       from: K8sPersistentVolumeSample
       eventId: entityGuid
       eventName: entityName
+    opentelemetry:
+      select: latest(kube_persistentvolume_created) * 1000
+      where: metricName = 'kube_persistentvolume_created'
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
 requestedStorageBytes:
   title: Capacity
   unit: BYTES
@@ -16,4 +22,9 @@ requestedStorageBytes:
       from: K8sPersistentVolumeSample
       eventId: entityGuid
       eventName: entityName
-
+    opentelemetry:
+      select: latest(kube_persistentvolume_capacity_bytes)
+      where: metricName = 'kube_persistentvolume_capacity_bytes'
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name


### PR DESCRIPTION
### Relevant information
Add Kubernetes persistentvolume golden metric queries for kube-state-metrics -> OpenTelemetry

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
