### PR TITLE
feat: infra k8s cluster name as tag

### DIFF
--- a/entity-types/infra-kubernetescluster/definition.yml
+++ b/entity-types/infra-kubernetescluster/definition.yml
@@ -22,6 +22,8 @@ synthesis:
         # value added for test entities only
         - attribute: newrelicOnly
           value: "true"
+      tags:
+        k8s.cluster.name:
     # Infrastructure event data via opentelemetry 
     - identifier: k8s.cluster.name
       encodeIdentifierInGUID: true
@@ -43,3 +45,5 @@ synthesis:
         # value added for test entities only
         - attribute: newrelicOnly
           value: "true"
+      tags:
+        k8s.cluster.name:


### PR DESCRIPTION
### Relevant information
New experiences being developed require the k8s.cluster.name defined as tag in the infra-kubernetescluster entity. 


### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
