### PR TITLE
Revert "feat: Add new lookup defining container candidate relationship"

### DIFF
--- a/relationships/candidates/CONTAINER.yml
+++ b/relationships/candidates/CONTAINER.yml
@@ -14,23 +14,3 @@ lookups:
       action: CREATE_UNINSTRUMENTED
       uninstrumented:
         type: CONTAINER
-  - entityTypes:
-      - domain: INFRA
-        type: CONTAINER
-    tags:
-      matchingMode: ALL
-      predicates:
-        - tagKeys: [ "k8s.clusterName" ]
-          field: k8sClusterName
-        - tagKeys: [ "k8s.namespaceName" ]
-          field: k8sNamespaceName
-        - tagKeys: [ "k8s.podName" ]
-          field: k8sPodName
-        - tagKeys: [ "k8s.containerName" ]
-          field: k8sContainerName
-    onMatch:
-      onMultipleMatches: RELATE_ALL
-    onMiss:
-      action: CREATE_UNINSTRUMENTED
-      uninstrumented:
-        type: CONTAINER


### PR DESCRIPTION
Reverts newrelic/entity-definitions#1893

## What?

Removes rule for containers.

## Why?

It is impacting the persistency layer performance and causing kafka consumer lag in our pipelines.