### PR TITLE
Update expected ARN pattern

### DIFF
--- a/relationships/synthesis/APM-APPLICATION-to-INFRA-KINESISSTREAM.yml
+++ b/relationships/synthesis/APM-APPLICATION-to-INFRA-KINESISSTREAM.yml
@@ -9,7 +9,7 @@ relationships:
       - attribute: cloud.platform
         anyOf: [ "aws_kinesis_data_streams"]
       - attribute: cloud.resource_id
-        regex: "^arn:aws:kinesis:([^:]*):([^:]*):stream:([^:]*)"
+        regex: "^arn:aws:kinesis:([^:]*):([^:]*):stream\/([^:]*)"
     relationship:
       expires: P75M
       relationshipType: CALLS


### PR DESCRIPTION
The relationship for APM and kinesis stream relies on an ARN to make the connection. The ARN pattern in the yml file doesn't seem to make what is expected. 

The current pattern is expecting a `:` after the word `stream`, but a `/` is what is expected. 

The [PR that added this file](https://github.com/newrelic/entity-definitions/pull/1774) notes in the description the expected pattern: `arn:${realm}:kinesis:${region}:${accountId}:stream/${StreamName}`

This PR updates the pattern to match. 
 

