### PR TITLE
feat: CpuUtilization, memoryUsage, storageUsage using otel kubeletstats

### DIFF
--- a/entity-types/infra-container/golden_metrics.yml
+++ b/entity-types/infra-container/golden_metrics.yml
@@ -12,6 +12,7 @@ cpuUtilization:
     newRelic:
       select: max(docker.container.cpuPercent) or max(k8s.container.cpuCoresUtilization) AS 'CPU Utilization (%)'
     opentelemetry:
+      # via dockerstatsreceiver & kubeletstatsreceiver – which send equivalent value named container.cpu.utilization
       select: max(container.cpu.utilization) AS 'CPU Utilization (%)'
 memoryUsage:
   title: Memory usage (bytes)
@@ -20,7 +21,8 @@ memoryUsage:
     newRelic:
       select: max(docker.container.memoryUsageBytes) or max(k8s.container.memoryWorkingSetBytes) AS 'Memory used (bytes)'
     opentelemetry:
-      select: max(container.memory.usage.total) AS 'Memory used (bytes)'
+      # via dockerstatsreceiver OR kubeletstatsreceiver respectively
+      select: max(container.memory.usage.total) or max(container.memory.usage) AS 'Memory used (bytes)'
 storageUsage:
   title: Storage usage (bytes)
   unit: BYTES
@@ -28,7 +30,8 @@ storageUsage:
     newRelic:
       select: max(docker.container.ioTotalBytes) or max(k8s.container.fsUsedPercent) AS 'Storage used (bytes)'
     opentelemetry:
-      select: max(container.blockio.io_service_bytes_recursive) AS 'Storage used (bytes)'
+      # via dockerstatsreceiver OR kubeletstatsreceiver respectively
+      select: max(container.blockio.io_service_bytes_recursive) or max(container.filesystem.usage) AS 'Storage used (bytes)'
 networkTrafficTotal:
   title: Network traffic (bytes per second)
   unit: BYTES_PER_SECOND


### PR DESCRIPTION
### Relevant information
Adds support for K8s Infra-Container golden metrics via OpenTelemetry [kubeletstatsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/kubeletstatsreceiver). Uses `or` to support this and related values provided by `dockerstatsreceiver` which are alternatively available outside K8s context.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
