### PR TITLE
Change fluent bit host entity identifier

### DIFF
--- a/entity-types/ext-fluentbit_host/definition.yml
+++ b/entity-types/ext-fluentbit_host/definition.yml
@@ -2,7 +2,7 @@ domain: EXT
 type: FLUENTBIT_HOST
 synthesis:
   rules:
-  - identifier: hostname
+  - identifier: host.id
     name: hostname
     encodeIdentifierInGUID: true
     conditions:

--- a/relationships/synthesis/INFRA-HOST-to-EXT-FLUENTBIT_HOST.yml
+++ b/relationships/synthesis/INFRA-HOST-to-EXT-FLUENTBIT_HOST.yml
@@ -24,7 +24,7 @@ relationships:
             valueInGuid: NA
           identifier:
             fragments:
-              - attribute: hostname
+              - attribute: host.id
             hashAlgorithm: FARM_HASH
       target:
         extractGuid:


### PR DESCRIPTION
### Relevant information

This PR attempts to change the identifier attribute for the fluent bit host entity, in the entity definition and relationship definition.

### Checklist

* [X] I've read the guidelines and understand the acceptance criteria.
* [X] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
