### PR TITLE
fix k8s cluster candidate after tag renaming

### DIFF
--- a/relationships/candidates/KUBERNETESCLUSTER.yml
+++ b/relationships/candidates/KUBERNETESCLUSTER.yml
@@ -6,7 +6,7 @@ lookups:
     tags:
       matchingMode: ANY
       predicates:
-        - tagKeys: [ "displayname", "k8s.cluster.name" ]
+        - tagKeys: [ "displayname", "k8s.cluster.name", "k8s.clusterName" ]
           field: cluster.name
     onMatch:
       onMultipleMatches: RELATE_ALL


### PR DESCRIPTION
### Relevant information

fix k8s cluster candidate after tag renaming
https://github.com/newrelic/entity-definitions/pull/1988/files#diff-96cf068cf6341a9af9e6f95e394bd9be6a7dff844153839708721ab7db0993a9

https://new-relic.atlassian.net/browse/NR-416403 

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
