### PR TITLE
 AWS VPC VPN not showing golden metrics in entity explorer

### DIFF
--- a/entity-types/infra-awsvpcvpntunnel/golden_metrics.yml
+++ b/entity-types/infra-awsvpcvpntunnel/golden_metrics.yml
@@ -1,9 +1,9 @@
 tunnelState:
   title: Tunnel State
-  unit: PERCENTAGE
+  unit: COUNT
   queries:
     aws:
-      select: latest(aws.vpn.TunnelState)
+      select: sum(aws.vpn.TunnelState)
       from: Metric
       eventId: entity.guid
       eventName: entity.name
@@ -12,7 +12,7 @@ tunnelDataOut:
   unit: BYTES
   queries:
     aws:
-      select: latest(aws.vpn.TunnelDataOut)
+      select: sum(aws.vpn.TunnelDataOut)
       from: Metric
       eventId: entity.guid
       eventName: entity.name
@@ -21,7 +21,7 @@ tunnelDataIn:
   unit: BYTES
   queries:
     aws:
-      select: latest(aws.vpn.TunnelDataIn)
+      select: sum(aws.vpn.TunnelDataIn)
       from: Metric
       eventId: entity.guid
       eventName: entity.name


### PR DESCRIPTION

### Relevant information
 Fix AWS VPC VPN not showing golden metrics in entity explorer since Wrong aggregater had used. Updated the aggregator to sum() in VPC VPN Tunnel entity
<!--
  Describe what you have done.
  Provide details that are relevant to the PR

  Always think that the person reviewing the PR doesn't have the context you have.

  Links to examples, documentation and similar resources make the process easier to review.
  

-->

<!--
  Contributions to this repository are reviewed at least twice a week

  There's no further action required once the PR has been created.
 -->

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
