### PR TITLE
Fix EXT-PIXIE_DNS test data

### DIFF
--- a/entity-types/ext-pixie_dns/tests/Metric.json
+++ b/entity-types/ext-pixie_dns/tests/Metric.json
@@ -2,7 +2,7 @@
   {
     "dns.server.name": "metadata.newrelic.internal",
     "dns.server.namespace": "",
-    "dns.server.cluster_id": "",
+    "dns.server.cluster_id": "e1d4d7b4-4f2f-4c49-8e9d-9f6c3e6c3c3e",
     "metricName": "dns.latency",
     "dns.query_type": "A",
     "instrumentation.provider": "pixie",

--- a/entity-types/ext-pixie_dns/tests/Span.json
+++ b/entity-types/ext-pixie_dns/tests/Span.json
@@ -2,7 +2,7 @@
   {
     "dns.server.name": "metadata.newrelic.internal",
     "dns.server.namespace": "",
-    "dns.server.cluster_id": "",
+    "dns.server.cluster_id": "e1d4d7b4-4f2f-4c49-8e9d-9f6c3e6c3c3e",
     "dns.query": "query text here",
     "dns.query_type": "A",
     "newRelic.ingestPoint": "api.traces",


### PR DESCRIPTION
### Relevant information

After an upgrade in the validator service (fixing a bug that prevented some checks to be performed), the validation of `EXT-PIXIE_DNS` started to fail because the test data is incorrect.

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
