### PR TITLE
Add synthesis rule for k8s Otel in infra Host

### DIFF
--- a/entity-types/infra-host/definition.yml
+++ b/entity-types/infra-host/definition.yml
@@ -21,6 +21,40 @@ goldenTags:
 - cloud.platform
 synthesis:
   rules:
+      # opentelemetry host data from k8s-otel-collector
+    - identifier: host.id
+      name: host.name
+      legacyFeatures:
+        overrideGuidType: true
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: eventType
+          value: Metric
+        - attribute: metricName
+          prefix: system.
+        - attribute: newrelic.source
+          value: 'api.metrics.otlp'
+        # if service.name is present, it's a service, not a host
+        - attribute: service.name
+          present: false
+        # if container.id is present, it's a container, not a host
+        - attribute: container.id
+          present: false
+      tags:
+        k8s.cluster.name:
+        cloud.provider:
+        cloud.account.id:
+        cloud.region:
+        cloud.availability_zone:
+        cloud.platform:
+        host.id:
+        host.name:
+        host.type:
+        host.arch:
+        host.image.name:
+        host.image.id:
+        host.image.version:
+        instrumentation.provider:
     # opentelemetry host data from opentelemetry-collector
     - identifier: host.id
       name: host.name

--- a/relationships/synthesis/INFRA-HOST-to-INFRA-KUBERNETES_POD.yml
+++ b/relationships/synthesis/INFRA-HOST-to-INFRA-KUBERNETES_POD.yml
@@ -19,3 +19,25 @@ relationships:
           attribute: entityGuid
           entityType:
             value: KUBERNETES_POD
+  - name: k8sHostContainsPodOtel
+      version: "1"
+    origins:
+      - Kubernetes Integration
+    conditions:
+      - attribute: eventType
+        value: Metric
+      - attribute: entity.type
+        value: KUBERNETES_POD
+    relationship:
+      expires: P75M
+      relationshipType: CONTAINS
+      source:
+        extractGuid:
+          attribute: host.guid
+          entityType:
+            value: HOST
+      target:
+        extractGuid:
+          attribute: entityGuid
+          entityType:
+            value: KUBERNETES_POD

--- a/relationships/synthesis/INFRA-HOST-to-INFRA-KUBERNETES_POD.yml
+++ b/relationships/synthesis/INFRA-HOST-to-INFRA-KUBERNETES_POD.yml
@@ -20,7 +20,7 @@ relationships:
           entityType:
             value: KUBERNETES_POD
   - name: k8sHostContainsPodOtel
-      version: "1"
+    version: "1"
     origins:
       - Kubernetes Integration
     conditions:

--- a/relationships/synthesis/INFRA-HOST-to-INFRA-KUBERNETES_POD.yml
+++ b/relationships/synthesis/INFRA-HOST-to-INFRA-KUBERNETES_POD.yml
@@ -19,25 +19,3 @@ relationships:
           attribute: entityGuid
           entityType:
             value: KUBERNETES_POD
-  - name: k8sHostContainsPodOtel
-    version: "1"
-    origins:
-      - Kubernetes Integration
-    conditions:
-      - attribute: eventType
-        value: Metric
-      - attribute: entity.type
-        value: KUBERNETES_POD
-    relationship:
-      expires: P75M
-      relationshipType: CONTAINS
-      source:
-        extractGuid:
-          attribute: host.guid
-          entityType:
-            value: HOST
-      target:
-        extractGuid:
-          attribute: entityGuid
-          entityType:
-            value: KUBERNETES_POD


### PR DESCRIPTION
### Relevant information

- Infra Host synthesis rule missing k8s.cluster.name tag for entities that are k8s Otel Hosts added new rule to capture that 
- Add Relationship for k8s Otel to infra host k8sHostContainsPodOtel

<!--
  Contributions to this repository are reviewed at least twice a week

  There's no further action required once the PR has been created.
 -->

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
