### PR TITLE
EBPF entities <> Kubernetes: Add new entity def rule for k8s pods from ebpf data (depends on #1551)

### DIFF
--- a/entity-types/infra-kubernetes_pod/definition.yml
+++ b/entity-types/infra-kubernetes_pod/definition.yml
@@ -62,3 +62,32 @@ synthesis:
       created_by_kind:
         # from kube-state-metrics kube_pod_info
         entityTagNames: [k8s.createdKind]
+
+  - compositeIdentifier:
+      separator: ":"
+      attributes:
+        - k8s.cluster.name
+        - k8s.namespace.name
+        - k8s.pod.name
+    encodeIdentifierInGUID: true
+    name: k8s.pod.name
+    conditions:
+      # identifier attributes
+      - attribute: k8s.pod.name
+        present: true
+      - attribute: k8s.namespace.name
+        present: true
+      - attribute: k8s.cluster.name
+        present: true
+      # ebpf data
+      - attribute: instrumentation.provider
+        value: "nr_ebpf_agent"
+    tags:
+      k8s.pod.name:
+        entityTagNames: [k8s.podName]
+      k8s.namespace.name:
+        entityTagNames: [k8s.namespaceName]
+      k8s.cluster.name:
+        entityTagNames: [k8s.clusterName]
+      k8s.node.name:
+        entityTagNames: [k8s.nodeName]

--- a/entity-types/infra-kubernetes_pod/tests/Span.json
+++ b/entity-types/infra-kubernetes_pod/tests/Span.json
@@ -1,0 +1,15 @@
+[
+  {
+    "protocol.name": "redis",
+    "instrumentation.provider": "nr_ebpf_agent",
+    "trace_role": "server",
+    "local_addr": "198.xxx.x.xx",
+    "local_port": "98",
+    "remote_addr": "192.xxx.x.xx",
+    "remote_port": "92",
+    "k8s.pod.name": "redis-0",
+    "k8s.namespace.name": "default",
+    "k8s.cluster.name": "k8s-cluster",
+    "newrelic.source": "api.traces.otlp"
+  }
+]


### PR DESCRIPTION
### Relevant information

The existing rule does not create k8s pod entities from ebpf data. 

In particular, we're missing `metricName` and we have `service.name` set to the `local_addr` (which is supposed to not be present in the current rule).

<!--
  Describe what you have done.
  Provide details that are relevant to the PR

  Always think that the person reviewing the PR doesn't have the context you have.

  Links to examples, documentation and similar resources make the process easier to review.
-->

<!--
  Contributions to this repository are reviewed at least twice a week

  There's no further action required once the PR has been created.
 -->

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
