### PR TITLE
chore: Updated the app sync relationship to look at `http.url` which is where the app sync URL will live on external client calls

### DIFF
--- a/relationships/synthesis/APM-APPLICATION-to-INFRA-AWSAPPSYNCAPI.yml
+++ b/relationships/synthesis/APM-APPLICATION-to-INFRA-AWSAPPSYNCAPI.yml
@@ -6,7 +6,7 @@ relationships:
     conditions:
       - attribute: eventType
         anyOf: [ "Span" ]
-      - attribute: peer.hostname
+      - attribute: http.url 
         regex: '[a-z]+[a-z0-9]*\.appsync-api\.[a-z]{2}-[a-z]+-\d+\.amazonaws\.com'
     relationship:
       expires: P75M


### PR DESCRIPTION
In our spec conversation [here](https://source.datanerd.us/agents/agent-specs/pull/716/files) we mentioned that `peer.hostname` is for database spans not external client spans.  The attribute the agents will be setting the app sync url is `http.url`
