### PR TITLE
NR-353035 added summary metrics to fluentbit onhost

### DIFF
--- a/entity-types/ext-fluentbit_host/summary_metrics.yml
+++ b/entity-types/ext-fluentbit_host/summary_metrics.yml
@@ -1,0 +1,15 @@
+operatingSystem:
+  title: Operating system
+  unit: STRING
+  tag:
+    key: host.os
+hostName:
+  title: Host name
+  unit: STRING
+  tag:
+    key: host.name
+version:
+  title: Fluent Bit version
+  unit: STRING
+  tag:
+    key: fluentbit.version


### PR DESCRIPTION
### Relevant information

This PR adds summary metrics for Fluent Bit onhost entity.

### Checklist

* [X] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
