### PR TITLE
fix: Added support for another metric format

### DIFF
--- a/relationships/synthesis/APM-APPLICATION-to-INFRA-MQBROKER.yml
+++ b/relationships/synthesis/APM-APPLICATION-to-INFRA-MQBROKER.yml
@@ -21,7 +21,7 @@ relationships:
             - field: endpoint
               attribute: server.address         
 
-  - name: apmConsumesAwsMqTopic
+  - name: apmConsumesAwsMqBroker
     version: "1"
     origins:
       - Distributed Tracing
@@ -41,4 +41,26 @@ relationships:
           candidateCategory: AWSMQBROKER
           fields:
             - field: endpoint
-              attribute: server.address  
+              attribute: server.address
+
+  - name: apmCallsAwsMqBroker
+    version: "1"
+    origins:
+      - Distributed Tracing
+    conditions:
+      - attribute: eventType
+        anyOf: [ "Span" ]
+      - attribute: name
+        regex: "OtherTransaction/Message/[^/]*/[^/]*"
+    relationship:
+      expires: P75M
+      relationshipType: CALLS
+      source:
+        extractGuid:
+          attribute: entity.guid
+      target:
+        lookupGuid:
+          candidateCategory: AWSMQBROKER
+          fields:
+            - field: endpoint
+              attribute: server.address


### PR DESCRIPTION
### Relevant information

Added support for one more metric format for the relationship between APM and AWS MQ broker

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
