### PR TITLE
Remove capturing group in arn regex

### DIFF
--- a/relationships/synthesis/EXT-SERVICE-to-INFRA-AWSMQBROKER.yml
+++ b/relationships/synthesis/EXT-SERVICE-to-INFRA-AWSMQBROKER.yml
@@ -148,7 +148,7 @@ relationships:
       - attribute: entity.type
         anyOf: [ "SERVICE" ]
       - attribute: newrelic.aws_metric_streams.arn
-        regex: "^arn:aws:mq:([^:]*):([^:]*):broker/([^:]*)"
+        regex: "^arn:aws:mq:[^:]*:[^:]*:broker/[^:]*"
         present: true
     relationship:
       expires: P75M

--- a/relationships/synthesis/EXT-SERVICE-to-KAFKATOPIC.yml
+++ b/relationships/synthesis/EXT-SERVICE-to-KAFKATOPIC.yml
@@ -180,7 +180,7 @@ relationships:
       - attribute: entity.type
         anyOf: [ "SERVICE" ]
       - attribute: newrelic.aws_metric_streams.arn
-        regex: "^arn:aws:kafka:([^:]*):([^:]*):cluster/([^:]*)"
+        regex: "^arn:aws:kafka:[^:]*:[^:]*:cluster/[^:]*"
         present: true
     relationship:
       expires: P75M

--- a/relationships/synthesis/EXT-SERVICE-to-MEMCACHED.yml
+++ b/relationships/synthesis/EXT-SERVICE-to-MEMCACHED.yml
@@ -156,7 +156,7 @@ relationships:
       - attribute: entity.type
         anyOf: [ "SERVICE" ]
       - attribute: newrelic.aws_metric_streams.arn
-        regex: "^arn:aws:elasticache:([^:]*):([^:]*):cluster/([^:]*)"
+        regex: "^arn:aws:elasticache:[^:]*:[^:]*:cluster/[^:]*"
         present: true
     relationship:
       expires: P75M

--- a/relationships/synthesis/EXT-SERVICE-to-REDIS.yml
+++ b/relationships/synthesis/EXT-SERVICE-to-REDIS.yml
@@ -152,7 +152,7 @@ relationships:
       - attribute: entity.type
         anyOf: [ "SERVICE" ]
       - attribute: newrelic.aws_metric_streams.arn
-        regex: "arn:aws:elasticache:([^:]*):([^:]*):cluster:([^:]*)"
+        regex: "arn:aws:elasticache:[^:]*:[^:]*:cluster:[^:]*"
     relationship:
       expires: P75M
       relationshipType: CALLS


### PR DESCRIPTION
For the explicit matching using arn, changed the regex by removing the capturing group. This is needed to create exclusinve matching conditions.