### PR TITLE
feat: Adding candidate and relationship btw OTel and kinesis stream

### DIFF
--- a/relationships/candidates/AWSKINESISSTREAM.yml
+++ b/relationships/candidates/AWSKINESISSTREAM.yml
@@ -1,0 +1,16 @@
+category: AWSKINESISSTREAM
+lookups:
+  - entityTypes:
+      - domain: INFRA
+        type: AWSKINESISSTREAM
+    tags:
+      matchingMode: ALL
+      predicates:
+        - tagKeys: ["aws.Arn"]
+          field: cloudResourceId
+    onMatch:
+      onMultipleMatches: RELATE_ALL
+    onMiss:
+      action: CREATE_UNINSTRUMENTED
+      uninstrumented:
+        type: AWSKINESISSTREAM

--- a/relationships/synthesis/EXT-SERVICE-to-INFRA-KINESISSTREAM.yml
+++ b/relationships/synthesis/EXT-SERVICE-to-INFRA-KINESISSTREAM.yml
@@ -1,0 +1,22 @@
+relationships:
+  - name: extServiceCallsInfraKinesisStream
+    version: "1"
+    origins:
+      - Distributed Tracing
+    conditions:
+      - attribute: eventType
+        anyOf: [ "Span" ]
+      - attribute: rpc.service
+        anyOf: [ "kinesis" ]
+    relationship:
+      expires: P75M
+      relationshipType: CALLS
+      source:
+        extractGuid:
+          attribute: entity.guid
+      target:
+        lookupGuid:
+          candidateCategory: AWSKINESISSTREAM
+          fields:
+            - field: cloudResourceId
+              attribute: cloud.resource_id


### PR DESCRIPTION
We are establishing a relationship between OTel and AWS Kinesis Stream by using the ARN as the matching criterion. Users or customers from the OTel service need to manually send the ARN within the cloud.resource_id span attribute.

On the Cloud Monitoring platform side, we are associating tags with the aws.Arn for AWS Kinesis streams, ensuring that the collector.name is equal to cloudwatch-metric-streams.

The ARN is formatted as follows for a function: arn:${realm}:kinesis:${region}:${accountId}:stream/${StreamName}

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
