### PR TITLE
fix: modified entity relationship for fluentbit kubernetes

### DIFF
--- a/relationships/synthesis/INFRA-KUBERNETES_DAEMONSET-to-EXT-FLUENTBIT_KUBERNETES.yml
+++ b/relationships/synthesis/INFRA-KUBERNETES_DAEMONSET-to-EXT-FLUENTBIT_KUBERNETES.yml
@@ -3,7 +3,6 @@ relationships:
     version: "1"
     origins: 
       - Metric API
-      - Kubernetes Integration
     conditions:
       - attribute: eventType
         anyOf: [ "Metric" ]
@@ -15,32 +14,32 @@ relationships:
       expires: P75M
       relationshipType: MANAGES
       source:
-        extractGuid:
-          attribute: entityGuid
-          entityType:
-            value: KUBERNETES_DAEMONSET
-            valueInGuid: NA
-      target:
         buildGuid:
           account:
-            lookup: true
+            lookup: true  
           domain:
-            value: EXT
+            value: INFRA
           type:
-            value: FLUENTBIT_KUBERNETES
+            value: KUBERNETES_DAEMONSET
+            valueInGuid: NA
           identifier:
             fragments:
+              - value: "k8s:"
               - attribute: cluster_name
               - value: ":"
               - attribute: namespace
-              - value: ":"
+              - value: ":daemonset:"
               - attribute: daemonset_name
             hashAlgorithm: FARM_HASH
+      target:
+        extractGuid:
+          attribute: entity.guid
+          entityType:
+            value: FLUENTBIT_KUBERNETES
   - name: otelKsmK8sDaemonSetManagesFluentbit
     version: "1"
     origins: 
       - Metric API
-      - OpenTelemetry
     conditions:
       - attribute: eventType
         anyOf: [ "Metric" ]
@@ -52,18 +51,13 @@ relationships:
       expires: P75M
       relationshipType: MANAGES
       source:
-        extractGuid:
-          attribute: entity.guid
-          entityType:
-            value: KUBERNETES_DAEMONSET
-      target:
         buildGuid:
           account:
-            lookup: true
+            lookup: true  
           domain:
-            value: EXT
+            value: INFRA
           type:
-            value: FLUENTBIT_KUBERNETES
+            value: KUBERNETES_DAEMONSET
           identifier:
             fragments:
               - attribute: cluster_name
@@ -72,3 +66,8 @@ relationships:
               - value: ":"
               - attribute: daemonset_name
             hashAlgorithm: FARM_HASH
+      target:
+        extractGuid:
+          attribute: entity.guid
+          entityType:
+            value: FLUENTBIT_KUBERNETES


### PR DESCRIPTION
### Relevant information

This PR attempts to fix the issue of entity relationship not getting created between fluent bit and kubernetes daemonset 

### Checklist

* [X] I've read the guidelines and understand the acceptance criteria.
* [X] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
