### PR TITLE
fix: replace entity that was deleted

### DIFF
--- a/entity-types/ext-meraki_device/definition.yml
+++ b/entity-types/ext-meraki_device/definition.yml
@@ -1,0 +1,24 @@
+# Meraki devices being polled locally through their SNMP interface.  This method only supports system and if-mib of the individual device
+---
+domain: EXT
+type: MERAKI_DEVICE
+synthesis:
+  name: device_name
+  identifier: device_name
+  encodeIdentifierInGUID: true
+
+  conditions:
+  - attribute: provider
+    value: kentik-meraki
+
+  tags:
+    src_addr:
+      entityTagName: device_ip
+      multiValue: false
+
+goldenTags:
+- device_ip
+
+dashboardTemplates:
+  kentik:
+    template: meraki-device-dashboard.json

--- a/entity-types/ext-meraki_device/golden_metrics.yml
+++ b/entity-types/ext-meraki_device/golden_metrics.yml
@@ -1,0 +1,19 @@
+receiveErrors:
+  title: Aggregate Receive Errors (count)
+  unit: COUNT
+  queries:
+    # All Meraki devices
+    kentik:
+      select: sum(kentik.snmp.ifInErrors)
+      from: Metric
+      where: "provider = 'kentik-meraki'"
+
+transmitErrors:
+  title: Aggregate Transmit Errors (count)
+  unit: COUNT
+  queries:
+    # All Meraki devices
+    kentik:
+      select: sum(kentik.snmp.ifOutErrors)
+      from: Metric
+      where: "provider = 'kentik-meraki'"

--- a/entity-types/ext-meraki_device/meraki-device-dashboard.json
+++ b/entity-types/ext-meraki_device/meraki-device-dashboard.json
@@ -1,0 +1,287 @@
+{
+  "name": "Meraki Device",
+  "description": null,
+  "pages": [
+    {
+      "name": "Meraki Device",
+      "description": null,
+      "widgets": [
+        {
+          "title": "Summary",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "dataFormatters": [
+              {
+                "name": "Uptime (Days)",
+                "precision": 2,
+                "type": "decimal"
+              },
+              {
+                "name": "Last Update",
+                "type": "date"
+              }
+            ],
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT latest(device_name) AS 'Device Name', latest(src_addr) AS 'Device IP', latest(kentik.snmp.Uptime)/8640000 AS 'Uptime (Days)', latest(SysObjectID) AS 'SysObjectID', latest(entity.type) AS 'Entity Type', latest(instrumentation.name) AS 'Ktranslate Profile', latest(timestamp) AS 'Last Update', latest(PollingHealth) AS 'Polling Health', latest(PollingHealthReason) AS 'Health Reason' WHERE instrumentation.name = 'kentik-meraki' "
+              }
+            ],
+            "thresholds": []
+          }
+        },
+        {
+          "title": "",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 8,
+            "height": 1
+          },
+          "visualization": {
+            "id": "viz.markdown"
+          },
+          "rawConfiguration": {
+            "text": "## This Meraki device is being polled locally via SNMP and only exposes a limited subset of information."
+          }
+        },
+        {
+          "title": "System Description",
+          "layout": {
+            "column": 5,
+            "row": 2,
+            "width": 8,
+            "height": 2
+          },
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "dataFormatters": [],
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT latest(SysDescr) as 'Description' where instrumentation.name = 'kentik-meraki'"
+              }
+            ],
+            "thresholds": []
+          }
+        },
+        {
+          "title": "Interfaces Summary",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 12,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.table"
+          },
+          "rawConfiguration": {
+            "dataFormatters": [],
+            "facet": {
+              "showOtherSeries": false
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT latest(kentik.snmp.IfInUtilization) AS 'RX %', latest(kentik.snmp.IfOutUtilization) AS 'TX %', latest(if_OperStatus) AS 'Operational Status', latest(kentik.snmp.ifInErrorPercent) AS 'RX Error %', latest(kentik.snmp.ifOutErrorPercent) AS 'TX Error %' FACET device_name, if_name or if_interface_name AS 'Interface', if_Alias AS 'Interface Alias', if_Speed AS 'Interface Speed' WHERE instrumentation.name = 'kentik-meraki' LIMIT MAX"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Receive Traffic %",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 6,
+            "height": 4
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT average(kentik.snmp.IfInUtilization) as 'RX %' FACET if_name or if_interface_name WHERE provider = 'kentik-firepower' TIMESERIES 5 MINUTES LIMIT 10"
+              }
+            ],
+            "yAxisLeft": {
+              "max": 100,
+              "min": 0,
+              "zero": false
+            }
+          }
+        },
+        {
+          "title": "Transmit Traffic %",
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 7,
+            "row": 7,
+            "width": 6,
+            "height": 4
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT average(kentik.snmp.IfOutUtilization) as 'RX %' FACET if_name or if_interface_name WHERE provider = 'kentik-firepower' TIMESERIES 5 MINUTES LIMIT 10"
+              }
+            ],
+            "yAxisLeft": {
+              "max": 100,
+              "min": 0,
+              "zero": false
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 1,
+            "row": 11,
+            "height": 4,
+            "width": 6
+          },
+          "title": "Receive Traffic Mbps",
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT rate(max(kentik.snmp.ifHCInOctets)*8/1000/1000, 1 second) AS 'Mbps' FACET device_name, if_name or if_interface_name WHERE provider = 'kentik-firepower' TIMESERIES 5 MINUTES LIMIT 10"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 7,
+            "row": 11,
+            "height": 4,
+            "width": 6
+          },
+          "title": "Transmit Traffic Mbps",
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT rate(max(kentik.snmp.ifHCOutOctets)*8/1000/1000, 1 second) AS 'Mbps' FACET device_name, if_name or if_interface_name WHERE provider = 'kentik-firepower' TIMESERIES 5 MINUTES LIMIT 10"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 1,
+            "row": 15,
+            "height": 4,
+            "width": 6
+          },
+          "title": "Receive Error %",
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT max(kentik.snmp.ifInErrorPercent) FACET if_name or if_interface_name WHERE provider = 'kentik-firepower' TIMESERIES 5 MINUTES LIMIT 10"
+              }
+            ],
+            "yAxisLeft": {
+              "max": 100,
+              "min": 0,
+              "zero": false
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 7,
+            "row": 15,
+            "height": 4,
+            "width": 6
+          },
+          "title": "Transmit Error %",
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT max(kentik.snmp.ifOutErrorPercent) FACET if_name or if_interface_name WHERE provider = 'kentik-firepower' TIMESERIES 5 MINUTES LIMIT 10"
+              }
+            ],
+            "yAxisLeft": {
+              "max": 100,
+              "min": 0,
+              "zero": false
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/ext-meraki_device/summary_metrics.yml
+++ b/entity-types/ext-meraki_device/summary_metrics.yml
@@ -1,0 +1,28 @@
+# All Meraki devices
+ipAddress:
+  title: IP Address
+  unit: STRING
+  tag:
+    key: device_ip
+
+receiveErrors:
+  title: Receive Errors
+  unit: COUNT
+  queries:
+    # All Meraki devices
+    kentik:
+      select: sum(kentik.snmp.ifInErrors)
+      from: Metric
+      where: "provider = 'kentik-meraki'"
+      eventId: entity.guid
+
+transmitErrors:
+  title: Transmit Errors
+  unit: COUNT
+  queries:
+    # All Meraki devices
+    kentik:
+      select: sum(kentik.snmp.ifOutErrors)
+      from: Metric
+      where: "provider = 'kentik-meraki'"
+      eventId: entity.guid


### PR DESCRIPTION
### Relevant information

adding back the `EXT-MERAKI_DEVICE` entity type that was accidentally revoked during testing

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
