### PR TITLE
Include all db entity types in `DATABASE` candidate category

### DIFF
--- a/relationships/candidates/DATABASE.yml
+++ b/relationships/candidates/DATABASE.yml
@@ -5,10 +5,44 @@ lookups:
       type: AWSRDSDBCLUSTER
     - domain: INFRA
       type: AWSRDSDBINSTANCE
+    - domain: INFRA
+      type: AZURESQLDATABASE
+    - domain: INFRA
+      type: AZURESQLSERVER
+    - domain: INFRA
+      type: AZUREPOSTGRESQLFLEXIBLESERVER
+    - domain: INFRA
+      type: AZURESQLELASTICPOOL
+    - domain: INFRA
+      type: AZUREPOSTGRESQLSERVER
+    - domain: INFRA
+      type: AZURESQLMANAGEDINSTANCE
+    - domain: INFRA
+      type: AZUREMYSQLFLEXIBLESERVER
+    - domain: INFRA
+      type: AZUREMYSQLSERVER
+    - domain: INFRA
+      type: AZUREMARIADBSERVER
+    - domain: INFRA
+      type: GCPCLOUDSQL
+    - domain: INFRA
+      type: GCPALLOYDBDATABASE
+    - domain: INFRA
+      type: GCPALLOYDBINSTANCE
+    - domain: INFRA
+      type: GCPALLOYDBCLUSTER
+    - domain: INFRA
+      type: MSSQLINSTANCE
+    - domain: INFRA
+      type: MYSQLNODE
+    - domain: INFRA
+      type: POSTGRESQLINSTANCE
+    - domain: INFRA
+      type: ORACLEDBINSTANCE
     tags:
       matchingMode: ANY
       predicates:
-        - tagKeys: ["aws.endpoint", "aws.readerEndpoint", "aws.customEndpoints", "aws.rds.endpoint", "aws.rds.readerEndpoint", "aws.rds.customEndpoints"]
+        - tagKeys: ["endpoint", "nr.endpoint", "aws.endpoint", "aws.readerEndpoint", "aws.customEndpoints", "aws.rds.endpoint", "aws.rds.readerEndpoint", "aws.rds.customEndpoints"]
           field: endpoint
     onMatch:
      onMultipleMatches: RELATE_ALL


### PR DESCRIPTION
Also include both `endpoint` and `nr.endpoint` as lookup tags

### Relevant information

Include all db entity types in `DATABASE` candidate category and also include both `endpoint` and `nr.endpoint` as lookup tags so (potentially) any uninstrumented db could be resolved using manual tagging.

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
