### PR TITLE
Bugfix for Otel to AWS MSK relationship

### DIFF
--- a/relationships/synthesis/EXT-SERVICE-to-KAFKATOPIC.yml
+++ b/relationships/synthesis/EXT-SERVICE-to-KAFKATOPIC.yml
@@ -2,7 +2,7 @@ relationships:
   - name: extServiceProducesAwsMskTopic
     version: "1"
     origins:
-      - Distributed Tracing 
+      - OpenTelemetry
     conditions:
       - attribute: eventType
         value: "Span"
@@ -32,7 +32,7 @@ relationships:
   - name: extServiceConsumesAwsMskTopic
     version: "1"
     origins:
-      - Distributed Tracing 
+      - OpenTelemetry
     conditions:
       - attribute: eventType
         value: "Span"

--- a/relationships/synthesis/EXT-SERVICE-to-KAFKATOPIC.yml
+++ b/relationships/synthesis/EXT-SERVICE-to-KAFKATOPIC.yml
@@ -20,14 +20,14 @@ relationships:
           fields:
             - field: clusterName
               capture:
-                attribute: net.peer.name
-                regex: "^[^\\.]+\\.([^\\.]+)\\.[^\\.]+\\.[^\\.]+\\.kafka\\.[^\\.]+\\.amazonaws\\.com"
+                attribute: messaging.url              
+                regex: "^[^\\.]+\\.([^\\.]+)\\.[^\\.]+\\.[^\\.]+\\.kafka\\.[^\\.]+\\.amazonaws\\.com:[0-9]+.*"
             - field: region
               capture:
-                attribute: net.peer.name
-                regex: "^[^\\.]+\\.[^\\.]+\\.[^\\.]+\\.[^\\.]+\\.kafka\\.([^\\.]+)\\.amazonaws\\.com"
+                attribute: messaging.url
+                regex: "^[^\\.]+\\.[^\\.]+\\.[^\\.]+\\.[^\\.]+\\.kafka\\.([^\\.]+)\\.amazonaws\\.com:[0-9]+.*"
             - field: topic
-              attribute: topic
+              attribute: messaging.destination
 
   - name: extServiceConsumesAwsMskTopic
     version: "1"
@@ -50,12 +50,12 @@ relationships:
           fields:
             - field: clusterName
               capture:
-                attribute: net.peer.name
-                regex: "^[^\\.]+\\.([^\\.]+)\\.[^\\.]+\\.[^\\.]+\\.kafka\\.[^\\.]+\\.amazonaws\\.com"
+                attribute: messaging.url
+                regex: "^[^\\.]+\\.([^\\.]+)\\.[^\\.]+\\.[^\\.]+\\.kafka\\.[^\\.]+\\.amazonaws\\.com:[0-9]+.*"
             - field: region
               capture:
-                attribute: net.peer.name
-                regex: "^[^\\.]+\\.[^\\.]+\\.[^\\.]+\\.[^\\.]+\\.kafka\\.([^\\.]+)\\.amazonaws\\.com"
+                attribute: messaging.url
+                regex: "^[^\\.]+\\.[^\\.]+\\.[^\\.]+\\.[^\\.]+\\.kafka\\.([^\\.]+)\\.amazonaws\\.com:[0-9]+.*"
             - field: topic
-              attribute: topic
+              attribute: messaging.destination
 


### PR DESCRIPTION
### Relevant information
Updated the attribute names in the relationship file as per span data.

Updated the regular expression to capture broker name and region. It now matches the AWS broker URL folloed my any string. This is because python instrumentation records the broker url enclosed in double quotes ("<broker_url>").

Also changed the origin to open telemetry.

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
