### PR TITLE
[NR-299138] Added Relationships file for Autoscaling group to EC2

### DIFF
--- a/relationships/candidates/AWSAUTOSCALINGGROUP.yml
+++ b/relationships/candidates/AWSAUTOSCALINGGROUP.yml
@@ -1,0 +1,14 @@
+category: AWSAUTOSCALINGGROUP
+lookups:
+  - entityTypes:
+      - domain: INFRA
+        type: AWSAUTOSCALINGGROUP
+    tags:
+      matchingMode: ALL
+      predicates:
+        - tagKeys: ["aws.instanceId"]
+          field: instanceId
+    onMatch:
+      onMultipleMatches: RELATE_ALL
+    onMiss:
+      action: NO_OP

--- a/relationships/synthesis/INFRA-AWSAUTOSCALINGGROUP-to-INFRA_AWSEC2.yml
+++ b/relationships/synthesis/INFRA-AWSAUTOSCALINGGROUP-to-INFRA_AWSEC2.yml
@@ -1,0 +1,24 @@
+relationships:
+  - name: awsAutoScalingGroupManagesEc2
+    version: "1"
+    origins:
+      - AWS Integration
+    conditions:
+      - attribute: eventType
+        anyOf: [ "Metric" ]
+      - attribute: entity.type
+        anyOf: [ "AWSAUTOSCALINGGROUP", "AWS_AUTO_SCALING_GROUP" ]
+    relationship:
+      expires: P75M
+      relationshipType: MANAGES
+      source:
+        lookupGuid:
+          candidateCategory: AWSAUTOSCALINGGROUP
+          fields:
+            - field: awsAutoScalingGroupArn
+              attribute: aws.autoscaling.instanceId
+      target:
+        extractGuid:
+          attribute: entity.guid
+          entityType:
+            value: AWSEC2


### PR DESCRIPTION
### Relevant information
This PR is a proxy to existing approved PR since the DEV is out on emergency vacation.
Existing Approved PR - https://github.com/newrelic/entity-definitions/pull/1722

[Description Copied from Previous PR]
Created candidate and synthesis files for AWSAUTOSCALINGGROUP to AWSEC2 relationship
as part of this story : https://new-relic.atlassian.net/browse/NR-299138

### Checklist
 [YES] I've read the guidelines and understand the acceptance criteria.
 [YES] The value of the attribute marked as identifier will be unique and valid.
 [YES] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.