### PR TITLE
EBPF entities <> Kubernetes

### DIFF
--- a/entity-types/ebpf-client/definition.yml
+++ b/entity-types/ebpf-client/definition.yml
@@ -11,6 +11,8 @@ synthesis:
       value: "nr_ebpf_agent"
     - attribute: trace_role
       value: "client"
+    - attribute: k8s.cluster.name
+      present: false
     tags:
       local_addr:
         entityTagName: "ip"

--- a/entity-types/ebpf-redis_server/definition.yml
+++ b/entity-types/ebpf-redis_server/definition.yml
@@ -17,6 +17,8 @@ synthesis:
       value: "nr_ebpf_agent"
     - attribute: trace_role
       value: "server"
+    - attribute: k8s.cluster.name
+      present: false
     tags:
       local_addr:
         entityTagName: "ip"


### PR DESCRIPTION
Adds a condition to prevent ebpf entities from being created if k8s metadata is present, so that k8s entities are created instead.

### Relevant information

<!--
  Describe what you have done.
  Provide details that are relevant to the PR

  Always think that the person reviewing the PR doesn't have the context you have.

  Links to examples, documentation and similar resources make the process easier to review.
-->

<!--
  Contributions to this repository are reviewed at least twice a week

  There's no further action required once the PR has been created.
 -->

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
