### PR TITLE
Bugfix-APM-Memcache-Relationship: Fixed the target lookup field

### DIFF
--- a/relationships/synthesis/APM-APPLICATION-to-INFRA-ELASTICACHEMEMCACHEDCLUSTER.yml
+++ b/relationships/synthesis/APM-APPLICATION-to-INFRA-ELASTICACHEMEMCACHEDCLUSTER.yml
@@ -17,6 +17,12 @@ relationships:
           candidateCategory: MEMCACHED
           fields:
             - field: endpoint
-              attribute: metricName__4             
-            - field: port       
+              capture:
+                attribute: metricName__4
+                regex: "(^[^\\.]+\\.[^\\.]+\\.)[^\\.]+\\.[^\\.]+\\.cache\\.amazonaws\\.com$"
+              value: "cfg"
+              capture:
+                attribute: metricName__4
+                regex: "^[^\\.]+\\.[^\\.]+\\.[^\\.]+\\.([^\\.]+\\.cache\\.amazonaws\\.com)$"
+            - field: port
               attribute: metricName__5

--- a/relationships/synthesis/APM-APPLICATION-to-INFRA-ELASTICACHEMEMCACHEDCLUSTER.yml
+++ b/relationships/synthesis/APM-APPLICATION-to-INFRA-ELASTICACHEMEMCACHEDCLUSTER.yml
@@ -20,12 +20,12 @@ relationships:
               fragments:
                 - attribute: metricName__4
                   operations:
-                    -operation: capture
+                    - operation: capture
                       regex: "(^[^\\.]+\\.[^\\.]+\\.)[^\\.]+\\.[^\\.]+\\.cache\\.amazonaws\\.com$"
                 - value: "cfg"
                 - attribute: metricName__4
                   operations:
-                    -operation: capture
+                    - operation: capture
                       regex: "^[^\\.]+\\.[^\\.]+\\.[^\\.]+\\.([^\\.]+\\.cache\\.amazonaws\\.com)$"
             - field: port
                 attribute: metricName__5

--- a/relationships/synthesis/APM-APPLICATION-to-INFRA-ELASTICACHEMEMCACHEDCLUSTER.yml
+++ b/relationships/synthesis/APM-APPLICATION-to-INFRA-ELASTICACHEMEMCACHEDCLUSTER.yml
@@ -18,12 +18,15 @@ relationships:
           fields:
             - field: endpoint
               fragments:
-                capture:
-                  attribute: metricName__4
-                  regex: "(^[^\\.]+\\.[^\\.]+\\.)[^\\.]+\\.[^\\.]+\\.cache\\.amazonaws\\.com$"
-                value: "cfg"
-                capture:
-                  attribute: metricName__4
-                  regex: "^[^\\.]+\\.[^\\.]+\\.[^\\.]+\\.([^\\.]+\\.cache\\.amazonaws\\.com)$"
+                - attribute: metricName__4
+                  operations:
+                    -operation: capture
+                      regex: "(^[^\\.]+\\.[^\\.]+\\.)[^\\.]+\\.[^\\.]+\\.cache\\.amazonaws\\.com$"
+                - value: "cfg"
+                - attribute: metricName__4
+                  operations:
+                    -operation: capture
+                      regex: "^[^\\.]+\\.[^\\.]+\\.[^\\.]+\\.([^\\.]+\\.cache\\.amazonaws\\.com)$"
             - field: port
                 attribute: metricName__5
+  

--- a/relationships/synthesis/APM-APPLICATION-to-INFRA-ELASTICACHEMEMCACHEDCLUSTER.yml
+++ b/relationships/synthesis/APM-APPLICATION-to-INFRA-ELASTICACHEMEMCACHEDCLUSTER.yml
@@ -17,12 +17,13 @@ relationships:
           candidateCategory: MEMCACHED
           fields:
             - field: endpoint
-              capture:
-                attribute: metricName__4
-                regex: "(^[^\\.]+\\.[^\\.]+\\.)[^\\.]+\\.[^\\.]+\\.cache\\.amazonaws\\.com$"
-              value: "cfg"
-              capture:
-                attribute: metricName__4
-                regex: "^[^\\.]+\\.[^\\.]+\\.[^\\.]+\\.([^\\.]+\\.cache\\.amazonaws\\.com)$"
+              fragments:
+                capture:
+                  attribute: metricName__4
+                  regex: "(^[^\\.]+\\.[^\\.]+\\.)[^\\.]+\\.[^\\.]+\\.cache\\.amazonaws\\.com$"
+                value: "cfg"
+                capture:
+                  attribute: metricName__4
+                  regex: "^[^\\.]+\\.[^\\.]+\\.[^\\.]+\\.([^\\.]+\\.cache\\.amazonaws\\.com)$"
             - field: port
-              attribute: metricName__5
+                attribute: metricName__5

--- a/relationships/synthesis/APM-APPLICATION-to-INFRA-ELASTICACHEMEMCACHEDCLUSTER.yml
+++ b/relationships/synthesis/APM-APPLICATION-to-INFRA-ELASTICACHEMEMCACHEDCLUSTER.yml
@@ -17,16 +17,12 @@ relationships:
           candidateCategory: MEMCACHED
           fields:
             - field: endpoint
-              fragments:
-                - attribute: metricName__4
-                  operations:
-                    - operation: capture
-                      regex: "(^[^\\.]+\\.[^\\.]+\\.)[^\\.]+\\.[^\\.]+\\.cache\\.amazonaws\\.com$"
-                - value: "cfg"
-                - attribute: metricName__4
-                  operations:
-                    - operation: capture
-                      regex: "^[^\\.]+\\.[^\\.]+\\.[^\\.]+\\.([^\\.]+\\.cache\\.amazonaws\\.com)$"
+              capture:
+                attribute: metricName__4
+                regex: "(^[^\\.]+\\.[^\\.]+\\.)[^\\.]+\\.[^\\.]+\\.cache\\.amazonaws\\.com$"
+              value: "cfg"
+              capture:
+                attribute: metricName__4
+                regex: "^[^\\.]+\\.[^\\.]+\\.[^\\.]+\\.([^\\.]+\\.cache\\.amazonaws\\.com)$"
             - field: port
-                attribute: metricName__5
-  
+              attribute: metricName__5


### PR DESCRIPTION
### Relevant information
For the APM-Memcache relationship, the target cloud entity is identified using lookup guid operation (endpoint and port).
The endpoint in the timeslice metric of APM and the endpoint given in AWS Memcache entity have a slight difference as shown below:


Hence, the lookup guid operation needed to be changed to capture the full endpoint name from metric in such a way that it matches the endpoint tag of Memcached entity.


### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
