### PR TITLE
Fix typo in k8s namespace attributes for Otel

### DIFF
--- a/entity-types/infra-kubernetes_cronjob/definition.yml
+++ b/entity-types/infra-kubernetes_cronjob/definition.yml
@@ -57,7 +57,7 @@ synthesis:
     #     separator: ":"
     #     attributes:
     #       - k8s.cluster.name
-    #       - k8.namespace.name
+    #       - k8s.namespace.name
     #       - k8s.object.name
     #   encodeIdentifierInGUID: true
     #   name: k8s.object.name
@@ -69,7 +69,7 @@ synthesis:
     #     # identifier attributes
     #     - attribute: k8s.object.name
     #       present: true
-    #     - attribute: k8.namespace.name
+    #     - attribute: k8s.namespace.name
     #       present: true
     #     - attribute: k8s.cluster.name
     #       present: true

--- a/entity-types/infra-kubernetes_daemonset/definition.yml
+++ b/entity-types/infra-kubernetes_daemonset/definition.yml
@@ -50,7 +50,7 @@ synthesis:
         separator: ":"
         attributes:
           - k8s.cluster.name
-          - k8.namespace.name
+          - k8s.namespace.name
           - k8s.object.name
       encodeIdentifierInGUID: true
       name: k8s.object.name
@@ -62,7 +62,7 @@ synthesis:
         # identifier attributes
         - attribute: k8s.object.name
           present: true
-        - attribute: k8.namespace.name
+        - attribute: k8s.namespace.name
           present: true
         - attribute: k8s.cluster.name
           present: true

--- a/entity-types/infra-kubernetes_deployment/definition.yml
+++ b/entity-types/infra-kubernetes_deployment/definition.yml
@@ -89,7 +89,7 @@ synthesis:
         separator: ":"
         attributes:
           - k8s.cluster.name
-          - k8.namespace.name
+          - k8s.namespace.name
           - k8s.object.name
       encodeIdentifierInGUID: true
       name: k8s.object.name
@@ -101,7 +101,7 @@ synthesis:
         # identifier attributes
         - attribute: k8s.object.name
           present: true
-        - attribute: k8.namespace.name
+        - attribute: k8s.namespace.name
           present: true
         - attribute: k8s.cluster.name
           present: true

--- a/entity-types/infra-kubernetes_job/definition.yml
+++ b/entity-types/infra-kubernetes_job/definition.yml
@@ -55,7 +55,7 @@ synthesis:
     #     separator: ":"
     #     attributes:
     #       - k8s.cluster.name
-    #       - k8.namespace.name
+    #       - k8s.namespace.name
     #       - k8s.object.name
     #   encodeIdentifierInGUID: true
     #   name: k8s.object.name
@@ -67,7 +67,7 @@ synthesis:
     #     # identifier attributes
     #     - attribute: k8s.object.name
     #       present: true
-    #     - attribute: k8.namespace.name
+    #     - attribute: k8s.namespace.name
     #       present: true
     #     - attribute: k8s.cluster.name
     #       present: true

--- a/entity-types/infra-kubernetes_persistentvolumeclaim/definition.yml
+++ b/entity-types/infra-kubernetes_persistentvolumeclaim/definition.yml
@@ -60,7 +60,7 @@ synthesis:
     #     separator: ":"
     #     attributes:
     #       - k8s.cluster.name
-    #       - k8.namespace.name
+    #       - k8s.namespace.name
     #       - k8s.object.name
     #   encodeIdentifierInGUID: true
     #   name: k8s.object.name
@@ -72,7 +72,7 @@ synthesis:
     #     # identifier attributes
     #     - attribute: k8s.object.name
     #       present: true
-    #     - attribute: k8.namespace.name
+    #     - attribute: k8s.namespace.name
     #       present: true
     #     - attribute: k8s.cluster.name
     #       present: true

--- a/entity-types/infra-kubernetes_statefulset/definition.yml
+++ b/entity-types/infra-kubernetes_statefulset/definition.yml
@@ -50,7 +50,7 @@ synthesis:
         separator: ":"
         attributes:
           - k8s.cluster.name
-          - k8.namespace.name
+          - k8s.namespace.name
           - k8s.object.name
       encodeIdentifierInGUID: true
       name: k8s.object.name
@@ -62,7 +62,7 @@ synthesis:
         # identifier attributes
         - attribute: k8s.object.name
           present: true
-        - attribute: k8.namespace.name
+        - attribute: k8s.namespace.name
           present: true
         - attribute: k8s.cluster.name
           present: true


### PR DESCRIPTION
### Relevant information

Expanding on the typo for k8s namespace name in k8s Otel 

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
