### PR TITLE
changed lambda expiration to quarterly

### DIFF
--- a/entity-types/infra-awslambdafunction/definition.yml
+++ b/entity-types/infra-awslambdafunction/definition.yml
@@ -14,7 +14,7 @@ goldenTags:
 - label.env
 - label.environment
 configuration:
-  entityExpirationTime: DAILY
+  entityExpirationTime: QUARTERLY
   alertable: true
 
 synthesis:


### PR DESCRIPTION
**What is the problem the customer is trying to solve?**

There are many functions that invoke infrequently. They expect the associated entities to stick around in New Relic for at least [as long as APM entities](https://github.com/newrelic/entity-definitions/blob/19401c852e528dbbdc5a5347957b52dbf9d64b77/entity-types/apm-application/definition.yml#L34)
, which is quarterly.

**Why is it important for users that we fix that problem?**

Lambda function entities that get [deleted after 24 hours](https://github.com/newrelic/entity-definitions/blob/19401c852e528dbbdc5a5347957b52dbf9d64b77/entity-types/infra-awslambdafunction/definition.yml#L17)
lose tags and other entity-related data. It makes alerting on these entities difficult/impossible.

**What is the objective they are pursuing?**

Make infrequently invoked functions more useable in New Relic.

**How does the ideal solution look for them?**

Change the entityExpirationTime for Lambda functions to the same as APM entities (quarterly).


Related to this issue 
https://github.com/newrelic/entity-definitions/issues/1792


### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
