### PR TITLE
Add relationship to support manual instrumentation

### DIFF
--- a/relationships/candidates/MEMCACHED_EXPLICIT.yml
+++ b/relationships/candidates/MEMCACHED_EXPLICIT.yml
@@ -1,0 +1,18 @@
+category: MEMCACHED_EXPLICIT
+lookups:
+  - entityTypes:
+      - domain: INFRA
+        type: AWSELASTICACHEMEMCACHEDCLUSTER
+      - domain: INFRA
+        type: AWSELASTICACHEMEMCACHEDNODE
+    tags:
+      matchingMode: ALL
+      predicates:
+        - tagKeys: ["aws.Arn"]
+          field: cloudResourceId
+    onMatch:
+      onMultipleMatches: RELATE_ALL
+    onMiss:
+      action: CREATE_UNINSTRUMENTED
+      uninstrumented:
+        type: MEMCACHED

--- a/relationships/synthesis/EXT-SERVICE-to-MEMCACHED.yml
+++ b/relationships/synthesis/EXT-SERVICE-to-MEMCACHED.yml
@@ -18,6 +18,8 @@ relationships:
         regex: " .*\\.cache\\.amazonaws\\.com"
       - attribute: net.peer.port
         present: true
+      - attribute: newrelic.aws_metric_streams.arn
+        present: false
     relationship:
       expires: P75M
       relationshipType: CALLS
@@ -51,6 +53,8 @@ relationships:
         present: true
         regex: " .*\\.cache\\.amazonaws\\.com"
       - attribute: net.peer.port
+        present: false
+      - attribute: newrelic.aws_metric_streams.arn
         present: false
     relationship:
       expires: P75M
@@ -86,6 +90,8 @@ relationships:
         regex: " .*\\.cache\\.amazonaws\\.com"
       - attribute: server.port
         present: true
+      - attribute: newrelic.aws_metric_streams.arn
+        present: false
     relationship:
       expires: P75M
       relationshipType: CALLS
@@ -119,6 +125,8 @@ relationships:
         present: true
         regex: " .*\\.cache\\.amazonaws\\.com"
       - attribute: server.port
+        present: false
+      - attribute: newrelic.aws_metric_streams.arn
         present: false
     relationship:
       expires: P75M

--- a/relationships/synthesis/EXT-SERVICE-to-MEMCACHED.yml
+++ b/relationships/synthesis/EXT-SERVICE-to-MEMCACHED.yml
@@ -134,3 +134,31 @@ relationships:
               attribute: server.address
             - field: port
               attribute: 11211 # Default port for memcached
+
+  - name: extServiceCallsAwsElastiCacheMemcached_Explicit
+    version: "1"
+    origins:
+      - Distributed Tracing
+      - OpenTelemetry
+    conditions:
+      - attribute: eventType
+        anyOf: [ "Span", "Log" ]
+      - attribute: newrelic.source
+        anyOf: [ "api.traces.otlp", "api.logs.otlp" ]
+      - attribute: entity.type
+        anyOf: [ "SERVICE" ]
+      - attribute: newrelic.aws_metric_streams.arn
+        regex: "^arn:aws:elasticache:([^:]*):([^:]*):cluster/([^:]*)"
+        present: true
+    relationship:
+      expires: P75M
+      relationshipType: CALLS
+      source:
+        extractGuid:
+          attribute: entity.guid
+      target:
+        lookupGuid:
+          candidateCategory: MEMCACHED_EXPLICIT
+          fields:
+            - field: cloudResourceId
+              attribute: newrelic.aws_metric_streams.arn


### PR DESCRIPTION
To simplify relationship creation between Otel service and AWS Memcached using manual instrumentation if auto instrumentation not supported, I have added a relationship called `extServiceCallsAwsElastiCacheMemcached_Explicit`. This only requires the client to send AWS resource arn to NR and the relationship will be created.