### PR TITLE
Update status of infra-container

### DIFF
--- a/entity-types/infra-container/definition.yml
+++ b/entity-types/infra-container/definition.yml
@@ -175,7 +175,7 @@ synthesis:
         entityTagNames: [k8s.deploymentName]
       k8s.node.name:
         entityTagNames: [k8s.nodeName]
-  # Docker Container from Samples
+  # Docker Container from Samples - NOT in use yet - see FF EntitySynthesis/ExtractEntityFromInfraTelemetry
   - identifier: entityId
     name: name
     legacyFeatures:
@@ -236,7 +236,7 @@ synthesis:
         entityTagName: aws.region
     prefixedTags:
       label.:
-  # K8s Container from Samples
+  # K8s Container from Samples - NOT in use yet - see FF EntitySynthesis/ExtractEntityFromInfraTelemetry
   - identifier: entityId
     name: containerName
     legacyFeatures:


### PR DESCRIPTION
not a code change, just adding to the comment to clarify the current status of Entity Synthesis for infra telemetry (Infra Data Platform / IDP). This change was agreed with both Mike (PM for K8s) and Faddy.

### Relevant information

The current entity synthesis rules for infra telemetry is confusing, because it tricks colleagues into believing that this would be active, and that changes to these rules would actually do something. That's not the case, and for that reason we clarify the status better in the comment that is the header for each of these 2 sections.


### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
