### PR TITLE
chore: Updated the regex for apm to elasticache memcached cluster to optionally allow for `Memcache` instead of `Memcached` in the metric name

### DIFF
--- a/relationships/synthesis/APM-APPLICATION-to-INFRA-ELASTICACHEMEMCACHEDCLUSTER.yml
+++ b/relationships/synthesis/APM-APPLICATION-to-INFRA-ELASTICACHEMEMCACHEDCLUSTER.yml
@@ -5,7 +5,7 @@ relationships:
       - APM Metrics
     conditions:
       - attribute: metricName
-        regex: "^Datastore/instance/Memcached/[^/]*\\.cache\\.amazonaws\\.com/[0-9]+"
+        regex: "^Datastore/instance/Memcache[d]?/[^/]*\\.cache\\.amazonaws\\.com/[0-9]+"
     relationship:
       expires: P75M
       relationshipType: CALLS


### PR DESCRIPTION

### Relevant information

The Node.js agent creates the memcached metrics without a trailing `d`. We cannot update these metric names without making a breaking change.  We have no intention of making this breaking change so this PR updates the regex to allow for the omission of the trailing `d`

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
