### PR TITLE
add overrideGuidType legacy attribute to INFRA-MYSQLNODE

### DIFF
--- a/entity-types/infra-mysqlnode/definition.yml
+++ b/entity-types/infra-mysqlnode/definition.yml
@@ -31,6 +31,7 @@ synthesis:
       name: entityName
       legacyFeatures:
         useNonStandardAttributes: true
+        overrideGuidType: true
       prefixedTags:
         label.:
           ttl: PT4H


### PR DESCRIPTION
### Relevant information

<!--
add missing legacy attribute to MYSQL NODE
-->

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
