### PR TITLE
Fix typo in HTTPSERVICE candidate category

### DIFF
--- a/relationships/candidates/HTTPSERVICE.yml
+++ b/relationships/candidates/HTTPSERVICE.yml
@@ -8,7 +8,7 @@ lookups:
     tags:
       matchingMode: ANY
       predicates:
-        - tagKeys: ["nr.endpointHostname", ""endpointHostname""]
+        - tagKeys: ["nr.endpointHostname", "endpointHostname"]
           field: hostname
     onMatch:
      onMultipleMatches: RELATE_ALL


### PR DESCRIPTION
### Relevant information

Fix typo in HTTPSERVICE candidate category

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
