### PR TITLE
fix: changed origin of fluenbit entity relationship

### DIFF
--- a/relationships/synthesis/INFRA-KUBERNETES_DAEMONSET-to-EXT-FLUENTBIT_KUBERNETES.yml
+++ b/relationships/synthesis/INFRA-KUBERNETES_DAEMONSET-to-EXT-FLUENTBIT_KUBERNETES.yml
@@ -2,7 +2,7 @@ relationships:
   - name: k8sDaemonSetManagesFluentbit
     version: "1"
     origins: 
-      - Metric API
+      - Prometheus
     conditions:
       - attribute: eventType
         anyOf: [ "Metric" ]
@@ -39,7 +39,7 @@ relationships:
   - name: otelKsmK8sDaemonSetManagesFluentbit
     version: "1"
     origins: 
-      - Metric API
+      - Prometheus
     conditions:
       - attribute: eventType
         anyOf: [ "Metric" ]


### PR DESCRIPTION
### Relevant information

This PR attempts to fix the k8sDaemonsetManagesFluentBitKubernetes Relationship by changing the origin of telemetry

### Checklist

* [X] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
