### PR TITLE
Add condition to make sure `service.name` is not present in eBPF data when creating a pod entity

### DIFF
--- a/entity-types/infra-kubernetes_pod/definition.yml
+++ b/entity-types/infra-kubernetes_pod/definition.yml
@@ -111,6 +111,8 @@ synthesis:
         present: true
       - attribute: k8s.cluster.name
         present: true
+      - attribute: service.name
+        present: false
       # ebpf data
       - attribute: instrumentation.provider
         value: "nr_ebpf_agent"


### PR DESCRIPTION
### Relevant information
We want to be able to create OTel service entities from the eBPF agent data if the attribute `service.name` is present. The current rule seems to be matching against all data we export from the agent even if we provide a `service.name` since the rule only checks for relevant k8s metadata. This PR adds a condition to make sure that a k8s pod entity is created from the eBPF agent only if `service.name` is not present. 
<!--
  Describe what you have done.
  Provide details that are relevant to the PR

  Always think that the person reviewing the PR doesn't have the context you have.

  Links to examples, documentation and similar resources make the process easier to review.
-->

<!--
  Contributions to this repository are reviewed at least twice a week

  There's no further action required once the PR has been created.
 -->

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
