### PR TITLE
APM/OTel Relationship with AWS MQ Topic

### DIFF
--- a/relationships/candidates/AWSMQTOPIC.yml
+++ b/relationships/candidates/AWSMQTOPIC.yml
@@ -8,8 +8,6 @@ lookups:
       predicates:
         - tagKeys: ["aws.mq.configurationEndpointAddress"]
           field: endpoint
-        - tagKeys: ["aws.mq.configurationEndpointPort"]
-          field: port
     onMatch:
       onMultipleMatches: RELATE_ALL
     onMiss:

--- a/relationships/candidates/AWSMQTOPIC.yml
+++ b/relationships/candidates/AWSMQTOPIC.yml
@@ -1,0 +1,18 @@
+category: AWSMQTOPIC
+lookups:
+  - entityTypes:
+      - domain: INFRA
+        type: AWSMQTOPIC
+    tags:
+      matchingMode: ALL
+      predicates:
+        - tagKeys: ["aws.mq.configurationEndpointAddress"]
+          field: endpoint
+        - tagKeys: ["aws.mq.configurationEndpointPort"]
+          field: port
+    onMatch:
+      onMultipleMatches: RELATE_ALL
+    onMiss:
+      action: CREATE_UNINSTRUMENTED
+      uninstrumented:
+        type: AWSMQTOPIC

--- a/relationships/synthesis/APM-APPLICATION-to-INFRA-AWSMQTOPIC.yml
+++ b/relationships/synthesis/APM-APPLICATION-to-INFRA-AWSMQTOPIC.yml
@@ -1,0 +1,22 @@
+relationships:
+  - name: apmProducesAwsMqQueue
+    version: "1"
+    origins:
+      - APM Metrics
+    conditions:
+      - attribute: metricName
+        regex: "^MessageBroker/instance/[^/]*\\.mq\\.[^/]*\\.amazonaws\\.com/[0-9]+/Topic/Named/[^/]*""
+    relationship:
+      expires: P75M
+      relationshipType: PRODUCES
+      source:
+        extractGuid:
+          attribute: entity.guid
+      target:
+        lookupGuid:
+          candidateCategory: AWSMQQUEUE
+          fields:
+            - field: endpoint
+              attribute: metricName__4              
+            - field: port 
+              attribute: metricName__5

--- a/relationships/synthesis/APM-APPLICATION-to-INFRA-AWSMQTOPIC.yml
+++ b/relationships/synthesis/APM-APPLICATION-to-INFRA-AWSMQTOPIC.yml
@@ -1,14 +1,16 @@
 relationships:
-  - name: apmCallsAwsMqTopic
+  - name: apmProducesAwsMqTopic
     version: "1"
     origins:
-      - APM Metrics
+      - Distributed Tracing
     conditions:
-      - attribute: metricName
-        regex: "^MessageBroker/instance/[^/]*\\.mq\\.[^/]*\\.amazonaws\\.com/[0-9]+/Topic/Named/[^/]*"
+     - attribute: eventType
+        anyOf: [ "Span" ]
+      - attribute: name
+        regex: "MessageBroker/[^/]*/Topic/Produce/Named/[^/]*\\.mq\\.[^/]*\\.amazonaws\\.com/[0-9]+"
     relationship:
       expires: P75M
-      relationshipType: CALLS
+      relationshipType: PRODUCES
       source:
         extractGuid:
           attribute: entity.guid
@@ -17,5 +19,28 @@ relationships:
           candidateCategory: AWSMQTOPIC
           fields:
             - field: endpoint
-              attribute: metricName__3             
+              attribute: server.address         
+
+relationships:
+  - name: apmConsumesAwsMqTopic
+    version: "1"
+    origins:
+      - Distributed Tracing
+    conditions:
+     - attribute: eventType
+        anyOf: [ "Span" ]
+      - attribute: name
+        regex: "MessageBroker/[^/]*/Topic/Consume/Named/[^/]*\\.mq\\.[^/]*\\.amazonaws\\.com/[0-9]+"
+    relationship:
+      expires: P75M
+      relationshipType: CONSUMES
+      source:
+        extractGuid:
+          attribute: entity.guid
+      target:
+        lookupGuid:
+          candidateCategory: AWSMQTOPIC
+          fields:
+            - field: endpoint
+              attribute: server.address             
 

--- a/relationships/synthesis/EXT-SERVICE-to-INFRA-AWSMQTOPIC.yml
+++ b/relationships/synthesis/EXT-SERVICE-to-INFRA-AWSMQTOPIC.yml
@@ -1,11 +1,13 @@
 relationships:
-  - name: apmCallsAwsMqTopic
+  - name: extServiceCallsAwsMqTopic
     version: "1"
     origins:
-      - APM Metrics
+      - OpenTelemetry
     conditions:
-      - attribute: metricName
-        regex: "^MessageBroker/instance/[^/]*\\.mq\\.[^/]*\\.amazonaws\\.com/[0-9]+/Topic/Named/[^/]*"
+      - attribute: eventType
+        anyOf: [ "Span"]
+      - attribute: messaging.destinationkind
+        anyOf: [ "topic" ]
     relationship:
       expires: P75M
       relationshipType: CALLS
@@ -17,5 +19,4 @@ relationships:
           candidateCategory: AWSMQTOPIC
           fields:
             - field: endpoint
-              attribute: metricName__3             
-
+              attribute: net.peer.name


### PR DESCRIPTION
### Relevant information

For any service instrumented using Otel or New Relic APM, a service map is shown in the new relic dashboard which displays the relationship between the service in question and other entities it is dependent on.

In case a service calls a MQ service of AWS, this relationship is not shown in the service map. Instead, it shows that the service calls an external entity.

With the code changes in this PR, the user can correctly see the relationship between the Otel/APM service and Amazon MQ Topic (ActiveMQ or RabbitMQ)


### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
