### PR TITLE
Revert "Revert "fix: change fluent bit host entity identifier (#1962)……" (#1963)"

### DIFF
--- a/entity-types/ext-fluentbit_host/definition.yml
+++ b/entity-types/ext-fluentbit_host/definition.yml
@@ -2,7 +2,7 @@ domain: EXT
 type: FLUENTBIT_HOST
 synthesis:
   rules:
-  - identifier: hostname
+  - identifier: host.id
     name: hostname
     encodeIdentifierInGUID: true
     conditions:

--- a/relationships/synthesis/INFRA-HOST-to-EXT-FLUENTBIT_HOST.yml
+++ b/relationships/synthesis/INFRA-HOST-to-EXT-FLUENTBIT_HOST.yml
@@ -24,7 +24,7 @@ relationships:
             valueInGuid: NA
           identifier:
             fragments:
-              - attribute: hostname
+              - attribute: host.id
             hashAlgorithm: FARM_HASH
       target:
         extractGuid:


### PR DESCRIPTION
This reverts commit e89aaf9e4c53a7cb1692335f553042e226e9a601.

Reapplying https://github.com/newrelic/entity-definitions/pull/1962 after it was reverted as it was only needed to test in STG.
