### PR TITLE
feat: Adds synthesis rules for AWS entities out of logs

### DIFF
--- a/entity-types/infra-awsalb/definition.yml
+++ b/entity-types/infra-awsalb/definition.yml
@@ -17,3 +17,44 @@ goldenTags:
 configuration:
   entityExpirationTime: DAILY
   alertable: true
+
+synthesis:
+  rules:
+    # Legacy API Polling entities not using the ARN to compute the entity.guid, but directly providing the entityId
+    - identifier: entityId
+      name: entity.name
+      encodeIdentifierInGUID: false
+      conditions:
+        - attribute: eventType
+          value: Log
+        - attribute: entity.type
+          value: AWSALB
+        - attribute: entityId
+          present: true
+      tags:
+        aws.Arn:
+          entityTagNames: [ aws.arn ]
+        displayName:
+          entityTagNames: [ entity.name ]
+        # These may not be present, but will be included if so
+        aws.accountId:
+        aws.region:
+    # Metrics Streams and API Polling entities using the ARN to compute the entity.guid
+    - identifier: aws.arn
+      name: entity.name
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: eventType
+          value: Log
+        - attribute: entity.type
+          value: AWSALB
+        - attribute: entityId
+          present: false
+      tags:
+        aws.Arn:
+          entityTagNames: [ aws.arn ]
+        displayName:
+          entityTagNames: [ entity.name ]
+        # These may not be present, but will be included if so
+        aws.accountId:
+        aws.region:

--- a/entity-types/infra-awsalb/definition.yml
+++ b/entity-types/infra-awsalb/definition.yml
@@ -34,8 +34,6 @@ synthesis:
       tags:
         aws.Arn:
           entityTagNames: [ aws.arn ]
-        displayName:
-          entityTagNames: [ entity.name ]
         # These may not be present, but will be included if so
         aws.accountId:
         aws.region:
@@ -53,8 +51,6 @@ synthesis:
       tags:
         aws.Arn:
           entityTagNames: [ aws.arn ]
-        displayName:
-          entityTagNames: [ entity.name ]
         # These may not be present, but will be included if so
         aws.accountId:
         aws.region:

--- a/entity-types/infra-awscloudfrontdistribution/definition.yml
+++ b/entity-types/infra-awscloudfrontdistribution/definition.yml
@@ -8,3 +8,48 @@ goldenTags:
 configuration:
   entityExpirationTime: DAILY
   alertable: true
+
+synthesis:
+  rules:
+    # Legacy API Polling entities not using the ARN to compute the entity.guid, but directly providing the entityId
+    - identifier: entityId
+      name: entity.name
+      encodeIdentifierInGUID: false
+      conditions:
+        - attribute: eventType
+          value: Log
+        - attribute: entity.type
+          value: AWSCLOUDFRONTDISTRIBUTION
+        - attribute: entityId
+          present: true
+      tags:
+        aws.Arn:
+          entityTagNames: [ aws.arn ]
+        aws.cloudfront.DistributionId:
+          entityTagNames: [ entity.name ]
+        displayName:
+          entityTagNames: [ entity.name ]
+        # These may not be present, but will be included if so
+        aws.accountId:
+        aws.region:
+    # Metrics Streams and API Polling entities using the ARN to compute the entity.guid
+    - identifier: aws.arn
+      name: entity.name
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: eventType
+          value: Log
+        - attribute: entity.type
+          value: AWSCLOUDFRONTDISTRIBUTION
+        - attribute: entityId
+          present: false
+      tags:
+        aws.Arn:
+          entityTagNames: [ aws.arn ]
+        aws.cloudfront.DistributionId:
+          entityTagNames: [ entity.name ]
+        displayName:
+          entityTagNames: [ entity.name ]
+        # These may not be present, but will be included if so
+        aws.accountId:
+        aws.region:

--- a/entity-types/infra-awscloudfrontdistribution/definition.yml
+++ b/entity-types/infra-awscloudfrontdistribution/definition.yml
@@ -27,8 +27,6 @@ synthesis:
           entityTagNames: [ aws.arn ]
         aws.cloudfront.DistributionId:
           entityTagNames: [ entity.name ]
-        displayName:
-          entityTagNames: [ entity.name ]
         # These may not be present, but will be included if so
         aws.accountId:
         aws.region:
@@ -47,8 +45,6 @@ synthesis:
         aws.Arn:
           entityTagNames: [ aws.arn ]
         aws.cloudfront.DistributionId:
-          entityTagNames: [ entity.name ]
-        displayName:
           entityTagNames: [ entity.name ]
         # These may not be present, but will be included if so
         aws.accountId:

--- a/entity-types/infra-awselb/definition.yml
+++ b/entity-types/infra-awselb/definition.yml
@@ -9,3 +9,48 @@ goldenTags:
 configuration:
   entityExpirationTime: DAILY
   alertable: true
+
+synthesis:
+  rules:
+    # Legacy API Polling entities not using the ARN to compute the entity.guid, but directly providing the entityId
+    - identifier: entityId
+      name: entity.name
+      encodeIdentifierInGUID: false
+      conditions:
+        - attribute: eventType
+          value: Log
+        - attribute: entity.type
+          value: AWSELB
+        - attribute: entityId
+          present: true
+      tags:
+        aws.Arn:
+          entityTagNames: [ aws.arn ]
+        aws.elb.LoadBalancerName:
+          entityTagNames: [ entity.name ]
+        displayName:
+          entityTagNames: [ entity.name ]
+        # These may not be present, but will be included if so
+        aws.accountId:
+        aws.region:
+    # Metrics Streams and API Polling entities using the ARN to compute the entity.guid
+    - identifier: aws.arn
+      name: entity.name
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: eventType
+          value: Log
+        - attribute: entity.type
+          value: AWSELB
+        - attribute: entityId
+          present: false
+      tags:
+        aws.Arn:
+          entityTagNames: [ aws.arn ]
+        aws.elb.LoadBalancerName:
+          entityTagNames: [ entity.name ]
+        displayName:
+          entityTagNames: [ entity.name ]
+        # These may not be present, but will be included if so
+        aws.accountId:
+        aws.region:

--- a/entity-types/infra-awselb/definition.yml
+++ b/entity-types/infra-awselb/definition.yml
@@ -28,8 +28,6 @@ synthesis:
           entityTagNames: [ aws.arn ]
         aws.elb.LoadBalancerName:
           entityTagNames: [ entity.name ]
-        displayName:
-          entityTagNames: [ entity.name ]
         # These may not be present, but will be included if so
         aws.accountId:
         aws.region:
@@ -48,8 +46,6 @@ synthesis:
         aws.Arn:
           entityTagNames: [ aws.arn ]
         aws.elb.LoadBalancerName:
-          entityTagNames: [ entity.name ]
-        displayName:
           entityTagNames: [ entity.name ]
         # These may not be present, but will be included if so
         aws.accountId:

--- a/entity-types/infra-awslambdafunction/definition.yml
+++ b/entity-types/infra-awslambdafunction/definition.yml
@@ -36,8 +36,6 @@ synthesis:
           entityTagNames: [ aws.arn ]
         aws.lambda.FunctionName:
           entityTagNames: [ entity.name ]
-        displayName:
-          entityTagNames: [ entity.name ]
         # These may not be present, but will be included if so
         aws.accountId:
         aws.region:
@@ -57,8 +55,6 @@ synthesis:
         aws.Arn:
           entityTagNames: [ aws.arn ]
         aws.lambda.FunctionName:
-          entityTagNames: [ entity.name ]
-        displayName:
           entityTagNames: [ entity.name ]
         # These may not be present, but will be included if so
         aws.accountId:

--- a/entity-types/infra-awslambdafunction/definition.yml
+++ b/entity-types/infra-awslambdafunction/definition.yml
@@ -16,3 +16,50 @@ goldenTags:
 configuration:
   entityExpirationTime: DAILY
   alertable: true
+
+synthesis:
+  rules:
+    # Legacy API Polling entities not using the ARN to compute the entity.guid, but directly providing the entityId
+    - identifier: entityId
+      name: entity.name
+      encodeIdentifierInGUID: false
+      conditions:
+        - attribute: eventType
+          value: Log
+        - attribute: entity.type
+          value: AWSLAMBDAFUNCTION
+        - attribute: entityId
+          present: true
+      tags:
+        # Used in AWSLAMBDAFUNCTION.yml for entity relationship candidates
+        aws.Arn:
+          entityTagNames: [ aws.arn ]
+        aws.lambda.FunctionName:
+          entityTagNames: [ entity.name ]
+        displayName:
+          entityTagNames: [ entity.name ]
+        # These may not be present, but will be included if so
+        aws.accountId:
+        aws.region:
+    # Metrics Streams and API Polling entities using the ARN to compute the entity.guid
+    - identifier: aws.arn
+      name: entity.name
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: eventType
+          value: Log
+        - attribute: entity.type
+          value: AWSLAMBDAFUNCTION
+        - attribute: entityId
+          present: false
+      tags:
+        # Used in AWSLAMBDAFUNCTION.yml for entity relationship candidates
+        aws.Arn:
+          entityTagNames: [ aws.arn ]
+        aws.lambda.FunctionName:
+          entityTagNames: [ entity.name ]
+        displayName:
+          entityTagNames: [ entity.name ]
+        # These may not be present, but will be included if so
+        aws.accountId:
+        aws.region:

--- a/entity-types/infra-awsnlb/definition.yml
+++ b/entity-types/infra-awsnlb/definition.yml
@@ -33,8 +33,6 @@ synthesis:
       tags:
         aws.Arn:
           entityTagNames: [ aws.arn ]
-        displayName:
-          entityTagNames: [ entity.name ]
         # These may not be present, but will be included if so
         aws.accountId:
         aws.region:
@@ -52,8 +50,6 @@ synthesis:
       tags:
         aws.Arn:
           entityTagNames: [ aws.arn ]
-        displayName:
-          entityTagNames: [ entity.name ]
         # These may not be present, but will be included if so
         aws.accountId:
         aws.region:

--- a/entity-types/infra-awsnlb/definition.yml
+++ b/entity-types/infra-awsnlb/definition.yml
@@ -16,3 +16,44 @@ goldenTags:
 configuration:
   entityExpirationTime: DAILY
   alertable: true
+
+synthesis:
+  rules:
+    # Legacy API Polling entities not using the ARN to compute the entity.guid, but directly providing the entityId
+    - identifier: entityId
+      name: entity.name
+      encodeIdentifierInGUID: false
+      conditions:
+        - attribute: eventType
+          value: Log
+        - attribute: entity.type
+          value: AWSNLB
+        - attribute: entityId
+          present: true
+      tags:
+        aws.Arn:
+          entityTagNames: [ aws.arn ]
+        displayName:
+          entityTagNames: [ entity.name ]
+        # These may not be present, but will be included if so
+        aws.accountId:
+        aws.region:
+    # Metrics Streams and API Polling entities using the ARN to compute the entity.guid
+    - identifier: aws.arn
+      name: entity.name
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: eventType
+          value: Log
+        - attribute: entity.type
+          value: AWSNLB
+        - attribute: entityId
+          present: false
+      tags:
+        aws.Arn:
+          entityTagNames: [ aws.arn ]
+        displayName:
+          entityTagNames: [ entity.name ]
+        # These may not be present, but will be included if so
+        aws.accountId:
+        aws.region:

--- a/entity-types/infra-awsrdsdbinstance/definition.yml
+++ b/entity-types/infra-awsrdsdbinstance/definition.yml
@@ -25,8 +25,6 @@ synthesis:
           entityTagNames: [aws.arn]
         aws.rds.DBInstanceIdentifier:
           entityTagNames: [entity.name]
-        displayName:
-          entityTagNames: [entity.name]
         # These may not be present, but will be included if so
         aws.accountId:
         aws.region:
@@ -45,8 +43,6 @@ synthesis:
         aws.Arn:
           entityTagNames: [aws.arn]
         aws.rds.DBInstanceIdentifier:
-          entityTagNames: [entity.name]
-        displayName:
           entityTagNames: [entity.name]
         # These may not be present, but will be included if so
         aws.accountId:

--- a/entity-types/infra-awsrdsdbinstance/definition.yml
+++ b/entity-types/infra-awsrdsdbinstance/definition.yml
@@ -6,3 +6,48 @@ goldenTags:
 configuration:
   entityExpirationTime: DAILY
   alertable: true
+
+synthesis:
+  rules:
+    # Legacy API Polling entities not using the ARN to compute the entity.guid, but directly providing the entityId
+    - identifier: entityId
+      name: entity.name
+      encodeIdentifierInGUID: false
+      conditions:
+        - attribute: eventType
+          value: Log
+        - attribute: entity.type
+          value: AWSRDSDBINSTANCE
+        - attribute: entityId
+          present: true
+      tags:
+        aws.Arn:
+          entityTagNames: [aws.arn]
+        aws.rds.DBInstanceIdentifier:
+          entityTagNames: [entity.name]
+        displayName:
+          entityTagNames: [entity.name]
+        # These may not be present, but will be included if so
+        aws.accountId:
+        aws.region:
+    # Metrics Streams and API Polling entities using the ARN to compute the entity.guid
+    - identifier: aws.arn
+      name: entity.name
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: eventType
+          value: Log
+        - attribute: entity.type
+          value: AWSRDSDBINSTANCE
+        - attribute: entityId
+          present: false
+      tags:
+        aws.Arn:
+          entityTagNames: [aws.arn]
+        aws.rds.DBInstanceIdentifier:
+          entityTagNames: [entity.name]
+        displayName:
+          entityTagNames: [entity.name]
+        # These may not be present, but will be included if so
+        aws.accountId:
+        aws.region:

--- a/entity-types/infra-awss3bucket/definition.yml
+++ b/entity-types/infra-awss3bucket/definition.yml
@@ -13,3 +13,52 @@ dashboardTemplates:
 configuration:
   entityExpirationTime: DAILY
   alertable: true
+
+synthesis:
+  rules:
+    # Legacy API Polling entities not using the ARN to compute the entity.guid, but directly providing the entityId
+    - identifier: entityId
+      name: entity.name
+      encodeIdentifierInGUID: false
+      conditions:
+        - attribute: eventType
+          value: Log
+        - attribute: entity.type
+          value: AWSS3BUCKET
+        - attribute: entityId
+          present: true
+      tags:
+        # Used in AWSS3BUCKET.yml for entity relationship candidates
+        aws.Arn:
+          entityTagNames: [ aws.arn ]
+        # Used in AWSS3BUCKET.yml for entity relationship candidates
+        aws.s3.BucketName:
+          entityTagNames: [entity.name]
+        displayName:
+          entityTagNames: [entity.name]
+        # These may not be present, but will be included if so
+        aws.accountId:
+        aws.region:
+    # Metrics Streams and API Polling entities using the ARN to compute the entity.guid
+    - identifier: aws.arn
+      name: entity.name
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: eventType
+          value: Log
+        - attribute: entity.type
+          value: AWSS3BUCKET
+        - attribute: entityId
+          present: false
+      tags:
+        # Used in AWSS3BUCKET.yml for entity relationship candidates
+        aws.Arn:
+          entityTagNames: [ aws.arn ]
+        # Used in AWSS3BUCKET.yml for entity relationship candidates
+        aws.s3.BucketName:
+          entityTagNames: [entity.name]
+        displayName:
+          entityTagNames: [entity.name]
+        # These may not be present, but will be included if so
+        aws.accountId:
+        aws.region:

--- a/entity-types/infra-awss3bucket/definition.yml
+++ b/entity-types/infra-awss3bucket/definition.yml
@@ -34,8 +34,6 @@ synthesis:
         # Used in AWSS3BUCKET.yml for entity relationship candidates
         aws.s3.BucketName:
           entityTagNames: [entity.name]
-        displayName:
-          entityTagNames: [entity.name]
         # These may not be present, but will be included if so
         aws.accountId:
         aws.region:
@@ -56,8 +54,6 @@ synthesis:
           entityTagNames: [ aws.arn ]
         # Used in AWSS3BUCKET.yml for entity relationship candidates
         aws.s3.BucketName:
-          entityTagNames: [entity.name]
-        displayName:
           entityTagNames: [entity.name]
         # These may not be present, but will be included if so
         aws.accountId:

--- a/entity-types/infra-awssqsqueue/definition.yml
+++ b/entity-types/infra-awssqsqueue/definition.yml
@@ -8,3 +8,52 @@ goldenTags:
 configuration:
   entityExpirationTime: DAILY
   alertable: true
+
+synthesis:
+  rules:
+    # Legacy API Polling entities not using the ARN to compute the entity.guid, but directly providing the entityId
+    - identifier: entityId
+      name: entity.name
+      encodeIdentifierInGUID: false
+      conditions:
+        - attribute: eventType
+          value: Log
+        - attribute: entity.type
+          value: AWSSQSQUEUE
+        - attribute: entityId
+          present: true
+      tags:
+        aws.Arn:
+          entityTagNames: [ aws.arn ]
+        # Used in AWSSQSQUEUE.yml for entity relationship candidates
+        aws.sqs.QueueName:
+          entityTagNames: [ entity.name ]
+        displayName:
+          entityTagNames: [ entity.name ]
+        # Used in AWSSQSQUEUE.yml for entity relationship candidates
+        aws.accountId:
+        # Used in AWSSQSQUEUE.yml for entity relationship candidates
+        aws.region:
+    # Metrics Streams and API Polling entities using the ARN to compute the entity.guid
+    - identifier: aws.arn
+      name: entity.name
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: eventType
+          value: Log
+        - attribute: entity.type
+          value: AWSSQSQUEUE
+        - attribute: entityId
+          present: false
+      tags:
+        aws.Arn:
+          entityTagNames: [ aws.arn ]
+        # Used in AWSSQSQUEUE.yml for entity relationship candidates
+        aws.sqs.QueueName:
+          entityTagNames: [ entity.name ]
+        displayName:
+          entityTagNames: [ entity.name ]
+        # Used in AWSSQSQUEUE.yml for entity relationship candidates
+        aws.accountId:
+        # Used in AWSSQSQUEUE.yml for entity relationship candidates
+        aws.region:

--- a/entity-types/infra-awssqsqueue/definition.yml
+++ b/entity-types/infra-awssqsqueue/definition.yml
@@ -28,8 +28,6 @@ synthesis:
         # Used in AWSSQSQUEUE.yml for entity relationship candidates
         aws.sqs.QueueName:
           entityTagNames: [ entity.name ]
-        displayName:
-          entityTagNames: [ entity.name ]
         # Used in AWSSQSQUEUE.yml for entity relationship candidates
         aws.accountId:
         # Used in AWSSQSQUEUE.yml for entity relationship candidates
@@ -50,8 +48,6 @@ synthesis:
           entityTagNames: [ aws.arn ]
         # Used in AWSSQSQUEUE.yml for entity relationship candidates
         aws.sqs.QueueName:
-          entityTagNames: [ entity.name ]
-        displayName:
           entityTagNames: [ entity.name ]
         # Used in AWSSQSQUEUE.yml for entity relationship candidates
         aws.accountId:

--- a/entity-types/infra-host/definition.yml
+++ b/entity-types/infra-host/definition.yml
@@ -309,8 +309,6 @@ synthesis:
         # Used in AWSEC2.yml for entity relationship candidates
         aws.ec2.InstanceId:
           entityTagNames: [ entity.name ]
-        displayName:
-          entityTagNames: [ entity.name ]
         # These may not be present, but will be included if so
         aws.accountId:
         aws.region:
@@ -331,8 +329,6 @@ synthesis:
           entityTagNames: [ aws.arn ]
         # Used in AWSEC2.yml for entity relationship candidates
         aws.ec2.InstanceId:
-          entityTagNames: [ entity.name ]
-        displayName:
           entityTagNames: [ entity.name ]
         # These may not be present, but will be included if so
         aws.accountId:

--- a/entity-types/infra-host/definition.yml
+++ b/entity-types/infra-host/definition.yml
@@ -291,6 +291,52 @@ synthesis:
         nodename:
           entityTagNames: [hostname]
         instrumentation.provider:
+    # AWS EC2 host synthesized via ElasticBeanstalk logs
+    # Legacy API Polling entities not using the ARN to compute the entity.guid, but directly providing the entityId
+    - identifier: entityId
+      name: entity.name
+      encodeIdentifierInGUID: false
+      conditions:
+        - attribute: eventType
+          value: Log
+        - attribute: entity.type
+          value: HOST
+        - attribute: entityId
+          present: true
+      tags:
+        aws.Arn:
+          entityTagNames: [ aws.arn ]
+        # Used in AWSEC2.yml for entity relationship candidates
+        aws.ec2.InstanceId:
+          entityTagNames: [ entity.name ]
+        displayName:
+          entityTagNames: [ entity.name ]
+        # These may not be present, but will be included if so
+        aws.accountId:
+        aws.region:
+    # AWS EC2 host synthesized via ElasticBeanstalk logs
+    # Metrics Streams and API Polling entities using the ARN to compute the entity.guid
+    - identifier: aws.arn
+      name: entity.name
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: eventType
+          value: Log
+        - attribute: entity.type
+          value: HOST
+        - attribute: entityId
+          present: false
+      tags:
+        aws.Arn:
+          entityTagNames: [ aws.arn ]
+        # Used in AWSEC2.yml for entity relationship candidates
+        aws.ec2.InstanceId:
+          entityTagNames: [ entity.name ]
+        displayName:
+          entityTagNames: [ entity.name ]
+        # These may not be present, but will be included if so
+        aws.accountId:
+        aws.region:
 configuration:
   entityExpirationTime: EIGHT_DAYS
   alertable: true


### PR DESCRIPTION
### Relevant information

This PR adds entity synthesis rules out of logs for the following entity types: `AWSRDSDBINSTANCE`, `AWSS3BUCKET`, `AWSALB`, `AWSELB`, `AWSNLB`, `AWSLAMBDAFUNCTION`, `AWSDCLOUDFRONTDISTRIBUTION`, `AWSSQSQUEUE`, `HOST` (EC2).

The Logs pipeline will infer the `aws.arn` attribute and include it together with the `entity.name` and `entity.type` attributes to the log prior to the synthesis step. This is why they are used as regular attributes to name the entity and in the synthesis rule conditions. These attributes, together with the resulting `entity.guid`, will be included in the log sent downstream for the materialization process to happen.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
