### PR TITLE
Fix validator for relationship synthesis rules

### DIFF
--- a/docs/relationships/relationship_synthesis.md
+++ b/docs/relationships/relationship_synthesis.md
@@ -371,7 +371,7 @@ source:
   buildGuid:
     account:
       attribute: accountId
-      # or lookup: yes
+      # or lookup: true
     domain:
       value: EXT
     type:

--- a/relationships/synthesis/APM-APPLICATION-to-INFRA-MSSQLINSTANCE.yml
+++ b/relationships/synthesis/APM-APPLICATION-to-INFRA-MSSQLINSTANCE.yml
@@ -16,7 +16,7 @@ relationships:
       target:
         buildGuid:
           account:
-            lookup: yes
+            lookup: true
           domain:
             value: INFRA
           type:

--- a/relationships/synthesis/APM-APPLICATION-to-INFRA-MYSQLNODE.yml
+++ b/relationships/synthesis/APM-APPLICATION-to-INFRA-MYSQLNODE.yml
@@ -16,7 +16,7 @@ relationships:
       target:
         buildGuid:
           account:
-            lookup: yes
+            lookup: true
           domain:
             value: INFRA
           type:

--- a/relationships/synthesis/APM-APPLICATION-to-INFRA-POSTGRESQLINSTANCE.yml
+++ b/relationships/synthesis/APM-APPLICATION-to-INFRA-POSTGRESQLINSTANCE.yml
@@ -16,7 +16,7 @@ relationships:
       target:
         buildGuid:
           account:
-            lookup: yes
+            lookup: true
           domain:
             value: INFRA
           type:

--- a/relationships/synthesis/APM-APPLICATION-to-INFRA-REDISINSTANCE.yml
+++ b/relationships/synthesis/APM-APPLICATION-to-INFRA-REDISINSTANCE.yml
@@ -16,7 +16,7 @@ relationships:
       target:
         buildGuid:
           account:
-            lookup: yes
+            lookup: true
           domain:
             value: INFRA
           type:

--- a/relationships/synthesis/INFRA-AWSECSCLUSTER-to-INFRA-AWSECSSERVICE.yml
+++ b/relationships/synthesis/INFRA-AWSECSCLUSTER-to-INFRA-AWSECSSERVICE.yml
@@ -1,6 +1,6 @@
 relationships:
   - name: awsEcsClusterContainsEcsService
-    version: 1
+    version: "1"
     origins:
       - AWS Integration
     conditions:

--- a/relationships/synthesis/INFRA-AWSELASTICSEARCHCLUSTER-to-INFRA-AWSELASTICSEARCHNODE.yml
+++ b/relationships/synthesis/INFRA-AWSELASTICSEARCHCLUSTER-to-INFRA-AWSELASTICSEARCHNODE.yml
@@ -1,6 +1,6 @@
 relationships:
   - name: awsElasticsearchClusterContainsElasticsearchNode
-    version: 1
+    version: "1"
     origins:
       - AWS Integration
     conditions:

--- a/relationships/synthesis/INFRA-AWSFSXWINDOWSFILESERVER-to-INFRA-AWSFSXVOLUME.yml
+++ b/relationships/synthesis/INFRA-AWSFSXWINDOWSFILESERVER-to-INFRA-AWSFSXVOLUME.yml
@@ -1,6 +1,6 @@
 relationships:
   - name: awsFsxFileServerContainsFsxVolume
-    version: 1
+    version: "1"
     origins:
       - AWS Integration
     conditions:

--- a/relationships/synthesis/INFRA-AWSLAMBDAFUNCTION-to-INFRA-AWSLAMBDAFUNCTIONALIAS.yml
+++ b/relationships/synthesis/INFRA-AWSLAMBDAFUNCTION-to-INFRA-AWSLAMBDAFUNCTIONALIAS.yml
@@ -1,6 +1,6 @@
 relationships:
   - name: awsLambdaFunctionAliasIsLambdaFunction
-    version: 1
+    version: "1"
     origins:
       - AWS Integration
     conditions:

--- a/relationships/synthesis/INFRA-AWSMSKCLUSTER-to-INFRA-AWSMSKBROKER.yml
+++ b/relationships/synthesis/INFRA-AWSMSKCLUSTER-to-INFRA-AWSMSKBROKER.yml
@@ -1,6 +1,6 @@
 relationships:
   - name: awsMskClusterContainsMskBroker
-    version: 1
+    version: "1"
     origins:
       - AWS Integration
     conditions:

--- a/relationships/synthesis/INFRA-AWSRDSDBCLUSTER-to-INFRA-AWSRDSDBINSTANCE.yml
+++ b/relationships/synthesis/INFRA-AWSRDSDBCLUSTER-to-INFRA-AWSRDSDBINSTANCE.yml
@@ -1,6 +1,6 @@
 relationships:
   - name: awsRdsClusterContainsRdsInstance
-    version: 1
+    version: "1"
     origins:
       - AWS Integration
     conditions:

--- a/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-EXT-PIXIE_AMQP.yml
+++ b/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-EXT-PIXIE_AMQP.yml
@@ -14,7 +14,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:

--- a/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-EXT-PIXIE_CASSANDRA.yml
+++ b/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-EXT-PIXIE_CASSANDRA.yml
@@ -14,7 +14,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:

--- a/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-EXT-PIXIE_DNS.yml
+++ b/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-EXT-PIXIE_DNS.yml
@@ -14,7 +14,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:

--- a/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-EXT-PIXIE_KAFKA.yml
+++ b/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-EXT-PIXIE_KAFKA.yml
@@ -14,7 +14,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:

--- a/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-EXT-PIXIE_MYSQL.yml
+++ b/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-EXT-PIXIE_MYSQL.yml
@@ -14,7 +14,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:

--- a/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-EXT-PIXIE_POSTGRES.yml
+++ b/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-EXT-PIXIE_POSTGRES.yml
@@ -14,7 +14,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:

--- a/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-EXT-PIXIE_REDIS.yml
+++ b/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-EXT-PIXIE_REDIS.yml
@@ -14,7 +14,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:

--- a/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-EXT-SERVICE.yml
+++ b/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-EXT-SERVICE.yml
@@ -12,7 +12,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:

--- a/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-HOST.yml
+++ b/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-HOST.yml
@@ -12,7 +12,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:

--- a/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_CRONJOB.yml
+++ b/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_CRONJOB.yml
@@ -12,7 +12,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:
@@ -46,7 +46,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:

--- a/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_DAEMONSET.yml
+++ b/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_DAEMONSET.yml
@@ -12,7 +12,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:
@@ -46,7 +46,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:

--- a/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_DEPLOYMENT.yml
+++ b/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_DEPLOYMENT.yml
@@ -12,7 +12,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:
@@ -46,7 +46,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:

--- a/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_JOB.yml
+++ b/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_JOB.yml
@@ -12,7 +12,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:
@@ -46,7 +46,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:

--- a/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_PERSISTENTVOLUME.yml
+++ b/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_PERSISTENTVOLUME.yml
@@ -12,7 +12,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:
@@ -46,7 +46,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:

--- a/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_PERSISTENTVOLUMECLAIM.yml
+++ b/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_PERSISTENTVOLUMECLAIM.yml
@@ -12,7 +12,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:
@@ -46,7 +46,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:

--- a/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_POD.yml
+++ b/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_POD.yml
@@ -12,7 +12,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:
@@ -46,7 +46,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:

--- a/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_STATEFULSET.yml
+++ b/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_STATEFULSET.yml
@@ -12,7 +12,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:
@@ -46,7 +46,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:

--- a/relationships/synthesis/INFRA-KUBERNETES_CRONJOB-to-INFRA-KUBERNETES_JOB.yml
+++ b/relationships/synthesis/INFRA-KUBERNETES_CRONJOB-to-INFRA-KUBERNETES_JOB.yml
@@ -14,7 +14,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:
@@ -54,7 +54,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:

--- a/relationships/synthesis/INFRA-KUBERNETES_DAEMONSET-to-INFRA-KUBERNETES_POD.yml
+++ b/relationships/synthesis/INFRA-KUBERNETES_DAEMONSET-to-INFRA-KUBERNETES_POD.yml
@@ -14,7 +14,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:
@@ -54,7 +54,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:

--- a/relationships/synthesis/INFRA-KUBERNETES_DEPLOYMENT-to-INFRA-KUBERNETES_POD.yml
+++ b/relationships/synthesis/INFRA-KUBERNETES_DEPLOYMENT-to-INFRA-KUBERNETES_POD.yml
@@ -12,7 +12,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes 
+            lookup: true 
           domain:
             value: INFRA
           type:
@@ -52,7 +52,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes 
+            lookup: true 
           domain:
             value: INFRA
           type:

--- a/relationships/synthesis/INFRA-KUBERNETES_JOB-to-INFRA-KUBERNETES_POD.yml
+++ b/relationships/synthesis/INFRA-KUBERNETES_JOB-to-INFRA-KUBERNETES_POD.yml
@@ -14,7 +14,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:
@@ -54,7 +54,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:

--- a/relationships/synthesis/INFRA-KUBERNETES_PERSISTENTVOLUME-to-INFRA-KUBERNETES_PERSISTENTVOLUMECLAIM.yml
+++ b/relationships/synthesis/INFRA-KUBERNETES_PERSISTENTVOLUME-to-INFRA-KUBERNETES_PERSISTENTVOLUMECLAIM.yml
@@ -14,7 +14,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:
@@ -55,7 +55,7 @@ relationships:
       target:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:

--- a/relationships/synthesis/INFRA-KUBERNETES_POD-to-EXT-PIXIE_AMQP.yml
+++ b/relationships/synthesis/INFRA-KUBERNETES_POD-to-EXT-PIXIE_AMQP.yml
@@ -14,7 +14,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:
@@ -47,7 +47,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:

--- a/relationships/synthesis/INFRA-KUBERNETES_POD-to-EXT-PIXIE_CASSANDRA.yml
+++ b/relationships/synthesis/INFRA-KUBERNETES_POD-to-EXT-PIXIE_CASSANDRA.yml
@@ -14,7 +14,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:
@@ -47,7 +47,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:

--- a/relationships/synthesis/INFRA-KUBERNETES_POD-to-EXT-PIXIE_DNS.yml
+++ b/relationships/synthesis/INFRA-KUBERNETES_POD-to-EXT-PIXIE_DNS.yml
@@ -14,7 +14,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:

--- a/relationships/synthesis/INFRA-KUBERNETES_POD-to-EXT-PIXIE_KAFKA.yml
+++ b/relationships/synthesis/INFRA-KUBERNETES_POD-to-EXT-PIXIE_KAFKA.yml
@@ -14,7 +14,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:
@@ -47,7 +47,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:

--- a/relationships/synthesis/INFRA-KUBERNETES_POD-to-EXT-PIXIE_MYSQL.yml
+++ b/relationships/synthesis/INFRA-KUBERNETES_POD-to-EXT-PIXIE_MYSQL.yml
@@ -14,7 +14,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:
@@ -47,7 +47,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:

--- a/relationships/synthesis/INFRA-KUBERNETES_POD-to-EXT-PIXIE_POSTGRES.yml
+++ b/relationships/synthesis/INFRA-KUBERNETES_POD-to-EXT-PIXIE_POSTGRES.yml
@@ -14,7 +14,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:
@@ -47,7 +47,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:

--- a/relationships/synthesis/INFRA-KUBERNETES_POD-to-EXT-PIXIE_REDIS.yml
+++ b/relationships/synthesis/INFRA-KUBERNETES_POD-to-EXT-PIXIE_REDIS.yml
@@ -14,7 +14,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:
@@ -47,7 +47,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:

--- a/relationships/synthesis/INFRA-KUBERNETES_POD-to-EXT-SERVICE.yml
+++ b/relationships/synthesis/INFRA-KUBERNETES_POD-to-EXT-SERVICE.yml
@@ -12,7 +12,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:

--- a/relationships/synthesis/INFRA-KUBERNETES_POD-to-INFRA-CONTAINER.yml
+++ b/relationships/synthesis/INFRA-KUBERNETES_POD-to-INFRA-CONTAINER.yml
@@ -12,7 +12,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:

--- a/relationships/synthesis/INFRA-KUBERNETES_STATEFULSET-to-INFRA-KUBERNETES_POD.yml
+++ b/relationships/synthesis/INFRA-KUBERNETES_STATEFULSET-to-INFRA-KUBERNETES_POD.yml
@@ -14,7 +14,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:
@@ -54,7 +54,7 @@ relationships:
       source:
         buildGuid:
           account:
-            lookup: yes  
+            lookup: true  
           domain:
             value: INFRA
           type:

--- a/validator/package.json
+++ b/validator/package.json
@@ -8,7 +8,7 @@
     "validate-summary-metrics": "ajv validate --errors=json -s schemas/summary-metrics-schema-v1.json -d '../entity-types/*/summary_metrics.yml' > /dev/null",
     "validate-golden-metrics": "ajv validate --errors=json -s schemas/golden-metrics-schema-v1.json -d '../entity-types/*/golden_metrics.yml' > /dev/null",
     "validate-dashboard": "ajv validate --errors=json -s schemas/dashboard-schema-v1.json -d '../entity-types/*/*dashboard.json' > /dev/null",
-    "validate-relationship-synthesis": "ajv validate --errors=json -s schemas/relationship-synthesis-schema-v1.json -d '../entity-types/synthesis/*.yml' > /dev/null",
+    "validate-relationship-synthesis": "ajv validate --errors=json -s schemas/relationship-synthesis-schema-v1.json -d '../relationships/synthesis/*.yml' > /dev/null",
     "validate-folders": "node tools/validate_folders.js",
     "validate-rules": "node tools/validate_rules.js",
     "validate-relationship-synthesis-rules": "node tools/validate_relationship_synthesis_rules.js",

--- a/validator/schemas/relationship-synthesis-schema-v1.json
+++ b/validator/schemas/relationship-synthesis-schema-v1.json
@@ -448,7 +448,8 @@
         "hashAlgorithm": {
           "type": "string",
           "enum": [
-            "FARM_HASH"
+            "FARM_HASH",
+            "IDENTITY"
           ]
         }
       },


### PR DESCRIPTION
### Relevant information

The validator for relationship synthesis rules was pointing to the wrong directory so rules were not being validated.
I also had to apply other changes to fix the errors after triggering the validator:

- Use the json boolean `true` rather than `yes`, since the validator complained about it because it's based in JSON schema.
- Include `IDENTITY` as a valid `hashAlgorithm` in the schema
- Update rules that were using a int rather than string for `version`

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
