### PR TITLE
feat: OS K8s deployment-pod relation using candidate lookup

### DIFF
--- a/entity-types/infra-kubernetes_deployment/definition.yml
+++ b/entity-types/infra-kubernetes_deployment/definition.yml
@@ -45,6 +45,45 @@ synthesis:
           entityTagNames: [k8s.namespaceName]
         k8s.cluster.name:
           entityTagNames: [k8s.clusterName]
+    # kube-state-metrics data via opentelemetry prometheusReceiver 
+    # Adds replicaset tag to deployments which enables candidate
+    # relationship with pods
+    - compositeIdentifier:
+        separator: ":"
+        attributes:
+          - k8s.cluster.name
+          - namespace
+          # owner_name is that of the deployment
+          - owner_name
+      encodeIdentifierInGUID: true
+      name: deployment
+      conditions:
+        # kube-state-metrics replicaset owned by deployment
+        - attribute: metricName
+          prefix: kube_replicaset_owner
+        - attribute: owner_kind
+          value: Deployment
+        # identifier attributes  
+        - attribute: owner_name
+          present: true      
+        - attribute: namespace
+          present: true
+        - attribute: k8s.cluster.name
+          present: true
+        # open telemetry
+        - attribute: newrelic.source
+          value: 'api.metrics.otlp'
+        # if service.name is present, it's a service
+        - attribute: service.name
+          present: false
+        # value added for test entities only
+        - attribute: newrelicOnly
+          value: "true"
+      tags:
+        replicaset:
+          # only most recent replicaset will have pods
+          multiValue: false
+          entityTagNames: [k8s.replicasetName]
     # Infrastructure event data via opentelemetry 
     - compositeIdentifier:
         separator: ":"

--- a/relationships/candidates/KUBERNETES_DEPLOYMENT.yml
+++ b/relationships/candidates/KUBERNETES_DEPLOYMENT.yml
@@ -1,0 +1,18 @@
+category: KUBERNETES_DEPLOYMENT
+lookups:
+  - entityTypes:
+    - domain: INFRA
+      type: KUBERNETES_DEPLOYMENT
+    tags:
+      matchingMode: ANY
+      predicates:
+        - tagKeys: ["k8s.replicasetName"]
+          field: replicaset
+        - tagKeys: ["k8s.namespaceName"]
+          field: namespace
+        - tagKeys: ["k8s.clusterName"]
+          field: cluster
+    onMatch:
+      onMultipleMatches: RELATE_ALL
+    onMiss:
+      action: NO_OP

--- a/relationships/synthesis/INFRA-KUBERNETES_DEPLOYMENT-to-INFRA-KUBERNETES_POD.yml
+++ b/relationships/synthesis/INFRA-KUBERNETES_DEPLOYMENT-to-INFRA-KUBERNETES_POD.yml
@@ -48,30 +48,15 @@ relationships:
       expires: P75M
       relationshipType: CONTAINS
       source:
-        buildGuid:
-          account:
-            lookup: true 
-          domain:
-            value: INFRA
-          type:
-            value: KUBERNETES_DEPLOYMENT
-          identifier:
-            fragments:
-              - attribute: k8s.cluster.name
-              - value: ":"
-              - attribute: namespace
-              - value: ":"
-              # The immediate owner is a ReplicaSet; its name is composed `DeploymentName-hash`
-              # This extracts the name of the Deployment which created the ReplicaSet. 
-              # In fringe scenarios this may fail due to find the correct name due to the 
-              # Deployment name being truncated so the ReplicaSet name isn't too long.
-              # Ideally this would use a join of the data on `kube_replicaset_owner` 
-              # (which has the raw deployment name) with `kube_pod_owner`, but joins aren't 
-              # available in this streaming context.
-              - capture:                
-                attribute: owner_name
-                regex: "^(.*)-(?:[^-]+)$"
-            hashAlgorithm: FARM_HASH
+        lookupGuid:
+          candidateCategory: KUBERNETES_DEPLOYMENT
+          fields:
+            - field: replicaset # replicaset owned by deployment
+              attribute: owner_name # replicaset which owns pod
+            - field: namespace # namespace of deployment
+              attribute: namespace # namespace of pod
+            - field: cluster # cluster of deployment
+              attribute: k8s.cluster.name # cluster of pod
       target:
         extractGuid:
           attribute: entity.guid


### PR DESCRIPTION
### Relevant information
Synthesizes a K8s Pod <-> Deployment relation using OpenTelemetry data from kube-state-metrics.

Deployments own ReplicaSets which in turn own Pods. This is a level deeper relationship than other K8s workloads (e.g. StatefulSets own Pods; Daemonsets own Pods). In order to achieve this relationship:

- Adds rule to deployment synthesis which uses [kube_replicaset_owner](https://github.com/kubernetes/kube-state-metrics/blob/main/docs/replicaset-metrics.md#replicaset-metrics) to add `k8s.replicasetName` tag to deployment.
- Adds `KUBERNETES_DEPLOYMENT` relationship candidate which maps tags to `replicaset`, `namespace` and `cluster` fields.
- Adds relationship rule which uses [kube_pod_owner](https://github.com/kubernetes/kube-state-metrics/blob/main/docs/pod-metrics.md#pod-metrics) with lookup of `KUBERNETES_DEPLOYMENT` by `replicaset`, `namespace` and `cluster` to create relationship between pod & deployment.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
