### PR TITLE
chore: update nrql to account for bespoke missing metrics

### DIFF
--- a/entity-types/ext-load_balancer/a10-thunder-dashboard.json
+++ b/entity-types/ext-load_balancer/a10-thunder-dashboard.json
@@ -568,7 +568,7 @@
               "nrqlQueries": [
                 {
                   "accountId": 0,
-                  "query": "FROM Metric SELECT latest(kentik.snmp.axVirtualServerPortStatCurConns) AS 'Current Connections', latest(axVirtualServerStatPortStatus) AS 'Status', latest(axVirtualServerStatPortDisplayStatus) AS 'Display Status' FACET axVirtualServerPortStatName AS 'Name', axVirtualServerPortStatAddress AS 'IP Address', axVirtualServerStatPortNum AS 'Port Number', axVirtualServerStatPortType AS 'Port Type' WHERE provider = 'kentik-load-balancer' LIMIT MAX"
+                  "query": "FROM Metric SELECT latest(axVirtualServerStatPortDisplayStatus) AS 'Status', latest(kentik.snmp.axVirtualServerPortStatCurConns) OR 'No Metric Available' AS 'Current Connections' FACET axVirtualServerPortStatName AS 'Name', axVirtualServerPortStatAddress AS 'IP Address', axVirtualServerStatPortNum AS 'Port Number', axVirtualServerStatPortType AS 'Port Type' WHERE provider = 'kentik-load-balancer' LIMIT MAX"
                 }
               ],
               "platformOptions": {


### PR DESCRIPTION
fixing the netmon load balancers dashboard for a10 devices to account for some situations where a single metric isn't being reported by the device