### PR TITLE
Consolidate prometheus synthesis

### DIFF
--- a/entity-types/infra-host/definition.yml
+++ b/entity-types/infra-host/definition.yml
@@ -230,26 +230,7 @@ synthesis:
         nodename:
           entityTagNames: [hostname]
         instrumentation.provider:
-    # AWS EC2 by instanceid
-    - identifier: instanceid
-      name: instanceid
-      legacyFeatures:
-        overrideGuidType: true
-      encodeIdentifierInGUID: true
-      conditions:
-      - attribute: instance
-        present: false
-      - attribute: metricName
-        prefix: "node_"
-      - attribute: instrumentation.provider
-        value: "prometheus"
-      tags:
-        instanceid:
-          entityTagNames: [host.id, instanceid]
-        nodename:
-          entityTagNames: [hostname]
-        instrumentation.provider:
-    # On a host
+    # AWS EC2 or On a host
     - identifier: instance
       name: instance
       legacyFeatures:

--- a/entity-types/infra-host/definition.yml
+++ b/entity-types/infra-host/definition.yml
@@ -177,6 +177,8 @@ synthesis:
         value: "prometheus"
       tags:
         instance:
+        instanceid:
+          entityTagNames: [host.id, instanceid]
         nodename:
           entityTagNames: [hostname]
         instrumentation.provider:


### PR DESCRIPTION
### Relevant information
Removed an extra unused synthesis rule for prometheus hosts. AWS EC2 hosts are handled via the "on a host" rule. This is just some cleanup after further investigation and discussion: https://newrelic.slack.com/archives/C05UUMVP12T/p1708536306136909

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
