### PR TITLE
feat: Golden tags for OS K8s PersistentVolume

### DIFF
--- a/entity-types/infra-kubernetes_persistentvolume/definition.yml
+++ b/entity-types/infra-kubernetes_persistentvolume/definition.yml
@@ -43,6 +43,15 @@ synthesis:
           entityTagNames: [k8s.volumeName]
         k8s.cluster.name:
           entityTagNames: [k8s.clusterName]
+        phase:
+          multiValue: false
+          entityTagNames: [k8s.persistentvolume.statusPhase]
+        claim_namespace:
+          entityTagNames: [k8s.pvcNamespace]
+        name:
+          entityTagNames: [k8s.pvcName]
+        storageclass:
+          entityTagNames: [k8s.persistentvolume.storageClass]
     # Infrastructure event data via opentelemetry 
     - compositeIdentifier:
         separator: ":"


### PR DESCRIPTION
### Relevant information
Add remapping of golden tags for KSM based K8s PersistentVolumes – `k8s.persistentvolume.statusPhase`, `k8s.pvcNamespace`, `k8s.pvcName` and `k8s.persistentvolume.storageClass`.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
