### PR TITLE
Entity definition for Media streaming video type entity

### DIFF
--- a/entity-types/media_streaming-video/definition.yml
+++ b/entity-types/media_streaming-video/definition.yml
@@ -25,4 +25,4 @@ goldenTags:
   - deviceModel
 configuration:
   alertable: true
-  entityExpirationTime: QUARTERLY
+  entityExpirationTime: EIGHT_DAYS

--- a/entity-types/media_streaming-video/definition.yml
+++ b/entity-types/media_streaming-video/definition.yml
@@ -1,0 +1,28 @@
+domain: MEDIA_STREAMING
+type: VIDEO
+synthesis:
+  rules:
+    # telemetry with Video* eventType
+    - identifier: appName
+      name: appName
+      encodeIdentifierInGUID: false
+      conditions:
+        - attribute: eventType
+          prefix: Video
+      tags:
+        playerName:
+        playerVersion:
+        deviceType:
+        deviceGroup:
+        deviceManufacturer:
+        deviceModel:
+goldenTags:
+  - playerName
+  - playerVersion
+  - deviceType
+  - deviceGroup
+  - deviceManufacturer
+  - deviceModel
+configuration:
+  alertable: true
+  entityExpirationTime: QUARTERLY


### PR DESCRIPTION
### Relevant information

As media streaming video agent would be ingesting `Video*` event types, We have added this definition for curating media streaming of type video entity from the telemetry being ingested by the media-streaming agents. 

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
