### PR TITLE
Fix ebpf-client rule

### DIFF
--- a/entity-types/ebpf-client/definition.yml
+++ b/entity-types/ebpf-client/definition.yml
@@ -9,8 +9,8 @@ synthesis:
       conditions:
       - attribute: instrumentation.provider
         value: nr_ebpf_agent
-      - attribute: span.kind
-        value: "2" 
+      - attribute: service.name 
+        value: placeholder_service_name 
       tags:
         local_addr:
           entityTagName: "ip"

--- a/entity-types/ebpf-client/definition.yml
+++ b/entity-types/ebpf-client/definition.yml
@@ -9,8 +9,6 @@ synthesis:
       conditions:
       - attribute: instrumentation.provider
         value: nr_ebpf_agent
-      - attribute: span.kind
-        value: "client"
       tags:
         local_addr:
           entityTagName: "ip"

--- a/entity-types/ebpf-client/definition.yml
+++ b/entity-types/ebpf-client/definition.yml
@@ -9,6 +9,8 @@ synthesis:
       conditions:
       - attribute: instrumentation.provider
         value: nr_ebpf_agent
+      - attribute: protocol.name
+        value: redis
       tags:
         local_addr:
           entityTagName: "ip"

--- a/entity-types/ebpf-client/definition.yml
+++ b/entity-types/ebpf-client/definition.yml
@@ -8,9 +8,9 @@ synthesis:
       encodeIdentifierInGUID: true
       conditions:
       - attribute: instrumentation.provider
-        value: nr_ebpf_agent
-      - attribute: service.name 
-        value: placeholder_service_name 
+        value: "nr_ebpf_agent"
+      - attribute: deployment.name 
+        value: "bkilimnik-nr-ebpf-agent-demo-2024-02-20"
       tags:
         local_addr:
           entityTagName: "ip"

--- a/entity-types/ebpf-client/definition.yml
+++ b/entity-types/ebpf-client/definition.yml
@@ -9,8 +9,8 @@ synthesis:
       conditions:
       - attribute: instrumentation.provider
         value: nr_ebpf_agent
-      - attribute: protocol.name
-        value: redis
+      - attribute: span.kind
+        value: "2" 
       tags:
         local_addr:
           entityTagName: "ip"

--- a/entity-types/ebpf-client/definition.yml
+++ b/entity-types/ebpf-client/definition.yml
@@ -5,7 +5,6 @@ synthesis:
     # Client Entity for Client-Captured Spans (kind == client)
     - name: local_addr
       identifier: local_addr
-      debug: true
       encodeIdentifierInGUID: true
       conditions:
       - attribute: instrumentation.provider

--- a/entity-types/ebpf-client/tests/Span.json
+++ b/entity-types/ebpf-client/tests/Span.json
@@ -1,7 +1,7 @@
 [
   {
     "instrumentation.provider": "nr_ebpf_agent",
-    "span.kind": "2",
+    "service.name": "placeholder_service_name",
     "local_addr": "192.xxx.x.xx",
     "local_port": "92" ,
     "remote_addr": "198.xxx.x.xx",

--- a/entity-types/ebpf-client/tests/Span.json
+++ b/entity-types/ebpf-client/tests/Span.json
@@ -1,7 +1,7 @@
 [
   {
-    "redis.req_cmd": "HMGET",
     "instrumentation.provider": "nr_ebpf_agent",
+    "px.cluster.id": "00000000-0000-0000-0000-000000000000",
     "span.kind": "client",
     "local_addr": "192.xxx.x.xx",
     "local_port": "92" ,

--- a/entity-types/ebpf-client/tests/Span.json
+++ b/entity-types/ebpf-client/tests/Span.json
@@ -1,8 +1,7 @@
 [
   {
     "instrumentation.provider": "nr_ebpf_agent",
-    "px.cluster.id": "00000000-0000-0000-0000-000000000000",
-    "span.kind": "client",
+    "span.kind": "2",
     "local_addr": "192.xxx.x.xx",
     "local_port": "92" ,
     "remote_addr": "198.xxx.x.xx",

--- a/entity-types/ebpf-client/tests/Span.json
+++ b/entity-types/ebpf-client/tests/Span.json
@@ -1,7 +1,7 @@
 [
   {
     "instrumentation.provider": "nr_ebpf_agent",
-    "service.name": "placeholder_service_name",
+    "deployment.name": "bkilimnik-nr-ebpf-agent-demo-2024-02-20",
     "local_addr": "192.xxx.x.xx",
     "local_port": "92" ,
     "remote_addr": "198.xxx.x.xx",


### PR DESCRIPTION
### Relevant information

## What?

Attempt to fix the ebpf-client rule.

## Why?

Telemetry from ebpf agent is not matching the defined rule.

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
