### PR TITLE
fix: Fixes ALB, NLB and ELB definitions

### DIFF
--- a/entity-types/infra-awsalb/definition.yml
+++ b/entity-types/infra-awsalb/definition.yml
@@ -29,6 +29,8 @@ synthesis:
           prefix: Log
         - attribute: aws.Arn
           present: true
+        - attribute: aws.alb.loadBalancer
+          present: true
         - attribute: entityId
           present: true
       tags:
@@ -41,6 +43,8 @@ synthesis:
         - attribute: eventType
           prefix: Log
         - attribute: aws.Arn
+          present: true
+        - attribute: aws.alb.loadBalancer
           present: true
         - attribute: entityId
           present: false

--- a/entity-types/infra-awselb/definition.yml
+++ b/entity-types/infra-awselb/definition.yml
@@ -21,6 +21,8 @@ synthesis:
           prefix: Log
         - attribute: aws.Arn
           present: true
+        - attribute: aws.elb.loadBalancer
+          present: true
         - attribute: entityId
           present: true
       tags:
@@ -35,6 +37,8 @@ synthesis:
         - attribute: eventType
           prefix: Log
         - attribute: aws.Arn
+          present: true
+        - attribute: aws.elb.loadBalancer
           present: true
         - attribute: entityId
           present: false

--- a/entity-types/infra-awsnlb/definition.yml
+++ b/entity-types/infra-awsnlb/definition.yml
@@ -28,6 +28,8 @@ synthesis:
           prefix: Log
         - attribute: aws.Arn
           present: true
+        - attribute: aws.nlb.loadBalancer
+          present: true
         - attribute: entityId
           present: true
       tags:
@@ -40,6 +42,8 @@ synthesis:
         - attribute: eventType
           prefix: Log
         - attribute: aws.Arn
+          present: true
+        - attribute: aws.nlb.loadBalancer
           present: true
         - attribute: entityId
           present: false


### PR DESCRIPTION
### Relevant information

I believe that these rules that were modified [here](https://github.com/newrelic/entity-definitions/pull/1791/files#diff-d7c8eedfd84ca7402cefbce12cfcdb6da85d3a58c49cf184915ad6f3432e16af) are having an impact to the rest of AWS synthesis rules, so I'm adding back the check for these specific attributes.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
