### PR TITLE
Revert "Update definition.yml"

### DIFF
--- a/entity-types/ext-pdu/definition.yml
+++ b/entity-types/ext-pdu/definition.yml
@@ -33,8 +33,6 @@ dashboardTemplates:
   # Servertech-4 profile
   kentik/servertech-pdu4:
     template: servertech-pdu4-dashboard.json
-  kentik/panduit_pdu:
-    template: panduit-pdu-dashboard.json
   # Generic/catchall
   kentik:
     template: kentik-dashboard.json


### PR DESCRIPTION
## What?

Reverts newrelic/entity-definitions#1830

## Why?

Blocking other rules to proceed due to invalid dashboard.

<img width="1723" alt="Screenshot 2025-01-16 at 10 01 28" src="https://github.com/user-attachments/assets/8c158c9d-6852-41b1-a49b-b8243670bce8" />



