### PR TITLE
Remove ext-service rule for newrelic-opentelemetry provider

### DIFF
--- a/entity-types/ext-service/definition.yml
+++ b/entity-types/ext-service/definition.yml
@@ -84,29 +84,6 @@ synthesis:
       faas.name:
       faas.id:
 
-    # telemetry from NewRelic opentelemetry distribution
-  - identifier: service.name
-    name: service.name
-    encodeIdentifierInGUID: true
-    conditions:
-    - attribute: instrumentation.provider
-      value: newrelic-opentelemetry
-    - attribute: newrelic.entity.type
-      present: false
-    tags:
-      k8s.cluster.name:
-        ttl: P1D
-      k8s.deployment.name:
-        ttl: P1D
-      k8s.namespace.name:
-        ttl: P1D
-      telemetry.sdk.language:
-        entityTagName: language
-      telemetry.sdk.version:
-      service.namespace:
-      faas.name:
-      faas.id:
-
     # telemetry from kamon-agent provider
   - identifier: service.name
     name: service.name


### PR DESCRIPTION
This rule is no longer necessary. It was introduced in #1004 in support of a prototype that we do not plan on advancing.