### PR TITLE
feat: Add pods-missing metric for OS K8s Workloads

### DIFF
--- a/entity-types/infra-kubernetes_daemonset/golden_metrics.yml
+++ b/entity-types/infra-kubernetes_daemonset/golden_metrics.yml
@@ -37,4 +37,11 @@ podsMissing:
       from: K8sDaemonsetSample
       eventId: entityGuid
       eventName: entityName
+    opentelemetry:
+      select:  latest(kube_daemonset_pods_missing)
+      from: Metric
+      where: newrelicOnly = 'true'
+      eventId: entity.guid
+      eventName: entity.name
+
 

--- a/entity-types/infra-kubernetes_deployment/golden_metrics.yml
+++ b/entity-types/infra-kubernetes_deployment/golden_metrics.yml
@@ -37,4 +37,10 @@ podsMissing:
       from: K8sDeploymentSample
       eventId: entityGuid
       eventName: entityName
+    opentelemetry:
+      select:  latest(kube_deployment_pods_missing)
+      from: Metric
+      where: newrelicOnly = 'true'
+      eventId: entity.guid
+      eventName: entity.name
 

--- a/entity-types/infra-kubernetes_statefulset/golden_metrics.yml
+++ b/entity-types/infra-kubernetes_statefulset/golden_metrics.yml
@@ -38,7 +38,8 @@ podsMissing:
       eventId: entityGuid
       eventName: entityName
     opentelemetry:
-      select:  latest(kube_statefulset_replicas - kube_statefulset_status_replicas_ready)
+      select:  latest(kube_statefulset_pods_missing)
       from: Metric
+      where: newrelicOnly = 'true'
       eventId: entity.guid
       eventName: entity.name


### PR DESCRIPTION
### Relevant information
Adds pods missing metric for OS K8s DaemonSet, Deployment, StatefulSet. This utilizes a custom metric synthesized in NR OS K8s agent as a workaround for issues with handling calculation in this streaming context.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
