### PR TITLE
feat: add optional VSPHEREVM to HOST relationship

### DIFF
--- a/relationships/candidates/HOST.yml
+++ b/relationships/candidates/HOST.yml
@@ -35,3 +35,18 @@ lookups:
       action: CREATE_UNINSTRUMENTED
       uninstrumented:
         type: HOST
+
+  - entityTypes:
+    - domain: INFRA
+      type: HOST
+    tags:
+      matchingMode: ANY
+      predicates:
+        - tagKeys: ["hostname"]
+          field: onHostEntityHostname
+    onMatch:
+     onMultipleMatches: RELATE_ALL
+    onMiss:
+      action: CREATE_UNINSTRUMENTED
+      uninstrumented:
+        type: HOST

--- a/relationships/synthesis/INFRA-VSPHEREVM-to-INFRA-HOST.yml
+++ b/relationships/synthesis/INFRA-VSPHEREVM-to-INFRA-HOST.yml
@@ -1,0 +1,30 @@
+relationships:
+  - name: vsphereVMContainsHost
+    version: "1"
+    origins:
+      - OnHost Integration
+    conditions:
+      - attribute: eventType
+        anyOf: ["VSphereVmSample"]
+      - attribute: vmHostname
+        present: true
+      # This additional attribute is required because the relationship doesn't apply to every environment
+      # (the VSPHEREVM vmHostname and the HOST hostname don't match in every scenario).
+      # Adding this label to VSphereVmSamples means that a relationship between the VSPHEREVM entity and the
+      # HOST entity whose hostname matches the vmHostname is expected.
+      - attribute: label.enableVMHostNameRelationship
+        present: true
+    relationship:
+      expires: P75M
+      relationshipType: CONTAINS
+      source:
+        extractGuid:
+          attribute: entityGuid
+          entityType:
+            value: VSPHEREVM
+      target:
+        lookupGuid:
+          candidateCategory: HOST
+          fields:
+            - field: onHostEntityHostname
+              attribute: vmHostname


### PR DESCRIPTION
### Relevant information

<!--
  Describe what you have done.
  Provide details that are relevant to the PR

  Always think that the person reviewing the PR doesn't have the context you have.

  Links to examples, documentation and similar resources make the process easier to review.
-->

<!--
  Contributions to this repository are reviewed at least twice a week

  There's no further action required once the PR has been created.
 -->

This PR introduces back the relationship defined in #1616, but this time it creates _uninstrumented_ HOST entities on miss.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
