### PR TITLE
feat: Add instanceid and host.id tags for prometheus on a host

### DIFF
--- a/entity-types/infra-host/definition.yml
+++ b/entity-types/infra-host/definition.yml
@@ -177,6 +177,8 @@ synthesis:
         value: "prometheus"
       tags:
         instance:
+        instanceid:
+          entityTagNames: [host.id, instanceid]
         nodename:
           entityTagNames: [hostname]
         instrumentation.provider:


### PR DESCRIPTION
### Relevant information
`host.id` is a required tag for host-apm relationships

<!--
  Contributions to this repository are reviewed at least twice a week

  There's no further action required once the PR has been created.
 -->

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
