### PR TITLE
Fix ext service redis rule

### DIFF
--- a/relationships/synthesis/EXT-SERVICE-to-REDIS.yml
+++ b/relationships/synthesis/EXT-SERVICE-to-REDIS.yml
@@ -34,41 +34,6 @@ relationships:
             - field: port
               attribute: net.peer.port
 
-  - name: extServiceCallsRedis1_20_Default_Port
-    version: "1"
-    origins:
-      - Distributed Tracing
-      - OpenTelemetry
-    conditions:
-      - attribute: eventType
-        anyOf: [ "Span" ]
-      - attribute: db.system
-        anyOf: [ "redis" ]
-      - attribute: newrelic.source 
-        anyOf: [ "api.traces.otlp" ] 
-      - attribute: entity.type 
-        anyOf: [ "SERVICE" ] 
-      - attribute: net.peer.name
-        regex: "^.*\\.cache\\.amazonaws\\.com$"
-      - attribute: net.peer.port
-        present: false
-      - attribute: newrelic.aws_metric_streams.arn
-        present: false
-    relationship:
-      expires: P75M
-      relationshipType: CALLS
-      source:
-        extractGuid:
-          attribute: entity.guid
-      target:
-        lookupGuid:
-          candidateCategory: REDIS
-          fields:
-            - field: endpoint
-              attribute: net.peer.name
-            - field: port
-              attribute: 6379 # Default port for redis
-
   - name: extServiceCallsRedis1_23
     version: "1"
     origins:
@@ -103,41 +68,6 @@ relationships:
               attribute: server.address
             - field: port
               attribute: server.port
-
-  - name: extServiceCallsRedis1_23_Default_Port
-    version: "1"
-    origins:
-      - Distributed Tracing
-      - OpenTelemetry
-    conditions:
-      - attribute: eventType
-        anyOf: [ "Span" ]
-      - attribute: db.system
-        anyOf: [ "redis" ]
-      - attribute: newrelic.source 
-        anyOf: [ "api.traces.otlp" ] 
-      - attribute: entity.type 
-        anyOf: [ "SERVICE" ] 
-      - attribute: server.address
-        regex: "^.*\\.cache\\.amazonaws\\.com$"
-      - attribute: server.port
-        present: false
-      - attribute: newrelic.aws_metric_streams.arn
-        present: false
-    relationship:
-      expires: P75M
-      relationshipType: CALLS
-      source:
-        extractGuid:
-          attribute: entity.guid
-      target:
-        lookupGuid:
-          candidateCategory: REDIS
-          fields:
-            - field: endpoint
-              attribute: server.address
-            - field: port
-              attribute: 6379 # Default port for redis
 
   - name: extServiceCallsRedis_Explicit
     version: "1"


### PR DESCRIPTION
### Relevant information

This PR remove two invalid relationship synthesis rules defined for EXT-SERVICE-REDIS.

Literals are not supported in the attribute field. The attribute field must specify a telemetry attribute where the value will be retrieved from.

The issue was introduced in the commit https://github.com/newrelic/entity-definitions/commit/81fa2c6d47872f119d47ddff4110747ed1409dac


### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
