### PR TITLE
Add `EXT-SERVICE` rule for data from eBPF agent

### DIFF
--- a/entity-types/ext-service/definition.yml
+++ b/entity-types/ext-service/definition.yml
@@ -164,6 +164,25 @@ synthesis:
       k8s.deployment.name:
         entityTagName: k8s.deploymentName
         ttl: P1D
+    
+    # telemetry from NR eBPF agent
+  - identifier: service.name
+    name: service.name
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: instrumentation.provider
+      value: nr_ebpf_agent
+    - attribute: service.name
+    tags:
+      k8s.cluster.name:
+        entityTagName: k8s.clusterName
+        ttl: P1D
+      k8s.namespace.name:
+        entityTagName: k8s.namespaceName
+        ttl: P1D
+      deployment.name:
+        entityTagName: k8s.deploymentName
+        ttl: P1D
 
     # IMPORTANT:
     # This rule matches on any telemetry with service.name


### PR DESCRIPTION
### Relevant information

Adds an explicit entity synthesis rule for data collected by the NR eBPF agent in order to populate `k8s.` tags. Previously, eBPF data matched the most generic rule.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
