### PR TITLE
fix: OS K8s Relations extract guid use dot syntax unlike for NRI Events

### DIFF
--- a/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_CRONJOB.yml
+++ b/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_CRONJOB.yml
@@ -55,6 +55,6 @@ relationships:
             hashAlgorithm: FARM_HASH
       target:  
         extractGuid:
-          attribute: entityGuid
+          attribute: entity.guid
           entityType:
             value: KUBERNETES_CRONJOB

--- a/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_DAEMONSET.yml
+++ b/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_DAEMONSET.yml
@@ -55,6 +55,6 @@ relationships:
             hashAlgorithm: FARM_HASH
       target:  
         extractGuid:
-          attribute: entityGuid
+          attribute: entity.guid
           entityType:
             value: KUBERNETES_DAEMONSET

--- a/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_DEPLOYMENT.yml
+++ b/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_DEPLOYMENT.yml
@@ -55,6 +55,6 @@ relationships:
             hashAlgorithm: FARM_HASH
       target:  
         extractGuid:
-          attribute: entityGuid
+          attribute: entity.guid
           entityType:
             value: KUBERNETES_DEPLOYMENT

--- a/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_JOB.yml
+++ b/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_JOB.yml
@@ -55,6 +55,6 @@ relationships:
             hashAlgorithm: FARM_HASH
       target:  
         extractGuid:
-          attribute: entityGuid
+          attribute: entity.guid
           entityType:
             value: KUBERNETES_JOB

--- a/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_PERSISTENTVOLUME.yml
+++ b/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_PERSISTENTVOLUME.yml
@@ -55,6 +55,6 @@ relationships:
             hashAlgorithm: FARM_HASH
       target:  
         extractGuid:
-          attribute: entityGuid
+          attribute: entity.guid
           entityType:
             value: KUBERNETES_PERSISTENTVOLUME

--- a/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_PERSISTENTVOLUMECLAIM.yml
+++ b/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_PERSISTENTVOLUMECLAIM.yml
@@ -55,6 +55,6 @@ relationships:
             hashAlgorithm: FARM_HASH
       target:  
         extractGuid:
-          attribute: entityGuid
+          attribute: entity.guid
           entityType:
             value: KUBERNETES_PERSISTENTVOLUMECLAIM

--- a/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_POD.yml
+++ b/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_POD.yml
@@ -55,6 +55,6 @@ relationships:
             hashAlgorithm: FARM_HASH
       target:  
         extractGuid:
-          attribute: entityGuid
+          attribute: entity.guid
           entityType:
             value: KUBERNETES_POD

--- a/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_STATEFULSET.yml
+++ b/relationships/synthesis/INFRA-KUBERNETESCLUSTER-to-INFRA-KUBERNETES_STATEFULSET.yml
@@ -55,6 +55,6 @@ relationships:
             hashAlgorithm: FARM_HASH
       target:  
         extractGuid:
-          attribute: entityGuid
+          attribute: entity.guid
           entityType:
             value: KUBERNETES_STATEFULSET

--- a/relationships/synthesis/INFRA-KUBERNETES_CRONJOB-to-INFRA-KUBERNETES_JOB.yml
+++ b/relationships/synthesis/INFRA-KUBERNETES_CRONJOB-to-INFRA-KUBERNETES_JOB.yml
@@ -67,6 +67,6 @@ relationships:
             hashAlgorithm: FARM_HASH
       target:
         extractGuid:
-          attribute: entityGuid
+          attribute: entity.guid
           entityType:
             value: KUBERNETES_JOB

--- a/relationships/synthesis/INFRA-KUBERNETES_DAEMONSET-to-INFRA-KUBERNETES_POD.yml
+++ b/relationships/synthesis/INFRA-KUBERNETES_DAEMONSET-to-INFRA-KUBERNETES_POD.yml
@@ -67,6 +67,6 @@ relationships:
             hashAlgorithm: FARM_HASH
       target:
         extractGuid:
-          attribute: entityGuid
+          attribute: entity.guid
           entityType:
             value: KUBERNETES_POD

--- a/relationships/synthesis/INFRA-KUBERNETES_DEPLOYMENT-to-INFRA-KUBERNETES_POD.yml
+++ b/relationships/synthesis/INFRA-KUBERNETES_DEPLOYMENT-to-INFRA-KUBERNETES_POD.yml
@@ -65,6 +65,6 @@ relationships:
             hashAlgorithm: FARM_HASH
       target:
         extractGuid:
-          attribute: entityGuid
+          attribute: entity.guid
           entityType:
             value: KUBERNETES_POD

--- a/relationships/synthesis/INFRA-KUBERNETES_JOB-to-INFRA-KUBERNETES_POD.yml
+++ b/relationships/synthesis/INFRA-KUBERNETES_JOB-to-INFRA-KUBERNETES_POD.yml
@@ -67,6 +67,6 @@ relationships:
             hashAlgorithm: FARM_HASH
       target:
         extractGuid:
-          attribute: entityGuid
+          attribute: entity.guid
           entityType:
             value: KUBERNETES_POD

--- a/relationships/synthesis/INFRA-KUBERNETES_PERSISTENTVOLUME-to-INFRA-KUBERNETES_PERSISTENTVOLUMECLAIM.yml
+++ b/relationships/synthesis/INFRA-KUBERNETES_PERSISTENTVOLUME-to-INFRA-KUBERNETES_PERSISTENTVOLUMECLAIM.yml
@@ -47,7 +47,7 @@ relationships:
       relationshipType: CONTAINS
       source:
         extractGuid:
-          attribute: entityGuid
+          attribute: entity.guid
           entityType:
             value: KUBERNETES_PERSISTENTVOLUME
       target:

--- a/relationships/synthesis/INFRA-KUBERNETES_STATEFULSET-to-INFRA-KUBERNETES_POD.yml
+++ b/relationships/synthesis/INFRA-KUBERNETES_STATEFULSET-to-INFRA-KUBERNETES_POD.yml
@@ -67,6 +67,6 @@ relationships:
             hashAlgorithm: FARM_HASH
       target:
         extractGuid:
-          attribute: entityGuid
+          attribute: entity.guid
           entityType:
             value: KUBERNETES_POD


### PR DESCRIPTION
### Relevant information
OS K8s relations used the `extractGuid` method with attribute `entityGuid`. That is the correct attribute name for NRI Event Samples, but for OS K8s entities the correct attribute name is `entity.guid`.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
