### PR TITLE
fix: Use capture to get deployment part of replicaset name when building relation source guid

### DIFF
--- a/relationships/synthesis/INFRA-KUBERNETES_DEPLOYMENT-to-INFRA-KUBERNETES_POD.yml
+++ b/relationships/synthesis/INFRA-KUBERNETES_DEPLOYMENT-to-INFRA-KUBERNETES_POD.yml
@@ -41,7 +41,7 @@ relationships:
       - attribute: metricName
         anyOf: [ "kube_pod_owner" ]
       - attribute: owner_kind
-        anyOf: [ "Deployment" ]
+        anyOf: [ "ReplicaSet" ]
       - attribute: newrelicOnly
         anyOf: [ "true" ]
     relationship:
@@ -61,7 +61,16 @@ relationships:
               - value: ":"
               - attribute: namespace
               - value: ":"
-              - attribute: owner_name
+              # The immediate owner is a ReplicaSet; its name is composed `DeploymentName-hash`
+              # This extracts the name of the Deployment which created the ReplicaSet. 
+              # In fringe scenarios this may fail due to find the correct name due to the 
+              # Deployment name being truncated so the ReplicaSet name isn't too long.
+              # Ideally this would use a join of the data on `kube_replicaset_owner` 
+              # (which has the raw deployment name) with `kube_pod_owner`, but joins aren't 
+              # available in this streaming context.
+              - capture:                
+                attribute: owner_name
+                regex: "^(.*)-(?:[^-]+)$"
             hashAlgorithm: FARM_HASH
       target:
         extractGuid:


### PR DESCRIPTION
### Relevant information
Unlike other K8s workloads (e.g. StatefulSets, DaemonSets) which directly create K8s Pods, K8s Deployments create K8s ReplicaSets which create K8s Pods.

The Deployment<->Pod relationship is therefore not included the in the KSM `kube_pod_owner` metric the same way that it is for other workloads (the owner name is for the ReplicaSet, rather than what we think of as the workload). There is a second metric (`kube_replicaset_owner`) that includes the deployment name. However, we can't join these two metrics in this streaming context. Therefore, this PR takes advantage of the fact that K8s has a defined naming convention where the replicaset is named by appending a hash to the deployment name. For example, if the deployment name was `small-apple-tree` the replicaset might be `small-apple-tree-abf56123fdj`. This extracts the deployment name from the replicaset name and uses it in building the ID for the deployment.

As noted in the code comments, this will _occasionally_ fail when a deployment name is very long. This is because K8s truncates very long deployment names before using it to create the ReplicaSet name

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
