### PR TITLE
[NR-416254] - Added AWS ECS Task Definition into Entity Definitions

### DIFF
--- a/entity-types/infra-awsecstaskdefinition/definition.yml
+++ b/entity-types/infra-awsecstaskdefinition/definition.yml
@@ -1,0 +1,8 @@
+domain: INFRA
+type: AWSECSTASKDEFINITION
+goldenTags:
+  - aws.accountId
+  - aws.region
+configuration:
+  entityExpirationTime: DAILY
+  alertable: false


### PR DESCRIPTION
### Relevant information
-- AWS ECS Task Definition is the new entity type introduced in CLOUDWATCH METRICS STREAMS integrations.
-- Related PR in beyond to synthesize the entity - https://source.datanerd.us/beyond/beyond-common/pull/245

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
