### PR TITLE
fix: restrict fb version to be single-valued

### DIFF
--- a/entity-types/ext-fluentbit_kubernetes/definition.yml
+++ b/entity-types/ext-fluentbit_kubernetes/definition.yml
@@ -25,7 +25,8 @@ synthesis:
       cluster_name:
         entityTagNames: [k8s.clusterName]
       version:
-        entityTagNames: [fluentbit.version]
+        entityTagName: fluentbit.version
+        multiValue: false
 dashboardTemplates:
   newRelic:
     template: dashboard.json


### PR DESCRIPTION
### Relevant information

This PR attempts to make the version tag on the fluent bit entity single value so that any change in version would override the only available version.

### Checklist

* [X] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
