### PR TITLE
feat: Add "STRING" to the list of valid metric units in golden metrics schema

### DIFF
--- a/validator/schemas/golden-metrics-schema-v1.json
+++ b/validator/schemas/golden-metrics-schema-v1.json
@@ -56,7 +56,7 @@
         "$id": "#/properties/unit",
         "type": "string",
         "title": "The unit of the metric",
-        "enum": ["REQUESTS_PER_SECOND", "REQUESTS_PER_MINUTE", "PAGES_PER_SECOND", "MESSAGES_PER_SECOND", "OPERATIONS_PER_SECOND", "COUNT", "SECONDS", "MS", "PERCENTAGE", "BITS", "BYTES", "BITS_PER_SECOND", "BYTES_PER_SECOND", "HERTZ", "APDEX", "TIMESTAMP", "CELSIUS"],
+        "enum": ["REQUESTS_PER_SECOND", "REQUESTS_PER_MINUTE", "PAGES_PER_SECOND", "MESSAGES_PER_SECOND", "OPERATIONS_PER_SECOND", "COUNT", "SECONDS", "MS", "PERCENTAGE", "BITS", "BYTES", "BITS_PER_SECOND", "BYTES_PER_SECOND", "HERTZ", "APDEX", "TIMESTAMP", "CELSIUS", "STRING"],
         "examples": [
           "COUNT"
         ]


### PR DESCRIPTION
### Relevant information


Story : https://new-relic.atlassian.net/browse/NR-328461

Adding CLS to the golden signals and summary signals. As part of this I am adding STRING to golden signals allow list

<!--
  Contributions to this repository are reviewed at least twice a week

  There's no further action required once the PR has been created.
 -->

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
