### PR TITLE
feat: added new rule for fb k8s entity with log event

### DIFF
--- a/entity-types/ext-fluentbit_kubernetes/definition.yml
+++ b/entity-types/ext-fluentbit_kubernetes/definition.yml
@@ -27,6 +27,26 @@ synthesis:
       version:
         entityTagName: fluentbit.version
         multiValue: false
+  - compositeIdentifier:
+        separator: ":"
+        attributes:
+          - cluster_name
+          - namespace_name
+          - annotations.log-forwarder/entity-name  
+    name: annotations.log-forwarder/entity-name
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: eventType
+      value: Log
+    - attribute: annotations.log-forwarder/type
+      value: fluent-bit-daemonset
+    tags:
+      annotations.log-forwarder/entity-name:
+        entityTagNames: [k8s.daemonsetName]
+      namespace_name:
+        entityTagNames: [k8s.namespaceName]
+      cluster_name:
+        entityTagNames: [k8s.clusterName]
 dashboardTemplates:
   newRelic:
     template: dashboard.json


### PR DESCRIPTION
### Relevant information

This PR attempts to add a new entity synthesis rule to the fluent bit kubernetes entity to synthesise entity from Log event types.

### Checklist

* [X] I've read the guidelines and understand the acceptance criteria.
* [X] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
