### PR TITLE
APM/OTel relationship with AWS MQ Queue

### DIFF
--- a/relationships/candidates/AWSMQQUEUE.yml
+++ b/relationships/candidates/AWSMQQUEUE.yml
@@ -1,0 +1,18 @@
+category: AWSMQQUEUE
+lookups:
+  - entityTypes:
+      - domain: INFRA
+        type: AWSMQQUEUE
+    tags:
+      matchingMode: ALL
+      predicates:
+        - tagKeys: ["aws.mq.configurationEndpointAddress"]
+          field: endpoint
+        - tagKeys: ["aws.mq.configurationEndpointPort"]
+          field: port
+    onMatch:
+      onMultipleMatches: RELATE_ALL
+    onMiss:
+      action: CREATE_UNINSTRUMENTED
+      uninstrumented:
+        type: AWSMQQUEUE

--- a/relationships/synthesis/APM-APPLICATION-to-INFRA-AWSMQQUEUE.yml
+++ b/relationships/synthesis/APM-APPLICATION-to-INFRA-AWSMQQUEUE.yml
@@ -1,0 +1,22 @@
+relationships:
+  - name: apmProducesAwsMqQueue
+    version: "1"
+    origins:
+      - APM Metrics
+    conditions:
+      - attribute: metricName
+        regex: "^MessageBroker/instance/[^/]*\\.mq\\.[^/]*\\.amazonaws\\.com/[0-9]+/Queue/Named/[^/]*""
+    relationship:
+      expires: P75M
+      relationshipType: CALLS
+      source:
+        extractGuid:
+          attribute: entity.guid
+      target:
+        lookupGuid:
+          candidateCategory: AWSMQQUEUE
+          fields:
+            - field: endpoint
+              attribute: metricName__4              
+            - field: port 
+              attribute: metricName__5


### PR DESCRIPTION
### Relevant information

For any service instrumented using Otel or New Relic APM, a service map is shown in the new relic dashboard which displays the relationship between the service in question and other entities it is dependent on.

In case a service calls a MQ Queue service of AWS, this relationship is not shown in the service map. Instead, it shows that the service calls an external entity.

With the code changes in this PR, the user can correctly see the relationship between the Otel/APM service and Amazon MQ Queue (ActiveMQ or RabbitMQ)


### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
