### PR TITLE
Fix dashboard queries for dbt_job_run

### DIFF
--- a/entity-types/ext-dbt_job_run/dashboard.json
+++ b/entity-types/ext-dbt_job_run/dashboard.json
@@ -24,7 +24,7 @@
               "nrqlQueries": [
                 {
                   "accountId": 0,
-                  "query": "select project_name, environment_name, run_team, team, resource_type, name, database_name, schema_name, status, error from dbt_resource_run where run_href = {{tags.run_href}} and resource_type != 'test' and status not in ('success', 'None', 'skipped') since 7 days ago"
+                  "query": "select project_name, environment_name, run_team, team, resource_type, name, database_name, schema_name, status, error from dbt_resource_run where run_href = '{{tags.run_href}}' and resource_type != 'test' and status not in ('success', 'None', 'skipped') since 7 days ago"
                 }
               ],
               "platformOptions": {
@@ -50,7 +50,7 @@
               "nrqlQueries": [
                 {
                   "accountId": 0,
-                  "query": "select run_team, team, name, database_name, schema_name, test_model_name, test_column_name, status, errors from dbt_resource_run where run_href = {{tags.run_href}} and resource_type = 'test' and status not in  ('pass', 'None', 'skipped') since 7 days ago"
+                  "query": "select run_team, team, name, database_name, schema_name, test_model_name, test_column_name, status, errors from dbt_resource_run where run_href = '{{tags.run_href}}' and resource_type = 'test' and status not in  ('pass', 'None', 'skipped') since 7 days ago"
                 }
               ],
               "platformOptions": {


### PR DESCRIPTION
### Relevant information

[Dbt](https://www.getdbt.com/) is a data transformation tool that comes in both cloud and open source versions. It is used by many companies in analytics and data engineering.

These entities allow observability for dbt job runs, failed models/tests, and failed test rows. The primary purpose of these entities is to generate alerts and notifications with custom descriptions and simple summary dashboards. Without these entities, we would need to resort to faceting and that makes the notifications unreadable. All entities are short lived (8 day retention)

Definitions:
* DBT_JOB_RUN: A set of data transformations and tests that are run in a DAG 
* DBT_FAILED_RESOURCE_RUN: A single task from the DBT_JOB_RUN that failed
* DBT_FAILED_TEST_ROW: A single instance of a row in a database that failed data-quality tests. 


Entities expected count:
* DBT_JOB_RUN: ~155 per day
* DBT_FAILED_RESOURCE_RUN 10 - 50 per day
* DBT_FAILED_TEST_ROW: 0 - 200 per day

This PR is to update the entities after testing in staging. 

Notes:
* Since we control the data for these entities, I provided entity_id (a uuidv4) and entity_name attributes. Those are not typos.


### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.