### PR TITLE
fix: OS K8s relations not require eventType Metric

### DIFF
--- a/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_CRONJOB.yml
+++ b/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_CRONJOB.yml
@@ -34,8 +34,6 @@ relationships:
     origins: 
       - OpenTelemetry
     conditions:
-      - attribute: eventType
-        anyOf: [ "Metric" ]
       - attribute: metricName
         anyOf: [ "kube_cronjob_created" ]
       - attribute: newrelicOnly

--- a/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_DAEMONSET.yml
+++ b/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_DAEMONSET.yml
@@ -34,8 +34,6 @@ relationships:
     origins: 
       - OpenTelemetry
     conditions:
-      - attribute: eventType
-        anyOf: [ "Metric" ]
       - attribute: metricName
         anyOf: [ "kube_daemonset_created" ]
       - attribute: newrelicOnly

--- a/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_DEPLOYMENT.yml
+++ b/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_DEPLOYMENT.yml
@@ -34,8 +34,6 @@ relationships:
     origins: 
       - OpenTelemetry
     conditions:
-      - attribute: eventType
-        anyOf: [ "Metric" ]
       - attribute: metricName
         anyOf: [ "kube_deployment_created" ]
       - attribute: newrelicOnly

--- a/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_JOB.yml
+++ b/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_JOB.yml
@@ -34,8 +34,6 @@ relationships:
     origins: 
       - OpenTelemetry
     conditions:
-      - attribute: eventType
-        anyOf: [ "Metric" ]
       - attribute: metricName
         anyOf: [ "kube_job_created" ]
       - attribute: newrelicOnly

--- a/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_PERSISTENTVOLUME.yml
+++ b/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_PERSISTENTVOLUME.yml
@@ -34,8 +34,6 @@ relationships:
     origins: 
       - OpenTelemetry
     conditions:
-      - attribute: eventType
-        anyOf: [ "Metric" ]
       - attribute: metricName
         anyOf: [ "kube_persistentvolume_created" ]
       - attribute: newrelicOnly

--- a/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_PERSISTENTVOLUMECLAIM.yml
+++ b/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_PERSISTENTVOLUMECLAIM.yml
@@ -34,8 +34,6 @@ relationships:
     origins: 
       - OpenTelemetry
     conditions:
-      - attribute: eventType
-        anyOf: [ "Metric" ]
       - attribute: metricName
         anyOf: [ "kube_persistentvolumeclaim_created" ]
       - attribute: newrelicOnly

--- a/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_POD.yml
+++ b/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_POD.yml
@@ -34,8 +34,6 @@ relationships:
     origins: 
       - OpenTelemetry
     conditions:
-      - attribute: eventType
-        anyOf: [ "Metric" ]
       - attribute: metricName
         anyOf: [ "kube_pod_created" ]
       - attribute: newrelicOnly

--- a/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_STATEFULSET.yml
+++ b/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_STATEFULSET.yml
@@ -34,8 +34,6 @@ relationships:
     origins: 
       - OpenTelemetry
     conditions:
-      - attribute: eventType
-        anyOf: [ "Metric" ]
       - attribute: metricName
         anyOf: [ "kube_statefulset_created" ]
       - attribute: newrelicOnly

--- a/relationships/synthesis/INFRA-KUBERNETES_CRONJOB-to-INFRA-KUBERNETES_JOB.yml
+++ b/relationships/synthesis/INFRA-KUBERNETES_CRONJOB-to-INFRA-KUBERNETES_JOB.yml
@@ -40,8 +40,6 @@ relationships:
     origins: 
       - OpenTelemetry
     conditions:
-      - attribute: eventType
-        anyOf: [ "Metric" ]
       - attribute: metricName
         anyOf: [ "kube_job_owner" ]
       - attribute: owner_kind

--- a/relationships/synthesis/INFRA-KUBERNETES_DAEMONSET-to-INFRA-KUBERNETES_POD.yml
+++ b/relationships/synthesis/INFRA-KUBERNETES_DAEMONSET-to-INFRA-KUBERNETES_POD.yml
@@ -40,8 +40,6 @@ relationships:
     origins: 
       - OpenTelemetry
     conditions:
-      - attribute: eventType
-        anyOf: [ "Metric" ]
       - attribute: metricName
         anyOf: [ "kube_pod_owner" ]
       - attribute: owner_kind

--- a/relationships/synthesis/INFRA-KUBERNETES_JOB-to-INFRA-KUBERNETES_POD.yml
+++ b/relationships/synthesis/INFRA-KUBERNETES_JOB-to-INFRA-KUBERNETES_POD.yml
@@ -40,8 +40,6 @@ relationships:
     origins: 
       - OpenTelemetry
     conditions:
-      - attribute: eventType
-        anyOf: [ "Metric" ]
       - attribute: metricName
         anyOf: [ "kube_pod_owner" ]
       - attribute: owner_kind

--- a/relationships/synthesis/INFRA-KUBERNETES_PERSISTENTVOLUME-to-INFRA-KUBERNETES_PERSISTENTVOLUMECLAIM.yml
+++ b/relationships/synthesis/INFRA-KUBERNETES_PERSISTENTVOLUME-to-INFRA-KUBERNETES_PERSISTENTVOLUMECLAIM.yml
@@ -38,8 +38,6 @@ relationships:
     origins: 
       - OpenTelemetry
     conditions:
-      - attribute: eventType
-        anyOf: [ "Metric" ]
       - attribute: metricName
         anyOf: [ "kube_persistentvolume_claim_ref" ]
       - attribute: newrelicOnly

--- a/relationships/synthesis/INFRA-KUBERNETES_STATEFULSET-to-INFRA-KUBERNETES_POD.yml
+++ b/relationships/synthesis/INFRA-KUBERNETES_STATEFULSET-to-INFRA-KUBERNETES_POD.yml
@@ -40,8 +40,6 @@ relationships:
     origins: 
       - OpenTelemetry
     conditions:
-      - attribute: eventType
-        anyOf: [ "Metric" ]
       - attribute: metricName
         anyOf: [ "kube_pod_owner" ]
       - attribute: owner_kind


### PR DESCRIPTION
### Relevant information
OS K8s relationships have had condition that required attribute `eventType` to have value of `Metric`. OTel metrics do not have an `eventType` attribute similar to Event Samples. This removes that condition.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
