### PR TITLE
fix: added where clause to nrql query

### DIFF
--- a/entity-types/ext-fluentbit_kubernetes/dashboard.json
+++ b/entity-types/ext-fluentbit_kubernetes/dashboard.json
@@ -458,7 +458,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT rate(sum(fluentbit_output_proc_records_total), 1 minute) as 'Processed', rate(sum(fluentbit_output_dropped_records_total), 1 minute) as 'Dropped', rate(sum(fluentbit_output_retried_records_total), 1 minute) as 'Retried' FROM Metric name = 'newrelic-logs-forwarder' facet pod_name timeseries max"
+                "query": "SELECT rate(sum(fluentbit_output_proc_records_total), 1 minute) as 'Processed', rate(sum(fluentbit_output_dropped_records_total), 1 minute) as 'Dropped', rate(sum(fluentbit_output_retried_records_total), 1 minute) as 'Retried' FROM Metric where name = 'newrelic-logs-forwarder' facet pod_name timeseries max"
               }
             ],
             "platformOptions": {


### PR DESCRIPTION
### Relevant information

This PR fixes the bug with a NRQL query in fluentbit kubernetes entity dashboard. 

### Checklist

* [X] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
