### PR TITLE
feat(Browser): Change FID metrics to INP

### DIFF
--- a/entity-types/browser-application/golden_metrics.yml
+++ b/entity-types/browser-application/golden_metrics.yml
@@ -14,11 +14,11 @@ largestContentfulPaint75PercentileS:
     from: PageViewTiming
     eventId: entityGuid
     eventName: appName
-firstInputDelay75PercentileMs:
-  title: First input delay (75 percentile) (ms)
+interactionToNextPaint75PercentileMs:
+  title: Interaction to next paint (75 percentile) (ms)
   unit: MS
   query:
-    select: percentile(firstInputDelay, 75)
+    select: percentile(interactionToNextPaint * 1000, 75)
     from: PageViewTiming
     eventId: entityGuid
     eventName: appName

--- a/entity-types/browser-application/summary_metrics.yml
+++ b/entity-types/browser-application/summary_metrics.yml
@@ -6,10 +6,10 @@ largestContentfulPaint75PercentileS:
   goldenMetric: largestContentfulPaint75PercentileS
   unit: SECONDS
   title: Largest contentful paint (75 percentile) (s)
-firstInputDelay75PercentileMs:
-  goldenMetric: firstInputDelay75PercentileMs
+interactionToNextPaint75PercentileMs:
+  goldenMetric: interactionToNextPaint75PercentileMs
   unit: MS
-  title: First input delay (75 percentile) (ms)
+  title: Interaction to next paint (75 percentile) (ms)
 errors:
   goldenMetric: errors
   unit: COUNT


### PR DESCRIPTION
### Relevant information

The Browser team is rolling out its support for [Interaction to Next Paint](https://web.dev/articles/inp), the Core Web Vital metric that has been recently released. We're in the process of replacing all First Input Delay metrics with that of INP, as it was chosen to be its replacement.

This PR replaces FID metrics with equivalent INP metrics on the Browser Entity Summary table to reflect our incorporation of the new standard.

#### More info

- Ticket: https://new-relic.atlassian.net/browse/NR-249585
- INP Product Brief: https://newrelic.atlassian.net/wiki/spaces/APPEXP/pages/2764505110/Product+Brief+-+Interaction+to+Next+Paint

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
