### PR TITLE
Update extServiceCallsAwsMqBroker_Explicit regex

### DIFF
--- a/relationships/synthesis/EXT-SERVICE-to-INFRA-AWSMQBROKER.yml
+++ b/relationships/synthesis/EXT-SERVICE-to-INFRA-AWSMQBROKER.yml
@@ -144,7 +144,7 @@ relationships:
       - attribute: entity.type
         anyOf: [ "SERVICE" ]
       - attribute: newrelic.aws_metric_streams.arn
-        regex: "^arn:aws:mq:[^:]*:[^:]*:broker/[^:]*"
+        regex: "^arn:aws:mq:[^:]+:[^:]+:broker:[^:]+:[^:]+"
     relationship:
       expires: P75M
       relationshipType: CALLS


### PR DESCRIPTION
### Relevant information

Attempt to fix regex for extServiceCallsAwsMqBroker_Explicit.

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
