### PR TITLE
NR-309927 Fix http error metrics for mobile applicatoins

### DIFF
--- a/entity-types/mobile-application/golden_metrics.yml
+++ b/entity-types/mobile-application/golden_metrics.yml
@@ -19,7 +19,7 @@ httpResponseTimeMsMetric:
     select: average(apm.mobile.external.duration) * 1000
     eventName: appName
 networkFailuresRateMetric:
-  title: Network failure count
+  title: Network failures rate
   unit: COUNT
   query:
     select: average(apm.mobile.failed.call.rate)

--- a/entity-types/mobile-application/golden_metrics.yml
+++ b/entity-types/mobile-application/golden_metrics.yml
@@ -18,7 +18,7 @@ httpResponseTimeMsMetric:
   query:
     select: average(apm.mobile.external.duration) * 1000
     eventName: appName
-networkFailuresCountMetric:
+networkFailuresRateMetric:
   title: Network failure count
   unit: COUNT
   query:

--- a/entity-types/mobile-application/summary_metrics.yml
+++ b/entity-types/mobile-application/summary_metrics.yml
@@ -12,7 +12,7 @@ httpResponseTimeMs:
   unit: MS
 networkFailuresRate:
   goldenMetric: networkFailuresRateMetric
-  title: Network error rate
+  title: Network failures rate
   unit: COUNT
 httpErrorsRate:
   goldenMetric: httpErrorsRateMetric

--- a/entity-types/mobile-application/summary_metrics.yml
+++ b/entity-types/mobile-application/summary_metrics.yml
@@ -10,9 +10,9 @@ httpResponseTimeMs:
   goldenMetric: httpResponseTimeMsMetric
   title: HTTP response time (ms)
   unit: MS
-networkFailuresCount:
-  goldenMetric: networkFailuresCountMetric
-  title: Network errors count
+networkFailuresRate:
+  goldenMetric: networkFailuresRateMetric
+  title: Network error rate
   unit: COUNT
 httpErrorsRate:
   goldenMetric: httpErrorsRateMetric


### PR DESCRIPTION
### Relevant information

GTSE https://new-relic.atlassian.net/browse/NR-309927

One customer issued a ticket because the `network error count` and the `http error rate` were not properly displayed in the UI.

In collector, they did some changes to fix the http error rate (which is fixed now, see the image) but the `network error count` should be moved to a `rate`. In fact, the metric used to determine the golden signal is already a rate. 

In collector, they started creating this new golden metric `networkFailuresRateMetric`.

<img width="1429" alt="Screenshot 2024-09-27 at 13 40 59" src="https://github.com/user-attachments/assets/769005b5-1868-4425-aae7-257a00752d00">
