### PR TITLE
feat: Golden metrics for OS k8s pod

### DIFF
--- a/entity-types/infra-kubernetes_pod/golden_metrics.yml
+++ b/entity-types/infra-kubernetes_pod/golden_metrics.yml
@@ -7,6 +7,12 @@ podReadiness:
       from: K8sPodSample
       eventId: entityGuid
       eventName: entityName
+    opentelemetry:
+      select: latest(phase = 'Ready')
+      where: metricName = 'kube_pod_status_phase'
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
 podScheduled:
   title: Scheduling status over time
   unit: COUNT
@@ -16,6 +22,12 @@ podScheduled:
       from: K8sPodSample
       eventId: entityGuid
       eventName: entityName
+    opentelemetry:
+      select: latest(condition)
+      where: metricName = 'kube_pod_status_scheduled'
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
 networkErrors:
   title: Network errors (per second)
   unit: COUNT


### PR DESCRIPTION
### Relevant information
Add Kubernetes pod golden metric queries for kube-state-metrics -> OpenTelemetry

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
