### PR TITLE
Add K8sClusterEntiyTag

### DIFF
--- a/entity-types/infra-kubernetescluster/definition.yml
+++ b/entity-types/infra-kubernetescluster/definition.yml
@@ -22,6 +22,8 @@ synthesis:
         # value added for test entities only
         - attribute: newrelicOnly
           value: "true"
+      tags:
+        k8s.cluster.name:
     # Infrastructure event data via opentelemetry 
     - identifier: k8s.cluster.name
       encodeIdentifierInGUID: true
@@ -43,3 +45,5 @@ synthesis:
         # value added for test entities only
         - attribute: newrelicOnly
           value: "true"
+      tags:
+        k8s.cluster.name:


### PR DESCRIPTION
### Relevant information

We need to have available `k8s.cluster.name` for K8s Cluster entities. I followed the same approach of https://github.com/newrelic/entity-definitions/blob/42b7a5a1780d897312f231aac3271898f8c87ff5/definitions/ext-pixie_postgres/definition.yml#L34-L35