### PR TITLE
Corrected AWS_MSK to AWS_S3 relationship with correct entityType

### DIFF
--- a/relationships/synthesis/INFRA-AWSMSKCLUSTER-to-INFRA-AWSS3BUCKET.yml
+++ b/relationships/synthesis/INFRA-AWSMSKCLUSTER-to-INFRA-AWSS3BUCKET.yml
@@ -7,7 +7,7 @@ relationships:
       - attribute: eventType
         anyOf: [ "Metric" ]
       - attribute: entity.type
-        anyOf: [ "AWSMSKCLUSTER" ]
+        anyOf: [ "AWSMSKCLUSTER", "AWS_MSK_CLUSTER" ]
     relationship:
       expires: P75M
       relationshipType: CONSUMES


### PR DESCRIPTION
### Relevant information
Corrected Entity Type in AWS_MSK_CLUSTER to AWS_S3 Bucket.

Reference - https://newrelic.slack.com/archives/CH5MLECNN/p1724324396433309

### Checklist

* [Yes ] I've read the guidelines and understand the acceptance criteria.
* [ Yes] The value of the attribute marked as `identifier` will be unique and valid. 
* [ Yes] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
