### PR TITLE
chore: Fix issues with memdb golden metrics

### DIFF
--- a/entity-types/infra-awsmemorydbcluster/golden_metrics.yml
+++ b/entity-types/infra-awsmemorydbcluster/golden_metrics.yml
@@ -3,7 +3,7 @@ bytesUsedForMemoryDb:
   unit: BYTES
   queries:
     aws:
-      select: latest(aws.memorydb.BytesUsedForMemoryDB)
+      select: average(aws.memorydb.BytesUsedForMemoryDB)
       from: Metric
       eventId: entity.guid
       eventName: entity.name
@@ -12,7 +12,7 @@ networkPacketsPerSecondAllowanceExceeded:
   unit: COUNT
   queries:
     aws:
-      select: latest(aws.memorydb.NetworkPacketsPerSecondAllowanceExceeded)
+      select: average(aws.memorydb.NetworkPacketsPerSecondAllowanceExceeded)
       from: Metric
       eventId: entity.guid
       eventName: entity.name
@@ -21,7 +21,7 @@ networkBandwidthOutAllowanceExceeded:
   unit: COUNT
   queries:
     aws:
-      select: latest(aws.memorydb.NetworkBandwidthOutAllowanceExceeded)
+      select: average(aws.memorydb.NetworkBandwidthOutAllowanceExceeded)
       from: Metric
       eventId: entity.guid
       eventName: entity.name
@@ -30,7 +30,7 @@ engineCpuUtilization:
   unit: PERCENTAGE
   queries:
     aws:
-      select: latest(aws.memorydb.EngineCPUUtilization)
+      select: average(aws.memorydb.EngineCPUUtilization)
       from: Metric
       eventId: entity.guid
       eventName: entity.name
@@ -39,7 +39,7 @@ replicationBytes:
   unit: BYTES
   queries:
     aws:
-      select: latest(aws.memorydb.ReplicationBytes)
+      select: average(aws.memorydb.ReplicationBytes)
       from: Metric
       eventId: entity.guid
       eventName: entity.name
@@ -48,7 +48,7 @@ networkConntrackAllowanceExceeded:
   unit: COUNT
   queries:
     aws:
-      select: latest(aws.memorydb.NetworkConntrackAllowanceExceeded)
+      select: average(aws.memorydb.NetworkConntrackAllowanceExceeded)
       from: Metric
       eventId: entity.guid
       eventName: entity.name
@@ -57,7 +57,7 @@ replicationLag:
   unit: SECONDS
   queries:
     aws:
-      select: latest(aws.memorydb.ReplicationLag)
+      select: average(aws.memorydb.ReplicationLag)
       from: Metric
       eventId: entity.guid
       eventName: entity.name
@@ -66,7 +66,7 @@ networkBytesIn:
   unit: BYTES
   queries:
     aws:
-      select: latest(aws.memorydb.NetworkBytesIn)
+      select: average(aws.memorydb.NetworkBytesIn)
       from: Metric
       eventId: entity.guid
       eventName: entity.name
@@ -75,7 +75,7 @@ replicationDelayedWriteCommands:
   unit: COUNT
   queries:
     aws:
-      select: latest(aws.memorydb.ReplicationDelayedWriteCommands)
+      select: average(aws.memorydb.ReplicationDelayedWriteCommands)
       from: Metric
       eventId: entity.guid
       eventName: entity.name
@@ -84,7 +84,7 @@ databaseMemoryUsagePercentage:
   unit: PERCENTAGE
   queries:
     aws:
-      select: latest(aws.memorydb.DatabaseMemoryUsagePercentage)
+      select: average(aws.memorydb.DatabaseMemoryUsagePercentage)
       from: Metric
       eventId: entity.guid
       eventName: entity.name


### PR DESCRIPTION
### Relevant information

MemoryDB golden metrics are not showing up properly in the summary page. After some querying I found that getting the 'latest' value isn't working but getting the 'average' I can see the metrics. 

I'm not changing the core of the entity, just updating the queries to use average instead of latest so they appear properly.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
