### PR TITLE
Update k8s Host entity rule to test entities only

### DIFF
--- a/entity-types/infra-host/definition.yml
+++ b/entity-types/infra-host/definition.yml
@@ -42,6 +42,9 @@ synthesis:
         # if container.id is present, it's a container, not a host
         - attribute: container.id
           present: false
+        # value added for test entities only
+        - attribute: newrelicOnly
+          value: "true"
       tags:
         k8s.cluster.name:
         cloud.provider:


### PR DESCRIPTION

### Relevant information

this rule will be removed soon as the next agent release for now making it a test entity only

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
