### PR TITLE
Fix tags in AWSSQSQUEUE entity

### DIFF
--- a/docs/entities/synthesis.md
+++ b/docs/entities/synthesis.md
@@ -181,6 +181,18 @@ synthesis:
 
 You can also change the name of the tag to another value, rather than using the name in the attribute. In general, we suggest not to use this configuration unless you are trying to use more standard namings, since sometimes it's difficult for the user to see the difference between entity tags and telemetry attributes, and changing the names could cause even more confusion.
 
+This is the relevant syntax:
+```yaml
+synthesis:
+  rules:
+  - identifier: someIdAttribute
+    name: someNameAttribute
+    tags:
+      originalAttributeName:
+        entityTagNames: [desiredTagName1, desiredTagName2]
+```
+The above example will result in an entity having two tags, `desiredTagName1` and `desiredTagName2`, with the value present in the `originalAttributeName` attribute from the processed data point.
+
 A good use case for this feature is `CONTAINER`: A container has different sources (docker, kubernetes, etc.), and we rename the tags to use a standard naming and a "per source" name.
 
 ```yaml

--- a/entity-types/infra-awssqsqueue/definition.yml
+++ b/entity-types/infra-awssqsqueue/definition.yml
@@ -30,11 +30,11 @@ synthesis:
         # Used in AWSSQSQUEUE.yml for entity relationship candidates
         aws.sqs.QueueName:
         # Used in AWSSQSQUEUE.yml for entity relationship candidates
-        aws.accountId:
-          entityTagNames: [ recipientAccountId ]
+        recipientAccountId:
+          entityTagNames: [ aws.accountId ]
         # Used in AWSSQSQUEUE.yml for entity relationship candidates
-        aws.region:
-          entityTagNames: [ awsRegion ]
+        awsRegion:
+          entityTagNames: [ aws.region ]
     # Metrics Streams and API Polling entities using the ARN to compute the entity.guid
     - identifier: aws.Arn
       name: aws.sqs.QueueName
@@ -54,8 +54,8 @@ synthesis:
         # Used in AWSSQSQUEUE.yml for entity relationship candidates
         aws.sqs.QueueName:
         # Used in AWSSQSQUEUE.yml for entity relationship candidates
-        aws.accountId:
-          entityTagNames: [ recipientAccountId ]
+        recipientAccountId:
+          entityTagNames: [ aws.accountId ]
         # Used in AWSSQSQUEUE.yml for entity relationship candidates
-        aws.region:
-          entityTagNames: [ awsRegion ]
+        awsRegion:
+          entityTagNames: [ aws.region ]


### PR DESCRIPTION
### Relevant information

In this [previous PR](https://github.com/newrelic/entity-definitions/pull/1785), I introduced a synthesis rule for the `AWSSQSQUEUE` entity type that incorrectly extracted some tags. This PR fixes it and also enhances the documentation to avoid this misunderstanding.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [-] The value of the attribute marked as `identifier` will be unique and valid. 
* [-] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
