### PR TITLE
fix: Remove local port from eBPF client role entity

### DIFF
--- a/entity-types/ext-service/definition.yml
+++ b/entity-types/ext-service/definition.yml
@@ -77,6 +77,8 @@ synthesis:
       value: opentelemetry
     - attribute: newrelic.entity.type
       present: false
+    - attribute: trace_role
+      present: false
     tags:
       k8s.cluster.name:
         ttl: P1D
@@ -149,13 +151,15 @@ synthesis:
         entityTagName: k8s.deploymentName
         ttl: P1D
     
-    # telemetry from NR eBPF agent
+    # telemetry from NR eBPF agent client
   - identifier: service.name
     name: service.name
     encodeIdentifierInGUID: true
     conditions:
     - attribute: instrumentation.name
       value: nr_ebpf
+    - attribute: trace_role
+      value: client
     - attribute: service.name
     tags:
       k8s.cluster.name:
@@ -167,8 +171,29 @@ synthesis:
       deployment.name:
         entityTagName: k8s.deploymentName
         ttl: P1D
-      trace_role:
-        entityTagName: service.role
+      host.name:
+      local_addr:
+
+    # telemetry from NR eBPF agent server
+  - identifier: service.name
+    name: service.name
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: instrumentation.name
+      value: nr_ebpf
+    - attribute: trace_role
+      value: server
+    - attribute: service.name
+    tags:
+      k8s.cluster.name:
+        entityTagName: k8s.clusterName
+        ttl: P1D
+      k8s.namespace.name:
+        entityTagName: k8s.namespaceName
+        ttl: P1D
+      deployment.name:
+        entityTagName: k8s.deploymentName
+        ttl: P1D
       host.name:
       local_addr:
       local_port:


### PR DESCRIPTION
### Relevant information

- Added exclusion in otel rule for when `trace_role` field is present
- Add separate role for eBPF client and server as we don't want to add port tag for client
Removed 
<!--
  Describe what you have done.
  Provide details that are relevant to the PR

  Always think that the person reviewing the PR doesn't have the context you have.

  Links to examples, documentation and similar resources make the process easier to review.
-->

<!--
  Contributions to this repository are reviewed at least twice a week

  There's no further action required once the PR has been created.
 -->

### Checklist

* [X] I've read the guidelines and understand the acceptance criteria.
* [X] The value of the attribute marked as `identifier` will be unique and valid. 
* [X] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
