### PR TITLE
alertable:false for AWSEFSMOUNTTARGET

### DIFF
--- a/entity-types/infra-awsefsmounttarget/definition.yml
+++ b/entity-types/infra-awsefsmounttarget/definition.yml
@@ -2,4 +2,4 @@ domain: INFRA
 type: AWSEFSMOUNTTARGET
 configuration:
   entityExpirationTime: DAILY
-  alertable: true
+  alertable: false

--- a/entity-types/infra-awsekscluster/definition.yml
+++ b/entity-types/infra-awsekscluster/definition.yml
@@ -2,4 +2,4 @@ domain: INFRA
 type: AWSEKSCLUSTER
 configuration:
   entityExpirationTime: DAILY
-  alertable: true
+  alertable: false

--- a/entity-types/infra-awsekscluster/definition.yml
+++ b/entity-types/infra-awsekscluster/definition.yml
@@ -2,4 +2,4 @@ domain: INFRA
 type: AWSEKSCLUSTER
 configuration:
   entityExpirationTime: DAILY
-  alertable: false
+  alertable: true


### PR DESCRIPTION
### Relevant information

These entities doe not have metrics and do not have to be shown in the Entity Explorer.

This is the same as other AWS entities such as VPC or Subnet

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
