### PR TITLE
Changed relationship TTL of AWS Lambda log forwarder entities

### DIFF
--- a/relationships/synthesis/EXT-AWS_FIREHOSE_LOG_FORWARDER-to-INFRA-KINESSISDELIVERYSTREAM.yml
+++ b/relationships/synthesis/EXT-AWS_FIREHOSE_LOG_FORWARDER-to-INFRA-KINESSISDELIVERYSTREAM.yml
@@ -11,7 +11,7 @@ relationships:
       - attribute: instrumentation.name
         anyOf: [ "firehose" ]
     relationship:
-      expires: P75M
+      expires: P72H
       relationshipType: IS
       source:
         extractGuid:

--- a/relationships/synthesis/EXT-AWS_LAMBDA_LOG_FORWARDER-to-INFRA-AWSLAMBDAFUNCTION.yml
+++ b/relationships/synthesis/EXT-AWS_LAMBDA_LOG_FORWARDER-to-INFRA-AWSLAMBDAFUNCTION.yml
@@ -11,7 +11,7 @@ relationships:
       - attribute: instrumentation.name
         anyOf: [ "lambda" ]
     relationship:
-      expires: P75M
+      expires: P72H
       relationshipType: IS
       source:
         extractGuid:


### PR DESCRIPTION
### Relevant information

This PR attempts to change the expiry on the relationships on AWS Log Forwarder entities from 75 minutes to 72 hours.

### Checklist

* [X] I've read the guidelines and understand the acceptance criteria.
* [X] The value of the attribute marked as `identifier` will be unique and valid. 
* [X] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
