### PR TITLE
fix: Update the attribute names to latest semantic convention

### DIFF
--- a/relationships/synthesis/EXT-SERVICE-to-KAFKATOPIC.yml
+++ b/relationships/synthesis/EXT-SERVICE-to-KAFKATOPIC.yml
@@ -20,14 +20,14 @@ relationships:
           fields:
             - field: clusterName
               capture:
-                attribute: messaging.url              
+                attribute: server.address            
                 regex: "^[^\\.]+\\.([^\\.]+)\\.[^\\.]+\\.[^\\.]+\\.kafka\\.[^\\.]+\\.amazonaws\\.com:[0-9]+.*"
             - field: region
               capture:
-                attribute: messaging.url
+                attribute: server.address
                 regex: "^[^\\.]+\\.[^\\.]+\\.[^\\.]+\\.[^\\.]+\\.kafka\\.([^\\.]+)\\.amazonaws\\.com:[0-9]+.*"
             - field: topic
-              attribute: messaging.destination
+              attribute: messaging.destination.name
 
   - name: extServiceConsumesAwsMskTopic
     version: "1"
@@ -50,12 +50,12 @@ relationships:
           fields:
             - field: clusterName
               capture:
-                attribute: messaging.url
+                attribute: server.address
                 regex: "^[^\\.]+\\.([^\\.]+)\\.[^\\.]+\\.[^\\.]+\\.kafka\\.[^\\.]+\\.amazonaws\\.com:[0-9]+.*"
             - field: region
               capture:
-                attribute: messaging.url
+                attribute: server.address
                 regex: "^[^\\.]+\\.[^\\.]+\\.[^\\.]+\\.[^\\.]+\\.kafka\\.([^\\.]+)\\.amazonaws\\.com:[0-9]+.*"
             - field: topic
-              attribute: messaging.destination
+              attribute: messaging.destination.name
 

--- a/relationships/synthesis/EXT-SERVICE-to-MEMCACHED.yml
+++ b/relationships/synthesis/EXT-SERVICE-to-MEMCACHED.yml
@@ -6,7 +6,7 @@ relationships:
     conditions:
       - attribute: eventType
         anyOf: [ "Span"]
-      - attribute: db.system
+      - attribute: db.system.name
         anyOf: [ "memcached" ]
     relationship:
       expires: P75M
@@ -19,6 +19,6 @@ relationships:
           candidateCategory: MEMCACHED
           fields:
             - field: endpoint
-              attribute: net.peer.name
+              attribute: server.address
             - field: port
-              attribute: net.peer.port
+              attribute: server.port


### PR DESCRIPTION
### Relevant information

Updated the span attributes used in relationship synthesis condition and mapping fields as per the latest Otel Symantic Conventions. Ref: https://opentelemetry.io/docs/specs/semconv/

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
