### PR TITLE
Revert "fix: change fluent bit host entity identifier (#1962)"

### DIFF
--- a/entity-types/ext-fluentbit_host/definition.yml
+++ b/entity-types/ext-fluentbit_host/definition.yml
@@ -2,7 +2,7 @@ domain: EXT
 type: FLUENTBIT_HOST
 synthesis:
   rules:
-  - identifier: host.id
+  - identifier: hostname
     name: hostname
     encodeIdentifierInGUID: true
     conditions:

--- a/relationships/synthesis/INFRA-HOST-to-EXT-FLUENTBIT_HOST.yml
+++ b/relationships/synthesis/INFRA-HOST-to-EXT-FLUENTBIT_HOST.yml
@@ -24,7 +24,7 @@ relationships:
             valueInGuid: NA
           identifier:
             fragments:
-              - attribute: host.id
+              - attribute: hostname
             hashAlgorithm: FARM_HASH
       target:
         extractGuid:


### PR DESCRIPTION
This reverts commit 7d22deb3d633a10f0aefe72c133b806130d61da2.

### Relevant information
Reverting this change since it was meant to be just in STG and it was deployed to PROD. Will redeploy to STG afterwards
