### PR TITLE
NR-386014 added entity definition for aws firehose log forwarder

### DIFF
--- a/entity-types/ext-aws_firehose_log_forwarder/definition.yml
+++ b/entity-types/ext-aws_firehose_log_forwarder/definition.yml
@@ -22,3 +22,5 @@ synthesis:
         # Can be Used for entity relationship candidates
         # Metrics Streams and API Polling entities using the ARN to compute the entity.guid
         aws.Arn:
+        instrumentation.version:
+          multiValue: false

--- a/entity-types/ext-aws_firehose_log_forwarder/definition.yml
+++ b/entity-types/ext-aws_firehose_log_forwarder/definition.yml
@@ -1,0 +1,24 @@
+domain: EXT
+type: AWS_FIREHOSE_LOG_FORWARDER
+goldenTags:
+- aws.region
+- aws.accountId
+configuration:
+  entityExpirationTime: QUARTERLY
+  alertable: true
+synthesis:
+  rules:
+    - identifier: awsLogForwarderArn
+      name: logForwarderName
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: eventType
+          value: Metric
+        - attribute: awslogForwarderArn
+          present: true
+        - attribute: instrumentation.name
+          value: firehose
+      tags:
+        # Can be Used for entity relationship candidates
+        # Metrics Streams and API Polling entities using the ARN to compute the entity.guid
+        aws.Arn:

--- a/entity-types/ext-aws_firehose_log_forwarder/definition.yml
+++ b/entity-types/ext-aws_firehose_log_forwarder/definition.yml
@@ -14,7 +14,7 @@ synthesis:
       conditions:
         - attribute: eventType
           value: Metric
-        - attribute: awslogForwarderArn
+        - attribute: awsLogForwarderArn
           present: true
         - attribute: instrumentation.name
           value: firehose

--- a/entity-types/ext-aws_firehose_log_forwarder/tests/Metric.json
+++ b/entity-types/ext-aws_firehose_log_forwarder/tests/Metric.json
@@ -1,0 +1,8 @@
+[
+    {
+      "instrumentation.name": "firehose",
+      "awslogForwarderArn": "nr-logforwarder:arn:aws:firehose:us-east-1:123456789012:deliverystream/example-firehose-stream",
+      "logForwarderName": "nr-logforwarder-example-firehose-stream",
+      "eventType": "Metric"
+    }
+  ]

--- a/entity-types/ext-aws_firehose_log_forwarder/tests/Metric.json
+++ b/entity-types/ext-aws_firehose_log_forwarder/tests/Metric.json
@@ -1,7 +1,7 @@
 [
     {
       "instrumentation.name": "firehose",
-      "awslogForwarderArn": "nr-logforwarder:arn:aws:firehose:us-east-1:123456789012:deliverystream/example-firehose-stream",
+      "awsLogForwarderArn": "nr-logforwarder:arn:aws:firehose:us-east-1:123456789012:deliverystream/example-firehose-stream",
       "logForwarderName": "nr-logforwarder-example-firehose-stream",
       "eventType": "Metric"
     }

--- a/entity-types/ext-aws_firehose_log_forwarder/tests/Metric.json
+++ b/entity-types/ext-aws_firehose_log_forwarder/tests/Metric.json
@@ -2,7 +2,6 @@
     {
       "instrumentation.name": "firehose",
       "awsLogForwarderArn": "nr-logforwarder:arn:aws:firehose:us-east-1:123456789012:deliverystream/example-firehose-stream",
-      "logForwarderName": "nr-logforwarder-example-firehose-stream",
-      "eventType": "Metric"
+      "logForwarderName": "nr-logforwarder-example-firehose-stream"
     }
   ]


### PR DESCRIPTION
### Relevant information

This PR adds entity definition for a new entity called AWS_FIREHOSE_LOG_FORWARDER.

### Checklist

* [X] I've read the guidelines and understand the acceptance criteria.
* [X] The value of the attribute marked as `identifier` will be unique and valid. 
* [X] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
