### PR TITLE
fix(NR-313566): Team and TeamOrganizationSettings aren't alertable

### DIFF
--- a/entity-types/ngep-team/definition.yml
+++ b/entity-types/ngep-team/definition.yml
@@ -3,4 +3,4 @@ type: TEAM
 
 configuration:
   entityExpirationTime: MANUAL
-  alertable: true
+  alertable: false

--- a/entity-types/ngep-teams_organization_settings/definition.yml
+++ b/entity-types/ngep-teams_organization_settings/definition.yml
@@ -3,4 +3,4 @@ type: TEAMS_ORGANIZATION_SETTINGS
 
 configuration:
   entityExpirationTime: MANUAL
-  alertable: true
+  alertable: false


### PR DESCRIPTION
### Relevant information

<!--
  Describe what you have done.
  Provide details that are relevant to the PR

  Always think that the person reviewing the PR doesn't have the context you have.

  Links to examples, documentation and similar resources make the process easier to review.
-->

<!--
  Contributions to this repository are reviewed at least twice a week

  There's no further action required once the PR has been created.
 -->

The `Team` and `TeamOrganizationSettings` entity type aren't alertable. The current gen [EXT-TEAM](https://github.com/newrelic/entity-definitions/blob/main/entity-types/ext-team/definition.yml) entity type isn't alertable either.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
