### PR TITLE
fix: fix infra-host definition so it uses the EC2 instanceId as the identifier of the entity

### DIFF
--- a/entity-types/infra-host/definition.yml
+++ b/entity-types/infra-host/definition.yml
@@ -292,27 +292,7 @@ synthesis:
           entityTagNames: [hostname]
         instrumentation.provider:
     # AWS EC2 host synthesized via ElasticBeanstalk logs
-    # Legacy API Polling entities not using the ARN to compute the entity.guid, but directly providing the entityId
-    - identifier: entityId
-      name: aws.ec2.InstanceId
-      encodeIdentifierInGUID: false
-      legacyFeatures:
-        overrideGuidType: true
-      conditions:
-        - attribute: eventType
-          prefix: Log
-        - attribute: aws.Arn
-          present: true
-        - attribute: aws.ec2.InstanceId
-          present: true
-        - attribute: entityId
-          present: true
-      tags:
-        aws.Arn:
-        # Used in AWSEC2.yml for entity relationship candidates
-        aws.ec2.InstanceId:
-    # AWS EC2 host synthesized via ElasticBeanstalk logs
-    # Metrics Streams and API Polling entities using the ARN to compute the entity.guid
+    # Metrics Streams and API Polling entities use the instanceId to compute the entity.guid
     - identifier: aws.ec2.InstanceId
       name: aws.ec2.InstanceId
       encodeIdentifierInGUID: true
@@ -325,8 +305,6 @@ synthesis:
           present: true
         - attribute: aws.ec2.InstanceId
           present: true
-        - attribute: entityId
-          present: false
       tags:
         aws.Arn:
         # Used in AWSEC2.yml for entity relationship candidates

--- a/entity-types/infra-host/definition.yml
+++ b/entity-types/infra-host/definition.yml
@@ -313,7 +313,7 @@ synthesis:
         aws.ec2.InstanceId:
     # AWS EC2 host synthesized via ElasticBeanstalk logs
     # Metrics Streams and API Polling entities using the ARN to compute the entity.guid
-    - identifier: aws.Arn
+    - identifier: aws.ec2.InstanceId
       name: aws.ec2.InstanceId
       encodeIdentifierInGUID: true
       legacyFeatures:


### PR DESCRIPTION
### Relevant information

This PR modifies the synthesis rule of HOST entities only for Log datapoints (feature currently not being used). The identifier of HOST entities needs to be aligned with the identifier used by the Metric Streams integration, which also uses the instanceId as the identifier as opposed to the ARN.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.

