### PR TITLE
fix: update facet to proper attribute

### DIFF
--- a/entity-types/ext-trap_device/kentik-trap-events-dashboard.json
+++ b/entity-types/ext-trap_device/kentik-trap-events-dashboard.json
@@ -24,7 +24,7 @@
 						"nrqlQueries": [
 							{
 								"accountId": 0,
-								"query": "FROM KSnmpTrap SELECT latest(device_name),latest(TrapName),count(*) AS 'Number of Traps', latest(timestamp) AS 'Last Trap Received'"
+								"query": "FROM KSnmpTrap SELECT latest(device_name), latest(TrapName),count(*) AS 'Number of Traps', latest(timestamp) AS 'Last Trap Received'"
 							}
 						],
 						"platformOptions": {
@@ -73,7 +73,7 @@
 						"height": 3
 					},
 					"visualization": {
-						"id": "viz.line"
+						"id": "viz.stacked-bar"
 					},
 					"rawConfiguration": {
 						"facet": {
@@ -85,14 +85,11 @@
 						"nrqlQueries": [
 							{
 								"accountId": 0,
-								"query": "FROM KSnmpTrap SELECT count(*) AS 'Number of Traps' TIMESERIES FACET TrapName"
+								"query": "FROM KSnmpTrap SELECT count(*) AS 'Number of Traps' TIMESERIES FACET TrapOID"
 							}
 						],
 						"platformOptions": {
 							"ignoreTimeRange": false
-						},
-						"yAxisLeft": {
-							"zero": true
 						}
 					}
 				},


### PR DESCRIPTION
### Relevant information
fix to update the facet on the dashboard from `TrapName` (deprecated) to the proper `TrapOID` attribute.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
