### PR TITLE
Revise OTel service to infra relationships

### DIFF
--- a/relationships/synthesis/INFRA_DOCKER_CONTAINER-to-EXT_SERVICE.yml
+++ b/relationships/synthesis/INFRA_DOCKER_CONTAINER-to-EXT_SERVICE.yml
@@ -1,12 +1,14 @@
 relationships:
-  # infra metrics from oTel dockerstats receiver
+  # infra metrics from OTel dockerstats receiver
   - name: extInfraDockerContainerEXTService
     version: "1"
     origins:
       - OpenTelemetry
     conditions:
       - attribute: eventType
-        anyOf: [ "Metric" ]
+        anyOf: [ "Log", "Metric", "Span" ]
+      - attribute: entity.type
+        anyOf: [ "SERVICE" ]
     relationship:
       expires: P75M
       relationshipType: HOSTS
@@ -25,8 +27,6 @@ relationships:
       target:
         extractGuid:
           attribute: entity.guid
-          entityType:
-            value: "SERVICE"
   # infra metrics from NR infra agent
   - name: nrInfraDockerContainerEXTService
     version: "1"
@@ -34,7 +34,9 @@ relationships:
       - OpenTelemetry
     conditions:
       - attribute: eventType
-        anyOf: [ "Metric" ]
+        anyOf: [ "Log", "Metric", "Span" ]
+      - attribute: entity.type
+        anyOf: [ "SERVICE" ]
     relationship:
       expires: P75M
       relationshipType: HOSTS
@@ -55,5 +57,3 @@ relationships:
       target:
         extractGuid:
           attribute: entity.guid
-          entityType:
-            value: "SERVICE"

--- a/relationships/synthesis/INFRA_KUBERNETES_CONTAINER-to-EXT_SERVICE.yml
+++ b/relationships/synthesis/INFRA_KUBERNETES_CONTAINER-to-EXT_SERVICE.yml
@@ -7,7 +7,7 @@ relationships:
       - Kubernetes Integration
     conditions:
       - attribute: eventType
-        anyOf: [ "Metric" ]
+        anyOf: [ "Log", "Metric", "Span" ]
       - attribute: entity.type
         anyOf: [ "SERVICE" ]
     relationship:
@@ -36,7 +36,7 @@ relationships:
       target:
         extractGuid:
           attribute: entity.guid
-  # infra metrics from kubeletstats receiver
+  # infra metrics from OTel kubeletstats receiver
   - name: extInfraK8sContainerEXTService
     version: "1"
     origins:
@@ -44,7 +44,7 @@ relationships:
       - Kubernetes Integration
     conditions:
       - attribute: eventType
-        anyOf: [ "Metric" ]
+        anyOf: [ "Log", "Metric", "Span" ]
       - attribute: entity.type
         anyOf: [ "SERVICE" ]
     relationship:
@@ -71,5 +71,3 @@ relationships:
       target:
         extractGuid:
           attribute: entity.guid
-          entityType:
-            attribute: entity.type


### PR DESCRIPTION
This PR adjusts the relationship rules for OTel instrumented services and infra entities.

1. Removed `entityType` from `extractGuid` because I believe it is unnecessary for these use cases.
2. The rules now match spans, logs, and metrics. This is because some otel services may not emit metrics.

@gkadapa-nr since you originally created these rules, please take a look.