### PR TITLE
fix: instrumentation.name selector on gm

### DIFF
--- a/entity-types/ext-trap_device/golden_metrics.yml
+++ b/entity-types/ext-trap_device/golden_metrics.yml
@@ -2,7 +2,7 @@ nrOfTraps:
   title: Number of Traps
   unit: COUNT
   queries:
-    kentik/netflow-events:
+    kentik/snmp-trap-events:
       select: count(*)
       from: KSnmpTrap
       where: "provider = 'kentik-trap-device'"
@@ -11,7 +11,7 @@ nrOfUniqueTraps:
   title: Number of Unique Traps
   unit: COUNT
   queries:
-    kentik/netflow-events:
+    kentik/snmp-trap-events:
       select: uniqueCount(TrapOID)
       from: KSnmpTrap
       where: "provider = 'kentik-trap-device'"


### PR DESCRIPTION
### Relevant information
fixes a typo in the `instrumentation.provider/instrumentation.name` selector on the golden metrics definition that was breaking signal creation.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
