### PR TITLE
Update golden_metrics.yml

### DIFF
--- a/entity-types/infra-f5node/golden_metrics.yml
+++ b/entity-types/infra-f5node/golden_metrics.yml
@@ -6,7 +6,7 @@ availability:
       select: average(`node.availabilityState`)
       from: F5BigIpNodeSample
       eventId: entityGuid
-      eventName: ENTITY_GUIDS
+      eventName: entityName
 monitorStatus:
   title: Health monitor status
   unit: COUNT
@@ -15,7 +15,7 @@ monitorStatus:
       select: average(`node.monitorStatus`)
       from: F5BigIpNodeSample
       eventId: entityGuid
-      eventName: ENTITY_GUIDS
+      eventName: entityName
 sessionStatus:
   title: Session Status
   unit: COUNT
@@ -24,5 +24,5 @@ sessionStatus:
       select: average(`node.sessionStatus`)
       from: F5BigIpNodeSample
       eventId: entityGuid
-      eventName: ENTITY_GUIDS
+      eventName: entityName
 


### PR DESCRIPTION
Change the eventName from `ENTITY_GUIDS` to entityName as suggested by GSP team, because the queries are broken with the current definition


* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
