### PR TITLE
chore: Update EXT-SERVICE-to-INFRA-DYNAMODBTABLE.yml to allow lowercase attribute name matching

### DIFF
--- a/relationships/synthesis/EXT-SERVICE-to-INFRA-DYNAMODBTABLE.yml
+++ b/relationships/synthesis/EXT-SERVICE-to-INFRA-DYNAMODBTABLE.yml
@@ -29,7 +29,7 @@ relationships:
       - attribute: eventType
         anyOf: [ "Span" ]
       - attribute: db.system
-        anyOf: [ "DynamoDB" ]
+        anyOf: [ "DynamoDB", "dynamodb" ]
     relationship:
       expires: P75M
       relationshipType: CALLS


### PR DESCRIPTION
### Relevant information

Allow the `db.system` attribute to match either `DynamoDB` or `dynamodb` -- the latter is emitted by the .NET agent (and any other APM agents that are also following OTel symantic conventions, which dictate that all attribute values should be lower case.)

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
