### PR TITLE
Update OTel-related ext-service rule

### DIFF
--- a/entity-types/ext-service/definition.yml
+++ b/entity-types/ext-service/definition.yml
@@ -200,11 +200,18 @@ synthesis:
     - attribute: newrelic.entity.type
       present: false
     tags:
+      k8s.cluster.name:
+        ttl: P1D
+      k8s.deployment.name:
+        ttl: P1D
+      k8s.namespace.name:
+        ttl: P1D
       telemetry.sdk.name:
         entityTagName: instrumentation.provider
       telemetry.sdk.language:
         entityTagName: language
       telemetry.sdk.version:
+      service.namespace:
 
 
 configuration:


### PR DESCRIPTION
The rule modified in this PR should behave identically to the following rule - namely the entity tags applied should be the same between the two rules. Both rules support OpenTelemetry.

https://github.com/newrelic/entity-definitions/blob/8e618b24a77a85db6dba6a0f5f3c49e3cae37d7e/entity-types/ext-service/definition.yml#L39-L62