### PR TITLE
feat: K8s pod-container relation from KSM via OTel

### DIFF
--- a/relationships/synthesis/INFRA-KUBERNETES_POD-to-INFRA-CONTAINER.yml
+++ b/relationships/synthesis/INFRA-KUBERNETES_POD-to-INFRA-CONTAINER.yml
@@ -32,3 +32,37 @@ relationships:
           attribute: entityGuid
           entityType:
             value: CONTAINER
+  - name: otelKsmK8sPodContainsContainer
+    # use kube-state-metrics kube_pod_container_info metric
+    version: "1"
+    origins: 
+      - OpenTelemetry
+    conditions:
+      - attribute: metricName
+        anyOf: [ "kube_pod_container_info" ]
+      - attribute: newrelicOnly
+        anyOf: [ "true" ]
+    relationship:
+      expires: P75M
+      relationshipType: CONTAINS
+      source:
+        buildGuid:
+          account:
+            lookup: true  
+          domain:
+            value: INFRA
+          type:
+            value: KUBERNETES_POD
+          identifier:
+            fragments:
+              - attribute: k8s.cluster.name
+              - value: ":"
+              - attribute: namespace
+              - value: ":"
+              - attribute: pod
+            hashAlgorithm: FARM_HASH
+      target:
+        extractGuid:
+          attribute: entity.guid
+          entityType:
+            value: CONTAINER


### PR DESCRIPTION
### Relevant information
Adds relationship synthesis for K8s Pod <-> Container relationship derived from kube-state-metrics telemetry received via OpenTelemetry. 

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
