### PR TITLE
Add Ext IBM iSeries Definition.

### DIFF
--- a/entity-types/ext-ibm_iseries/definition.yml
+++ b/entity-types/ext-ibm_iseries/definition.yml
@@ -1,0 +1,18 @@
+domain: EXT
+type: IBM_ISERIES
+
+synthesis:
+  name: hostName
+  identifier: hostName
+  encodeIdentifierInGUID : true
+  conditions:
+  - attribute: includeInIseriesEntity
+    present: true
+  tags:
+    systemName:
+      multiValue: false
+    ipAddress:
+      multiValue: false
+configuration:
+  alertable: true
+  entityExpirationTime: QUARTERLY

--- a/entity-types/ext-ibm_iseries/definition.yml
+++ b/entity-types/ext-ibm_iseries/definition.yml
@@ -15,4 +15,4 @@ synthesis:
       multiValue: false
 configuration:
   alertable: true
-  entityExpirationTime: QUARTERLY
+  entityExpirationTime: DAILY

--- a/entity-types/ext-ibm_iseries/definition.yml
+++ b/entity-types/ext-ibm_iseries/definition.yml
@@ -15,4 +15,4 @@ synthesis:
       multiValue: false
 configuration:
   alertable: true
-  entityExpirationTime: DAILY
+  entityExpirationTime: QUARTERLY


### PR DESCRIPTION
### Relevant information

Added a new External IBM iSeries entity definition with the main goal being that our custom insights metric generated with an attribute of includeInIseriesEntity should be used to automatically create our IBM iSeries as an Entity and visible on distributed tracing maps


### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
