### PR TITLE
Add service.name tag for explicitly defined infra hosts (otel)

### DIFF
--- a/entity-types/infra-host/definition.yml
+++ b/entity-types/infra-host/definition.yml
@@ -147,6 +147,7 @@ synthesis:
         host.image.id:
         host.image.version:
         instrumentation.provider:
+        service.name:
     # opentelemetry host data from opentelemetry-collector (explicit type)
     - identifier: host.id
       name: host.name
@@ -176,6 +177,7 @@ synthesis:
         host.image.id:
         host.image.version:
         instrumentation.provider:
+        service.name:
     # opentelemetry host data from opentelemetry-collector (explicit type)
     - identifier: host.id
       name: host.name
@@ -203,6 +205,7 @@ synthesis:
         host.image.id:
         host.image.version:
         instrumentation.provider:
+        service.name:
     # opentelemetry host data from New Relic sap solutions 
     - identifier: host.id
       name: host.id


### PR DESCRIPTION
### Relevant information
We recently added support for opentelemetry hosts with the `service.name` attribute (https://github.com/newrelic/entity-definitions/pull/1527).  However `service.name` was not added as a tag to be copied from telemetry to the entity.  

This PR adds the `service.name` attribute as a tag to infra-host entities that are synthesized following the rules introduced in https://github.com/newrelic/entity-definitions/pull/1527

<!--
  Contributions to this repository are reviewed at least twice a week

  There's no further action required once the PR has been created.
 -->

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
