### PR TITLE
Os k8s deployment pod lookup

### DIFF
--- a/entity-types/infra-kubernetes_deployment/definition.yml
+++ b/entity-types/infra-kubernetes_deployment/definition.yml
@@ -56,7 +56,7 @@ synthesis:
           # owner_name is that of the deployment
           - owner_name
       encodeIdentifierInGUID: true
-      name: deployment
+      name: owner_name
       conditions:
         # kube-state-metrics replicaset owned by deployment
         - attribute: metricName

--- a/entity-types/infra-kubernetes_deployment/tests/k8s-ksm-via-opentelemetry-prometheus-receiver.json
+++ b/entity-types/infra-kubernetes_deployment/tests/k8s-ksm-via-opentelemetry-prometheus-receiver.json
@@ -1,0 +1,22 @@
+[
+	{
+		"k8s.cluster.name": "farm",
+		"namespace": "orchards",
+		"deployment": "apple-tree",		
+		"newrelic.source": "api.metrics.otlp",
+		"newrelicOnly": "true",
+		"metricName": "kube_deployment_created",
+		"kube_deployment_created": {"type":"gauge","count":1,"sum":1.0,"min":1.0,"max":1.0,"latest":1.0}
+	},
+	{
+		"k8s.cluster.name": "farm",
+		"namespace": "orchards",
+		"owner_name": "apple-tree",		
+		"owner_kind": "Deployment",
+		"replicaset": "apple-tree-9f7b9f44b",
+		"newrelic.source": "api.metrics.otlp",
+		"newrelicOnly": "true",
+		"metricName": "kube_replicaset_owner",
+		"kube_replicaset_owner": {"type":"gauge","count":1,"sum":1.0,"min":1.0,"max":1.0,"latest":1.0}
+	}
+]


### PR DESCRIPTION
### Relevant information
Corrects attribute used for name in OS K8s deployment synthesis from `kube_replicaset_owner` – should be `owner_name`. Adds test data to validate synthesis rules.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
