### PR TITLE
Corrected the uninstrumented type name in candidate

### DIFF
--- a/relationships/candidates/AWSMQBROKER.yml
+++ b/relationships/candidates/AWSMQBROKER.yml
@@ -13,4 +13,4 @@ lookups:
     onMiss:
       action: CREATE_UNINSTRUMENTED
       uninstrumented:
-        type: AWSMQBROKER
+        type: MQBROKER


### PR DESCRIPTION
Corrected the type name for uninstrumented entity to be created on lookup miss through the candidate definition
### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
