### PR TITLE
feat: Host.id and Host.name tags are added

### DIFF
--- a/entity-types/infra-container/definition.yml
+++ b/entity-types/infra-container/definition.yml
@@ -31,6 +31,8 @@ synthesis:
       cloud.provider:
       cloud.account.id:
       cloud.region:
+      host.id:
+      host.name:
       # The library name contains the name of the receiver that is used to identify the source
       # and select the dashboard.
       otel.library.name:


### PR DESCRIPTION
### Relevant information

- Ticket: https://new-relic.atlassian.net/browse/NR-272609
- host.id and host.name are added in the tags section for infra container entity with Dockerstats receiver from otel collector.
- There host.id and host.name will be used to create the relation between the infra container and the ext service. 

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
