### PR TITLE
Ebpf entity defs: change span.kind to trace_role

### DIFF
--- a/entity-types/ebpf-client/definition.yml
+++ b/entity-types/ebpf-client/definition.yml
@@ -9,7 +9,7 @@ synthesis:
       encodeIdentifierInGUID: true
       conditions:
       - attribute: instrumentation.provider
-        value: nr_ebpf_agent
+        value: "nr_ebpf_agent"
       - attribute: trace_role
         value: "client"
       tags:

--- a/entity-types/ebpf-client/definition.yml
+++ b/entity-types/ebpf-client/definition.yml
@@ -10,7 +10,7 @@ synthesis:
       conditions:
       - attribute: instrumentation.provider
         value: nr_ebpf_agent
-      - attribute: span.kind
+      - attribute: trace_role
         value: "client"
       tags:
         local_addr:

--- a/entity-types/ebpf-client/tests/Span.json
+++ b/entity-types/ebpf-client/tests/Span.json
@@ -2,7 +2,7 @@
   {
     "redis.req_cmd": "HMGET",
     "instrumentation.provider": "nr_ebpf_agent",
-    "span.kind": "client",
+    "trace_role": "client",
     "local_addr": "192.xxx.x.xx",
     "local_port": "92" ,
     "remote_addr": "198.xxx.x.xx",

--- a/entity-types/ebpf-redis_server/definition.yml
+++ b/entity-types/ebpf-redis_server/definition.yml
@@ -15,7 +15,7 @@ synthesis:
       present: true
     - attribute: instrumentation.provider
       value: "nr_ebpf_agent"
-    - attribute: span.kind
+    - attribute: trace_role
       value: "server"
     tags:
       local_addr:

--- a/entity-types/ebpf-redis_server/tests/Span.json
+++ b/entity-types/ebpf-redis_server/tests/Span.json
@@ -2,7 +2,7 @@
   {
     "redis.req_cmd": "HMGET",
     "instrumentation.provider": "nr_ebpf_agent",
-    "span.kind": "server",
+    "trace_role": "server",
     "local_addr": "198.xxx.x.xx",
     "local_port": "98",
     "remote_addr": "192.xxx.x.xx",

--- a/relationships/synthesis/EBPF-CLIENT-to-EBPF_REDIS.yml
+++ b/relationships/synthesis/EBPF-CLIENT-to-EBPF_REDIS.yml
@@ -8,7 +8,7 @@ relationships:
         anyOf: [ "Span" ]
       - attribute: entity.type
         anyOf: [ "REDIS_SERVER" ]
-      - attribute: span.kind
+      - attribute: trace_role
         value: "server"
     relationship:
       expires: P75M
@@ -32,7 +32,7 @@ relationships:
         anyOf: [ "Span" ]
       - attribute: entity.type
         anyOf: [ "EBPF_CLIENT" ]
-      - attribute: span.kind
+      - attribute: trace_role
         value: "client"
       - attribute: redis.req_cmd
         present: true


### PR DESCRIPTION
### Relevant information

Entity synthesis for ebpf data based on the `span.kind` column (which is an [enum](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#spankind) ([sdk docs](https://open-telemetry.github.io/opentelemetry-js/enums/_opentelemetry_otlp_transformer.ESpanKind.html#SPAN_KIND_CLIENT)) is currently not working due to a known issue where the engine doesn’t support numbers (https://new-relic.atlassian.net/browse/NR-164291).

This PR changes the entity defs to use a new column 'trace_role' which is set to the strings "server" and "client". It also adds quotes missing around the value for `instrumentation.provider` in the client definition.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
