### PR TITLE
feat: Add tags for OS K8s containers

### DIFF
--- a/entity-types/infra-container/definition.yml
+++ b/entity-types/infra-container/definition.yml
@@ -67,6 +67,19 @@ synthesis:
       # value added for test entities only
       - attribute: newrelicOnly
         value: "true"
+    tags:
+      container_id: 
+        entityTagNames: [k8s.containerId]
+      image:
+        entityTagNames: [k8s.containerImage]
+      container:
+        entityTagNames: [k8s.containerName]
+      pod:
+        entityTagNames: [k8s.podName]
+      namespace:
+        entityTagNames: [k8s.namespaceName]
+      k8s.cluster.name:
+        entityTagNames: [k8s.clusterName]
   # cAdvisor data via opentelemetry prometheusReceiver 
   - compositeIdentifier:
       separator: ":"
@@ -99,6 +112,17 @@ synthesis:
       # value added for test entities only
       - attribute: newrelicOnly
         value: "true"
+    tags:
+      container:
+        entityTagNames: [k8s.containerName]
+      pod:
+        entityTagNames: [k8s.podName]
+      namespace:
+        entityTagNames: [k8s.namespaceName]
+      k8s.cluster.name:
+        entityTagNames: [k8s.clusterName]
+      k8s.node.name:
+        entityTagNames: [k8s.nodeName]
   # kubeletstatsreceiver data via opentelemetry 
   - compositeIdentifier:
       separator: ":"
@@ -110,7 +134,7 @@ synthesis:
     encodeIdentifierInGUID: true
     name: k8s.container.name
     conditions:
-      # cadvisor container prefix
+      # kubeletstats container prefix
       - attribute: metricName
         prefix: container.
       # identifier attributes
@@ -131,6 +155,17 @@ synthesis:
       # value added for test entities only
       - attribute: newrelicOnly
         value: "true"
+    tags:
+      k8s.container.name:
+        entityTagNames: [k8s.containerName]
+      k8s.pod.name:
+        entityTagNames: [k8s.podName]
+      k8s.namespace.name:
+        entityTagNames: [k8s.namespaceName]
+      k8s.cluster.name:
+        entityTagNames: [k8s.clusterName]
+      k8s.node.name:
+        entityTagNames: [k8s.nodeName]
   # Docker Container from Samples
   - identifier: entityId
     name: name


### PR DESCRIPTION
### Relevant information
Adds tags to synthesis rules for OS K8s containers synthesis from kube-state-metrics, cAdvisor & kubletstatsreceiver.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
