### PR TITLE
add useNonStandardAttributes to INFRA-MYSQLNODE

### DIFF
--- a/entity-types/infra-mysqlnode/definition.yml
+++ b/entity-types/infra-mysqlnode/definition.yml
@@ -29,6 +29,8 @@ synthesis:
 
     - identifier: entityId
       name: entityName
+      legacyFeatures:
+        useNonStandardAttributes: true
       prefixedTags:
         label.:
           ttl: PT4H

--- a/entity-types/infra-mysqlnode/tests/MysqlSample.json
+++ b/entity-types/infra-mysqlnode/tests/MysqlSample.json
@@ -105,7 +105,7 @@
     "net.maxUsedConnections": 2536,
     "net.threadsConnected": 2163,
     "net.threadsRunning": 2,
-    "nr.entityType": "MySQLNode",
+    "entityType": "MYSQLNODE",
     "nr.ingestTimeMs": 1746796787000,
     "nr.invalidAttributeCount": 2,
     "operatingSystem": "linux",


### PR DESCRIPTION
### Relevant information
  Adding legacyFeatures : useNonStandardAttributes to INFRA-MYSQLNODE to use entityGuid, entityName and entityId for materializing the entity

  

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
