### PR TITLE
Add a generic rule for APM->DB relationships

### DIFF
--- a/relationships/synthesis/APM-APPLICATION-to-DATABASE.yml
+++ b/relationships/synthesis/APM-APPLICATION-to-DATABASE.yml
@@ -37,3 +37,22 @@ relationships:
           fields:
             - field: endpoint
               attribute: metricName__4
+  - name: apmCallsGenericDatabase
+    version: "1"
+    origins:
+      - APM Metrics
+    conditions:
+      - attribute: metricName
+        regex: "^datastore/instance/(?:mysql|postgres|mssql|oracle|mariadb|jdbc)/[^/;]*/.*"
+    relationship:
+      expires: P75M
+      relationshipType: CALLS
+      source:
+        extractGuid:
+          attribute: entity.guid
+      target:
+        lookupGuid:
+          candidateCategory: DATABASE
+          fields:
+            - field: endpoint
+              attribute: metricName__4


### PR DESCRIPTION
### Relevant information

This new rule allows any hostname as DB endpoint, not limiting it to RDS.
It includes a more strict regex which only includes those providers that are supported in the `DATABASE` candidate category. The regex also filters out those unsupported metric names that contain a `;` in the endpoint (legacy format to concat different endpoints in a single metric).

This new rule, which will be internally rolled out, will eventually replace the two other rules present in the file.

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
