### PR TITLE
Update Deployment relationship to reflect the Deployment attribute fi…

### DIFF
--- a/relationships/candidates/KUBERNETES_DEPLOYMENT.yml
+++ b/relationships/candidates/KUBERNETES_DEPLOYMENT.yml
@@ -6,8 +6,8 @@ lookups:
     tags:
       matchingMode: ANY
       predicates:
-        - tagKeys: ["k8s.replicasetName"]
-          field: k8s.replicaset.name
+        - tagKeys: ["k8s.deploymentName"]
+          field: k8s.deployment.name
         - tagKeys: ["k8s.namespaceName"]
           field: k8s.namespace.name
         - tagKeys: ["k8s.clusterName"]

--- a/relationships/synthesis/INFRA-KUBERNETES_DEPLOYMENT-to-INFRA-KUBERNETES_POD.yml
+++ b/relationships/synthesis/INFRA-KUBERNETES_DEPLOYMENT-to-INFRA-KUBERNETES_POD.yml
@@ -32,31 +32,29 @@ relationships:
           attribute: entityGuid
           entityType:
             value: KUBERNETES_POD
-  - name: otelKsmK8sDeploymentContainsPod
-    # use kube-state-metrics kube_pod_owner metric
+  - name: otelKsmK8sDeploymentManagesPod
+    # use kube-state-metrics kube_deployment_status_condition metric
     version: "1"
     origins: 
       - OpenTelemetry
     conditions:
       - attribute: metricName
-        anyOf: [ "kube_pod_owner" ]
-      - attribute: owner_kind
-        anyOf: [ "ReplicaSet" ]
+        anyOf: [ "kube_deployment_status_condition" ]
       - attribute: newrelicOnly
         anyOf: [ "true" ]
     relationship:
       expires: P75M
-      relationshipType: CONTAINS
+      relationshipType: MANAGES
       source:
         lookupGuid:
           candidateCategory: KUBERNETES_DEPLOYMENT
           fields:
-            - field: k8s.replicaset.name # replicaset owned by deployment
-              attribute: owner_name # replicaset which owns pod
-            - field: k8s.namespace.name # namespace of deployment
-              attribute: k8s.namespace.name # namespace of pod
-            - field: cluster # cluster of deployment
-              attribute: k8s.cluster.name # cluster of pod
+            - field: k8s.deployment.name 
+              attribute: k8s.deployment.name
+            - field: k8s.namespace.name
+              attribute: k8s.namespace.name
+            - field: k8s.cluster.name
+              attribute: k8s.cluster.name
       target:
         extractGuid:
           attribute: entity.guid


### PR DESCRIPTION

### Relevant information

- Update Deployment relationship to reflect the Deployment attribute fix in helm charts
- We now have k8s.deployment.name attribution using that instead of replicaSet


### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
