### PR TITLE
Update definition.yml to remove the metricName condition

### DIFF
--- a/entity-types/ext-nvidia_jetson/definition.yml
+++ b/entity-types/ext-nvidia_jetson/definition.yml
@@ -8,8 +8,6 @@ synthesis:
     conditions:
       - attribute: eventType
         value: jetsonTegrastats
-      - attribute: metricName
-        value: "ram_used"
     tags:
       agentVersion:
         entityTagName: newrelic.agentVersion


### PR DESCRIPTION
Removing unnecessary condition for this definition. metricName was added as a condition but it does not make sense.

### Relevant information

<!--
  Describe what you have done.
  Provide details that are relevant to the PR

  Always think that the person reviewing the PR doesn't have the context you have.

  Links to examples, documentation and similar resources make the process easier to review.
-->

<!--
  Contributions to this repository are reviewed at least twice a week

  There's no further action required once the PR has been created.
 -->

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
