### PR TITLE
[NR-375022] Add entity definition for AWS Unified Firehose - Logging Integrations

### DIFF
--- a/entity-types/ext-aws_firehose_log_forwarder/definition.yml
+++ b/entity-types/ext-aws_firehose_log_forwarder/definition.yml
@@ -1,0 +1,38 @@
+domain: EXT
+type: AWS_FIREHOSE_LOG_FORWARDER
+goldenTags:
+  - aws.region
+  - aws.accountId
+configuration:
+  entityExpirationTime: QUARTERLY
+  alertable: true
+synthesis:
+  rules:
+    - compositeIdentifier:
+        separator: ":"
+        attributes:
+          - awsRealm
+          - instrumentation.name
+          - awsRegion
+          - awsAccountId
+          - DeliveryStreamName
+          - logForwarder
+      # Option 2: - identifier: awslogForwarderArn
+      name: functionName
+      encodeIdentifierInGUID: true
+      legacyFeatures:
+        overrideGuidType: true
+      conditions:
+        - attribute: eventType
+          prefix: Metric
+        - attribute: logForwarder
+          present: true
+        - attribute: instrumentation.provider
+          value: aws
+        - attribute: instrumentation.name
+          value: firehose
+      tags:
+        # Can be Used for entity relationship candidates
+        # Metrics Streams and API Polling entities using the ARN to compute the entity.guid
+        aws.Arn:
+        aws.firehose.DeliveryStreamName:


### PR DESCRIPTION
### Relevant information

This PR is used to identify AWS unified firehose (AWS log forwarder) as an entity in NR. Documentation to this service is [here](https://docs.newrelic.com/install/aws-logs/) (select All other AWS services in the dropdown)

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
