### PR TITLE
add: Add cumulative layout shift (75 percentile) metric to golden metrics

### DIFF
--- a/entity-types/browser-application/golden_metrics.yml
+++ b/entity-types/browser-application/golden_metrics.yml
@@ -22,6 +22,14 @@ interactionToNextPaint75PercentileS:
     from: PageViewTiming
     eventId: entityGuid
     eventName: appName
+cumulativeLayoutShift75Percentile:
+  title: Cumulative layout shift (75 percentile)
+  unit: NUMBER
+  query:
+    select: percentile(cumulativeLayoutShift, 75)
+    from: PageViewTiming
+    eventId: entityGuid
+    eventName: appName
 errors:
   title: Errors
   unit: COUNT

--- a/entity-types/browser-application/golden_metrics.yml
+++ b/entity-types/browser-application/golden_metrics.yml
@@ -22,7 +22,7 @@ interactionToNextPaint75PercentileS:
     from: PageViewTiming
     eventId: entityGuid
     eventName: appName
-cumulativeLayoutShift75Percentile:
+cumulativeLayoutShift75PercentileS:
   title: Cumulative layout shift (75 percentile)
   unit: NUMBER
   query:

--- a/entity-types/browser-application/summary_metrics.yml
+++ b/entity-types/browser-application/summary_metrics.yml
@@ -10,6 +10,10 @@ interactionToNextPaint75PercentileS:
   goldenMetric: interactionToNextPaint75PercentileS
   unit: SECONDS
   title: Interaction to next paint (75 percentile) (s)
+cumulativeLayoutShift75PercentileS:
+  goldenMetric: cumulativeLayoutShift75PercentileS
+  unit: NUMBER
+  title: Cumulative layout shift (75 percentile)
 errors:
   goldenMetric: errors
   unit: COUNT

--- a/validator/schemas/golden-metrics-schema-v1.json
+++ b/validator/schemas/golden-metrics-schema-v1.json
@@ -56,7 +56,7 @@
         "$id": "#/properties/unit",
         "type": "string",
         "title": "The unit of the metric",
-        "enum": ["REQUESTS_PER_SECOND", "REQUESTS_PER_MINUTE", "PAGES_PER_SECOND", "MESSAGES_PER_SECOND", "OPERATIONS_PER_SECOND", "COUNT", "SECONDS", "MS", "PERCENTAGE", "BITS", "BYTES", "BITS_PER_SECOND", "BYTES_PER_SECOND", "HERTZ", "APDEX", "TIMESTAMP", "CELSIUS"],
+        "enum": ["REQUESTS_PER_SECOND", "REQUESTS_PER_MINUTE", "PAGES_PER_SECOND", "MESSAGES_PER_SECOND", "OPERATIONS_PER_SECOND", "COUNT", "SECONDS", "MS", "PERCENTAGE", "BITS", "BYTES", "BITS_PER_SECOND", "BYTES_PER_SECOND", "HERTZ", "APDEX", "TIMESTAMP", "CELSIUS", "NUMBER"],
         "examples": [
           "COUNT"
         ]


### PR DESCRIPTION
### Relevant information


The Browser is extending the support of CLS (Cumulative Layout Shift ) a core web vital which is missing as the other two are already added. 

Ticket : [https://new-relic.atlassian.net/browse/NR-328461](https://new-relic.atlassian.net/browse/NR-328461)


<!--
  Contributions to this repository are reviewed at least twice a week

  There's no further action required once the PR has been created.
 -->

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
