### PR TITLE
Extends comments to clarify that these rules apply only to logs

### DIFF
--- a/entity-types/infra-awsalb/definition.yml
+++ b/entity-types/infra-awsalb/definition.yml
@@ -20,7 +20,8 @@ configuration:
 
 synthesis:
   rules:
-    # Legacy API Polling entities not using the ARN to compute the entity.guid, but directly providing the entityId
+    # Logs received via Lambda/Firehose log forwarder and enriched by the Logs Pipeline. See: https://docs.newrelic.com/docs/logs/logs-context/aws-logs-in-context/
+    # Logs from legacy API Polling entities not using the ARN to compute the entity.guid, but directly providing the entityId
     - identifier: entityId
       name: aws.alb.loadBalancer
       encodeIdentifierInGUID: false
@@ -37,7 +38,8 @@ synthesis:
           present: true
       tags:
         aws.Arn:
-    # Metrics Streams and API Polling entities using the ARN to compute the entity.guid
+    # Logs received via Lambda/Firehose log forwarder and enriched by the Logs Pipeline. See: https://docs.newrelic.com/docs/logs/logs-context/aws-logs-in-context/
+    # Logs from Metrics Streams or API Polling entities using the ARN to compute the entity.guid, or entities only sending logs
     - identifier: aws.Arn
       name: aws.alb.loadBalancer
       encodeIdentifierInGUID: true

--- a/entity-types/infra-awscloudfrontdistribution/definition.yml
+++ b/entity-types/infra-awscloudfrontdistribution/definition.yml
@@ -11,7 +11,8 @@ configuration:
 
 synthesis:
   rules:
-    # Legacy API Polling entities not using the ARN to compute the entity.guid, but directly providing the entityId
+    # Logs received via Lambda/Firehose log forwarder and enriched by the Logs Pipeline. See: https://docs.newrelic.com/docs/logs/logs-context/aws-logs-in-context/
+    # Logs from legacy API Polling entities not using the ARN to compute the entity.guid, but directly providing the entityId
     - identifier: entityId
       name: aws.cloudfront.DistributionId
       encodeIdentifierInGUID: false
@@ -29,7 +30,8 @@ synthesis:
       tags:
         aws.Arn:
         aws.cloudfront.DistributionId:
-    # Metrics Streams and API Polling entities using the ARN to compute the entity.guid
+    # Logs received via Lambda/Firehose log forwarder and enriched by the Logs Pipeline. See: https://docs.newrelic.com/docs/logs/logs-context/aws-logs-in-context/
+    # Logs from Metrics Streams or API Polling entities using the ARN to compute the entity.guid, or entities only sending logs
     - identifier: aws.Arn
       name: aws.cloudfront.DistributionId
       encodeIdentifierInGUID: true

--- a/entity-types/infra-awselb/definition.yml
+++ b/entity-types/infra-awselb/definition.yml
@@ -12,7 +12,8 @@ configuration:
 
 synthesis:
   rules:
-    # Legacy API Polling entities not using the ARN to compute the entity.guid, but directly providing the entityId
+    # Logs received via Lambda/Firehose log forwarder and enriched by the Logs Pipeline. See: https://docs.newrelic.com/docs/logs/logs-context/aws-logs-in-context/
+    # Logs from legacy API Polling entities not using the ARN to compute the entity.guid, but directly providing the entityId
     - identifier: entityId
       name: aws.elb.loadBalancer
       encodeIdentifierInGUID: false
@@ -31,7 +32,8 @@ synthesis:
         aws.Arn:
         aws.elb.loadBalancer:
           entityTagNames: [ aws.elb.LoadBalancerName ]
-    # Metrics Streams and API Polling entities using the ARN to compute the entity.guid
+    # Logs received via Lambda/Firehose log forwarder and enriched by the Logs Pipeline. See: https://docs.newrelic.com/docs/logs/logs-context/aws-logs-in-context/
+    # Logs from Metrics Streams or API Polling entities using the ARN to compute the entity.guid, or entities only sending logs
     - identifier: aws.Arn
       name: aws.elb.loadBalancer
       encodeIdentifierInGUID: true

--- a/entity-types/infra-awslambdafunction/definition.yml
+++ b/entity-types/infra-awslambdafunction/definition.yml
@@ -19,7 +19,8 @@ configuration:
 
 synthesis:
   rules:
-    # Legacy API Polling entities not using the ARN to compute the entity.guid, but directly providing the entityId
+    # Logs received via Lambda/Firehose log forwarder and enriched by the Logs Pipeline. See: https://docs.newrelic.com/docs/logs/logs-context/aws-logs-in-context/
+    # Logs from legacy API Polling entities not using the ARN to compute the entity.guid, but directly providing the entityId
     - identifier: entityId
       name: aws.lambda.FunctionName
       encodeIdentifierInGUID: false
@@ -38,7 +39,8 @@ synthesis:
         aws.Arn:
         # Used in AWSLAMBDAFUNCTION.yml for entity relationship candidates
         aws.lambda.FunctionName:
-    # Metrics Streams and API Polling entities using the ARN to compute the entity.guid
+    # Logs received via Lambda/Firehose log forwarder and enriched by the Logs Pipeline. See: https://docs.newrelic.com/docs/logs/logs-context/aws-logs-in-context/
+    # Logs from Metrics Streams or API Polling entities using the ARN to compute the entity.guid, or entities only sending logs
     - identifier: aws.Arn
       name: aws.lambda.FunctionName
       encodeIdentifierInGUID: true

--- a/entity-types/infra-awsnlb/definition.yml
+++ b/entity-types/infra-awsnlb/definition.yml
@@ -19,7 +19,8 @@ configuration:
 
 synthesis:
   rules:
-    # Legacy API Polling entities not using the ARN to compute the entity.guid, but directly providing the entityId
+    # Logs received via Lambda/Firehose log forwarder and enriched by the Logs Pipeline. See: https://docs.newrelic.com/docs/logs/logs-context/aws-logs-in-context/
+    # Logs from legacy API Polling entities not using the ARN to compute the entity.guid, but directly providing the entityId
     - identifier: entityId
       name: aws.nlb.loadBalancer
       encodeIdentifierInGUID: false
@@ -36,7 +37,8 @@ synthesis:
           present: true
       tags:
         aws.Arn:
-    # Metrics Streams and API Polling entities using the ARN to compute the entity.guid
+    # Logs received via Lambda/Firehose log forwarder and enriched by the Logs Pipeline. See: https://docs.newrelic.com/docs/logs/logs-context/aws-logs-in-context/
+    # Logs from Metrics Streams or API Polling entities using the ARN to compute the entity.guid, or entities only sending logs
     - identifier: aws.Arn
       name: aws.nlb.loadBalancer
       encodeIdentifierInGUID: true

--- a/entity-types/infra-awsrdsdbinstance/definition.yml
+++ b/entity-types/infra-awsrdsdbinstance/definition.yml
@@ -9,7 +9,8 @@ configuration:
 
 synthesis:
   rules:
-    # Legacy API Polling entities not using the ARN to compute the entity.guid, but directly providing the entityId
+    # Logs received via Lambda/Firehose log forwarder and enriched by the Logs Pipeline. See: https://docs.newrelic.com/docs/logs/logs-context/aws-logs-in-context/
+    # Logs from legacy API Polling entities not using the ARN to compute the entity.guid, but directly providing the entityId
     - identifier: entityId
       name: aws.rds.DBInstanceIdentifier
       encodeIdentifierInGUID: false
@@ -27,7 +28,8 @@ synthesis:
       tags:
         aws.Arn:
         aws.rds.DBInstanceIdentifier:
-    # Metrics Streams and API Polling entities using the ARN to compute the entity.guid
+    # Logs received via Lambda/Firehose log forwarder and enriched by the Logs Pipeline. See: https://docs.newrelic.com/docs/logs/logs-context/aws-logs-in-context/
+    # Logs from Metrics Streams or API Polling entities using the ARN to compute the entity.guid, or entities only sending logs
     - identifier: aws.Arn
       name: aws.rds.DBInstanceIdentifier
       encodeIdentifierInGUID: true

--- a/entity-types/infra-awss3bucket/definition.yml
+++ b/entity-types/infra-awss3bucket/definition.yml
@@ -16,7 +16,8 @@ configuration:
 
 synthesis:
   rules:
-    # Legacy API Polling entities not using the ARN to compute the entity.guid, but directly providing the entityId
+    # Logs received via Lambda/Firehose log forwarder and enriched by the Logs Pipeline. See: https://docs.newrelic.com/docs/logs/logs-context/aws-logs-in-context/
+    # Logs from legacy API Polling entities not using the ARN to compute the entity.guid, but directly providing the entityId
     - identifier: entityId
       name: aws.s3.BucketName
       encodeIdentifierInGUID: false
@@ -36,7 +37,8 @@ synthesis:
         aws.Arn:
         # Used in AWSS3BUCKET.yml for entity relationship candidates
         aws.s3.BucketName:
-    # Metrics Streams and API Polling entities using the ARN to compute the entity.guid
+    # Logs received via Lambda/Firehose log forwarder and enriched by the Logs Pipeline. See: https://docs.newrelic.com/docs/logs/logs-context/aws-logs-in-context/
+    # Logs from Metrics Streams or API Polling entities using the ARN to compute the entity.guid, or entities only sending logs
     - identifier: aws.Arn
       name: aws.s3.BucketName
       encodeIdentifierInGUID: true

--- a/entity-types/infra-awssqsqueue/definition.yml
+++ b/entity-types/infra-awssqsqueue/definition.yml
@@ -11,13 +11,15 @@ configuration:
 
 synthesis:
   rules:
-    # Legacy API Polling entities not using the ARN to compute the entity.guid, but directly providing the entityId
+    # Logs received via Lambda/Firehose log forwarder and enriched by the Logs Pipeline. See: https://docs.newrelic.com/docs/logs/logs-context/aws-logs-in-context/
+    # Logs from legacy API Polling entities not using the ARN to compute the entity.guid, but directly providing the entityId
     - identifier: entityId
       name: aws.sqs.QueueName
       encodeIdentifierInGUID: false
       legacyFeatures:
         overrideGuidType: true
       conditions:
+        # CloudTrail sets an eventType attribute that conflicts with our eventType (Log), so using eventSource instead
         - attribute: eventSource
           value: sqs.amazonaws.com
         - attribute: eventName
@@ -39,13 +41,15 @@ synthesis:
         # Used in AWSSQSQUEUE.yml for entity relationship candidates
         awsRegion:
           entityTagNames: [ aws.region ]
-    # Metrics Streams and API Polling entities using the ARN to compute the entity.guid
+    # Logs received via Lambda/Firehose log forwarder and enriched by the Logs Pipeline. See: https://docs.newrelic.com/docs/logs/logs-context/aws-logs-in-context/
+    # Logs from Metrics Streams or API Polling entities using the ARN to compute the entity.guid, or entities only sending logs
     - identifier: aws.Arn
       name: aws.sqs.QueueName
       encodeIdentifierInGUID: true
       legacyFeatures:
         overrideGuidType: true
       conditions:
+        # CloudTrail sets an eventType attribute that conflicts with our eventType (Log), so using eventSource instead
         - attribute: eventSource
           value: sqs.amazonaws.com
         - attribute: eventName

--- a/entity-types/infra-host/definition.yml
+++ b/entity-types/infra-host/definition.yml
@@ -291,8 +291,8 @@ synthesis:
         nodename:
           entityTagNames: [hostname]
         instrumentation.provider:
-    # AWS EC2 host synthesized via ElasticBeanstalk logs
-    # Metrics Streams and API Polling entities use the instanceId to compute the entity.guid
+    # Logs received via Lambda/Firehose log forwarder and enriched by the Logs Pipeline. See: https://docs.newrelic.com/docs/logs/logs-context/aws-logs-in-context/
+    # AWS EC2 host synthesized via ElasticBeanstalk logs. Metrics Streams and API Polling entities use the instanceId to compute the entity.guid
     - identifier: aws.ec2.InstanceId
       name: aws.ec2.InstanceId
       encodeIdentifierInGUID: true


### PR DESCRIPTION
### Relevant information

This PR simply adds more explanatory comments as to where the data used by the affected rules comes from. For these rules, the Logs Pipeline pre-enriches the logs with some attributes like the `aws.Arn`, optionally an `entityId` and an entity name (`aws.lambda.FunctionName` or `aws.alb.loadBalancer`, for instance) so that entity synthesis can work. More information can be found here: https://docs.newrelic.com/docs/logs/logs-context/aws-logs-in-context/ (still being reviewed)

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
