### PR TITLE
Add entity definitions for AWS EKS Cluster and AWS Mount target

### DIFF
--- a/entity-types/infra-awsefsmounttarget/definition.yml
+++ b/entity-types/infra-awsefsmounttarget/definition.yml
@@ -1,0 +1,5 @@
+domain: INFRA
+type: AWSEFSMOUNTTARGET
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true

--- a/entity-types/infra-awsekscluster/definition.yml
+++ b/entity-types/infra-awsekscluster/definition.yml
@@ -1,0 +1,5 @@
+domain: INFRA
+type: AWSEKSCLUSTER
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true


### PR DESCRIPTION
### Add entity definitions for AWS EKS Cluster and AWS Mount target
- Added `definition.yml` for `infra-efsmounttarget` with domain `INFRA` and type `AWSCOGNITOUSERPOOL`
- Added `definition.yml` for `infra-awsekscluster` with domain `INFRA` and type `AWSEKSCLUSTER`


<!--
  Describe what you have done.
  Provide details that are relevant to the PR

  Always think that the person reviewing the PR doesn't have the context you have.

  Links to examples, documentation and similar resources make the process easier to review.
-->

<!--
  Contributions to this repository are reviewed at least twice a week

  There's no further action required once the PR has been created.
 -->

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
