### PR TITLE
Rename AWSMSKTOPIC candidate relationships to KAFKATOPIC

### DIFF
--- a/entity-types/uninstrumented-kafkatopic/definition.yml
+++ b/entity-types/uninstrumented-kafkatopic/definition.yml
@@ -1,5 +1,5 @@
 domain: UNINSTRUMENTED
-type: AWSMSKTOPIC
+type: KAFKATOPIC
 
 configuration:
   entityExpirationTime: DAILY

--- a/relationships/candidates/KAFKATOPIC.yml
+++ b/relationships/candidates/KAFKATOPIC.yml
@@ -1,4 +1,4 @@
-category: AWSMSKTOPIC
+category: KAFKATOPIC
 lookups:
   - entityTypes:
     - domain: INFRA
@@ -17,4 +17,4 @@ lookups:
     onMiss:
       action: CREATE_UNINSTRUMENTED
       uninstrumented:
-        type: AWSMSKTOPIC
+        type: KAFKATOPIC

--- a/relationships/synthesis/APM-APPLICATION-to-KAFKATOPIC.yml
+++ b/relationships/synthesis/APM-APPLICATION-to-KAFKATOPIC.yml
@@ -14,7 +14,7 @@ relationships:
           attribute: entity.guid
       target:
         lookupGuid:
-          candidateCategory: AWSMSKTOPIC
+          candidateCategory: KAFKATOPIC
           fields:
             - field: clusterName
               capture:
@@ -42,7 +42,7 @@ relationships:
           attribute: entity.guid
       target:
         lookupGuid:
-          candidateCategory: AWSMSKTOPIC
+          candidateCategory: KAFKATOPIC
           fields:
             - field: clusterName
               capture:


### PR DESCRIPTION
### Relevant information

This change makes the uninstrumented entities for Kafka topics independent from MSK. In the same way we have an uninstrumented database entity instead of an uninstrumented RDS entity. We need this to support other Kafka providers in the future.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
