### PR TITLE
fix: Fixes AWSSQSQUEUE synthesis rules

### DIFF
--- a/entity-types/infra-awssqsqueue/definition.yml
+++ b/entity-types/infra-awssqsqueue/definition.yml
@@ -16,8 +16,10 @@ synthesis:
       name: aws.sqs.QueueName
       encodeIdentifierInGUID: false
       conditions:
-        - attribute: eventType
-          prefix: Log
+        - attribute: eventSource
+          value: sqs.amazonaws.com
+        - attribute: eventName
+          present: true
         - attribute: aws.Arn
           present: true
         - attribute: aws.sqs.QueueName
@@ -40,8 +42,10 @@ synthesis:
       name: aws.sqs.QueueName
       encodeIdentifierInGUID: true
       conditions:
-        - attribute: eventType
-          prefix: Log
+        - attribute: eventSource
+          value: sqs.amazonaws.com
+        - attribute: eventName
+          present: true
         - attribute: aws.Arn
           present: true
         - attribute: aws.sqs.QueueName


### PR DESCRIPTION
### Relevant information

The AWSSQSQUEUE entity definition included a rule that verified that the telemetry data point was coming from an `eventType` that starts with `Log` (to be able to support data partitions such as `Log_MyDataPartition`).

Nevertheless, logs originated from CloudTrail (this is where SQS logs come from) also include an `eventType` attribute (with value `AwsApiCall`). Because the `eventType` attribute is a reserved keyword by NRDB, this attribute is removed _after_ the entity synthesis step in the Logs pipeline. However, the entity synthesis step still observes it with `eventType: AwsApiCall`.

This PR modifies the existing synthesis rules to not rely on the `eventType` attributes at all. Instead, it verifies that `eventSource` is `sqs.amazonaws.com` (this is the value set by CloudTrail to events originated from SQS) and that `eventName` is present. The Logging Pipeline will be the one including `aws.sqs.QueueName` and optionally `entityId`, so if these are present it is basically as saying "if the logs came from the Logging Pipeline".

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
