### PR TITLE
fix: PersistentVolume synthesis should not require namespace

### DIFF
--- a/entity-types/infra-kubernetes_persistentvolume/definition.yml
+++ b/entity-types/infra-kubernetes_persistentvolume/definition.yml
@@ -17,7 +17,6 @@ synthesis:
         separator: ":"
         attributes:
           - k8s.cluster.name
-          - namespace
           - persistentvolume
       encodeIdentifierInGUID: true
       name: persistentvolume
@@ -27,8 +26,6 @@ synthesis:
           prefix: kube_persistentvolume_
         # identifier attributes
         - attribute: persistentvolume
-          present: true
-        - attribute: namespace
           present: true
         - attribute: k8s.cluster.name
           present: true


### PR DESCRIPTION
### Relevant information

Synthesis for OpenTelemetry instrumented K8s PersistentVolumes was requiring a `namespace` attribute. Unlike most other K8s resources, PersistentVolumes do not have a namespace. This removes that requirement and adjusts the guid encoding to reflect that.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
