### PR TITLE
[DO NOT MERGE] Adds entity synthesis rules for logs coming from newrelic-lambda-extension

### DIFF
--- a/entity-types/infra-awslambdafunction/definition.yml
+++ b/entity-types/infra-awslambdafunction/definition.yml
@@ -59,3 +59,51 @@ synthesis:
         aws.Arn:
         # Used in AWSLAMBDAFUNCTION.yml for entity relationship candidates
         aws.lambda.FunctionName:
+    # Logs received via newrelic-lambda-extension and enriched by the Logs Pipeline with entityId. See: https://docs.newrelic.com/docs/logs/logs-context/aws-logs-in-context/
+    # Logs from legacy API Polling entities not using the ARN to compute the entity.guid, but directly providing the entityId
+    - identifier: entityId
+      name: faas.name
+      encodeIdentifierInGUID: false
+      legacyFeatures:
+        overrideGuidType: true
+      conditions:
+        - attribute: eventType
+          prefix: Log
+        - attribute: plugin
+          prefix: newrelic-lambda-extension
+        - attribute: faas.arn
+          present: true
+        - attribute: faas.name
+          present: true
+        - attribute: entityId
+          present: true
+      tags:
+        faas.arn:
+          entityTagNames: [ aws.Arn ]
+        faas.name:
+          # Used in AWSLAMBDAFUNCTION.yml for entity relationship candidates
+          entityTagNames: [ aws.lambda.FunctionName ]
+    # Logs received via newrelic-lambda-extension. See: https://docs.newrelic.com/docs/logs/logs-context/aws-logs-in-context/
+    # Logs from Metrics Streams or API Polling entities using the ARN to compute the entity.guid, or entities only sending logs
+    - identifier: faas.arn
+      name: faas.name
+      encodeIdentifierInGUID: true
+      legacyFeatures:
+        overrideGuidType: true
+      conditions:
+        - attribute: eventType
+          prefix: Log
+        - attribute: plugin
+          prefix: newrelic-lambda-extension
+        - attribute: faas.arn
+          present: true
+        - attribute: faas.name
+          present: true
+        - attribute: entityId
+          present: false
+      tags:
+        faas.arn:
+          entityTagNames: [ aws.Arn ]
+        faas.name:
+          # Used in AWSLAMBDAFUNCTION.yml for entity relationship candidates
+          entityTagNames: [ aws.lambda.FunctionName ]


### PR DESCRIPTION
# **PLEASE DO NOT MERGE**
# **PR tests**

### Relevant information

This PR introduces two entity synthesis rules for logs coming from the `newrelic-lambda-extension`. Depending on whether the account where the instrumented lambda is running has API Polling or Metrics Streams enabled, the Logs Pipeline will enrich the logs with the `entityId` attribute (legacy API Polling entities only, refer to [this CDD](https://newrelic.atlassian.net/wiki/spaces/TDP/pages/3670966562/CDD+-+Entity+Synthesis+for+Infra+AWS+entities+out+of+Logs#Proposed-/-Leading-Solution)). This is why we need to define one synthesis rule for each case. Related documentation: https://docs.newrelic.com/docs/logs/logs-context/aws-logs-in-context/

Sample log (with `entityId`):
![Screenshot 2025-02-17 at 19 36 14](https://github.com/user-attachments/assets/5c7a891f-5181-45b9-b71e-25cdcf2e7ddb)


### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
