### PR TITLE
Change to endpoint for HTTPSERVICE lookup

### DIFF
--- a/relationships/candidates/HTTPSERVICE.yml
+++ b/relationships/candidates/HTTPSERVICE.yml
@@ -8,7 +8,7 @@ lookups:
     tags:
       matchingMode: ANY
       predicates:
-        - tagKeys: ["nr.endpointHostname", "endpointHostname"]
+        - tagKeys: ["nr.endpoint", "endpoint"]
           field: hostname
     onMatch:
      onMultipleMatches: RELATE_ALL


### PR DESCRIPTION
### Relevant information

It was decided to change the lookup into nr.endpoint & endpoint instead of the current one

Updating to reflect the decision

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
