### PR TITLE
fix: changed source of telemetry for fluent bit relationships

### DIFF
--- a/relationships/synthesis/INFRA-HOST-to-EXT-FLUENTBIT_HOST.yml
+++ b/relationships/synthesis/INFRA-HOST-to-EXT-FLUENTBIT_HOST.yml
@@ -2,7 +2,7 @@ relationships:
   - name: hostHostsFluentbit
     version: "1"
     origins: 
-      - Prometheus
+      - Metric API
     conditions:
       - attribute: eventType
         anyOf: [ "Metric" ]

--- a/relationships/synthesis/INFRA-KUBERNETES_DAEMONSET-to-EXT-FLUENTBIT_KUBERNETES.yml
+++ b/relationships/synthesis/INFRA-KUBERNETES_DAEMONSET-to-EXT-FLUENTBIT_KUBERNETES.yml
@@ -2,7 +2,7 @@ relationships:
   - name: k8sDaemonSetManagesFluentbit
     version: "1"
     origins: 
-      - Prometheus
+      - Metric API
     conditions:
       - attribute: eventType
         anyOf: [ "Metric" ]
@@ -50,7 +50,7 @@ relationships:
   - name: otelKsmK8sDaemonSetManagesFluentbit
     version: "1"
     origins: 
-      - Prometheus
+      - Metric API
     conditions:
       - attribute: eventType
         anyOf: [ "Metric" ]


### PR DESCRIPTION
### Relevant information

This PR attempts to change the source of telemetry of fluent bit entity relationship to allow creation of relationship

### Checklist

* [X] I've read the guidelines and understand the acceptance criteria.
* [X] The value of the attribute marked as `identifier` will be unique and valid. 
* [X] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
