### PR TITLE
fix: added valueinGuid in relationship

### DIFF
--- a/relationships/synthesis/INFRA-KUBERNETES_DAEMONSET-to-EXT-FLUENTBIT_KUBERNETES.yml
+++ b/relationships/synthesis/INFRA-KUBERNETES_DAEMONSET-to-EXT-FLUENTBIT_KUBERNETES.yml
@@ -3,6 +3,7 @@ relationships:
     version: "1"
     origins: 
       - Metric API
+      - Kubernetes Integration
     conditions:
       - attribute: eventType
         anyOf: [ "Metric" ]
@@ -18,6 +19,7 @@ relationships:
           attribute: entityGuid
           entityType:
             value: KUBERNETES_DAEMONSET
+            valueInGuid: NA
       target:
         buildGuid:
           account:
@@ -38,6 +40,7 @@ relationships:
     version: "1"
     origins: 
       - Metric API
+      - OpenTelemetry
     conditions:
       - attribute: eventType
         anyOf: [ "Metric" ]


### PR DESCRIPTION
### Relevant information

This PR attempts to fix the issue of the relationship between Fluentbit-Kubernetes and Kubernetes Daemonset not showing up on the UI.
### Checklist

* [X] I've read the guidelines and understand the acceptance criteria.
* [X] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
