### PR TITLE
Don't use entity type in EBPF relationships rule

### DIFF
--- a/relationships/synthesis/EBPF-CLIENT-to-EBPF_REDIS.yml
+++ b/relationships/synthesis/EBPF-CLIENT-to-EBPF_REDIS.yml
@@ -6,8 +6,8 @@ relationships:
     conditions:
       - attribute: eventType
         anyOf: [ "Span" ]
-      - attribute: entity.type
-        anyOf: [ "REDIS_SERVER" ]
+      - attribute: trace_role
+        anyOf: [ "server" ]
       - attribute: instrumentation.provider
         value: "nr_ebpf_agent"
     relationship:
@@ -30,8 +30,8 @@ relationships:
     conditions:
       - attribute: eventType
         anyOf: [ "Span" ]
-      - attribute: entity.type
-        anyOf: [ "CLIENT" ]
+      - attribute: trace_role
+        anyOf: [ "client" ]
       - attribute: redis.req_cmd
         present: true
       - attribute: instrumentation.provider


### PR DESCRIPTION
### Relevant information

Don't use entity type in EBPF relationships rule and use the `trace_role` (as it's done in entity synthesis) instead.

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
