### PR TITLE
fix: OS K8s InfraEvents has events not metrics as source

### DIFF
--- a/entity-types/infra-kubernetes_cronjob/definition.yml
+++ b/entity-types/infra-kubernetes_cronjob/definition.yml
@@ -74,7 +74,7 @@ synthesis:
           present: true
         # open telemetry
         - attribute: newrelic.source
-          value: api.metrics.otlp
+          value: api.events.otlp
         # if service.name is present, handle as one
         - attribute: service.name
           present: false

--- a/entity-types/infra-kubernetes_daemonset/definition.yml
+++ b/entity-types/infra-kubernetes_daemonset/definition.yml
@@ -68,7 +68,7 @@ synthesis:
           present: true
         # open telemetry
         - attribute: newrelic.source
-          value: api.metrics.otlp
+          value: api.events.otlp
         # if service.name is present, handle as one
         - attribute: service.name
           present: false

--- a/entity-types/infra-kubernetes_deployment/definition.yml
+++ b/entity-types/infra-kubernetes_deployment/definition.yml
@@ -68,7 +68,7 @@ synthesis:
           present: true
         # open telemetry
         - attribute: newrelic.source
-          value: api.metrics.otlp
+          value: api.events.otlp
         # if service.name is present, handle as one
         - attribute: service.name
           present: false

--- a/entity-types/infra-kubernetes_job/definition.yml
+++ b/entity-types/infra-kubernetes_job/definition.yml
@@ -72,7 +72,7 @@ synthesis:
           present: true
         # open telemetry
         - attribute: newrelic.source
-          value: api.metrics.otlp
+          value: api.events.otlp
         # if service.name is present, handle as one
         - attribute: service.name
           present: false

--- a/entity-types/infra-kubernetes_persistentvolume/definition.yml
+++ b/entity-types/infra-kubernetes_persistentvolume/definition.yml
@@ -63,7 +63,7 @@ synthesis:
           present: true
         # open telemetry
         - attribute: newrelic.source
-          value: api.metrics.otlp
+          value: api.events.otlp
         # if service.name is present, handle as one
         - attribute: service.name
           present: false

--- a/entity-types/infra-kubernetes_persistentvolumeclaim/definition.yml
+++ b/entity-types/infra-kubernetes_persistentvolumeclaim/definition.yml
@@ -77,7 +77,7 @@ synthesis:
           present: true
         # open telemetry
         - attribute: newrelic.source
-          value: api.metrics.otlp
+          value: api.events.otlp
         # if service.name is present, handle as one
         - attribute: service.name
           present: false

--- a/entity-types/infra-kubernetes_pod/definition.yml
+++ b/entity-types/infra-kubernetes_pod/definition.yml
@@ -86,7 +86,7 @@ synthesis:
         present: true
       # open telemetry
       - attribute: newrelic.source
-        value: api.metrics.otlp
+        value: api.events.otlp
       # if service.name is present, handle as one
       - attribute: service.name
         present: false

--- a/entity-types/infra-kubernetes_statefulset/definition.yml
+++ b/entity-types/infra-kubernetes_statefulset/definition.yml
@@ -68,7 +68,7 @@ synthesis:
           present: true
         # open telemetry
         - attribute: newrelic.source
-          value: api.metrics.otlp
+          value: api.events.otlp
         # if service.name is present, handle as one
         - attribute: service.name
           present: false

--- a/entity-types/infra-kubernetescluster/definition.yml
+++ b/entity-types/infra-kubernetescluster/definition.yml
@@ -36,7 +36,7 @@ synthesis:
           present: true
         # open telemetry
         - attribute: newrelic.source
-          value: api.metrics.otlp
+          value: api.events.otlp
         # if service.name is present, handle as one
         - attribute: service.name
           present: false


### PR DESCRIPTION
### Relevant information

Corrects `newrelic.source` for OS K8s entity synthesis from InfrastructureEvents – should be `api.events.otlp` rather than `api.metrics.otlp`.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
