### PR TITLE
Introduce a new candidate category for HTTP services

### DIFF
--- a/entity-types/uninstrumented-httpservice/definition.yml
+++ b/entity-types/uninstrumented-httpservice/definition.yml
@@ -1,0 +1,6 @@
+domain: UNINSTRUMENTED
+type: HTTPSERVICE
+
+configuration:
+  entityExpirationTime: FOUR_HOURS
+  alertable: false

--- a/relationships/candidates/HTTPSERVICE.yml
+++ b/relationships/candidates/HTTPSERVICE.yml
@@ -1,0 +1,18 @@
+category: HTTPSERVICE
+lookups:
+  - entityTypes:
+    - domain: APM
+      type: APPLICATION
+    - domain: EXT
+      type: SERVICE
+    tags:
+      matchingMode: ALL
+      predicates:
+        - tagKeys: ["nr.endpointHostname"]
+          field: hostname
+    onMatch:
+     onMultipleMatches: RELATE_ALL
+    onMiss:
+      action: CREATE_UNINSTRUMENTED
+      uninstrumented:
+        type: HTTPSERVICE


### PR DESCRIPTION
### Relevant information

This PR introduces a new candidate category for HTTP services and its corresponding uninstrumented entity definition.
This category will be used internally, so there won't be any synthesis rule associated to it.

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
