### PR TITLE
fix: change datasource in golden metrics definition for AWS firehose log forwarder entity

### DIFF
--- a/entity-types/ext-aws_firehose_log_forwarder/golden_metrics.yml
+++ b/entity-types/ext-aws_firehose_log_forwarder/golden_metrics.yml
@@ -2,6 +2,6 @@ deliveryToHttpEndpointSuccessRate:
   title: Delivery to HTTP Endpoint Success Rate (%)
   unit: PERCENTAGE
   queries:
-    default:
-      select: average(`DeliveryToHttpEndpoint.Success (Average)`) * 100
+    newRelic:
+      select: average(`DeliveryToHttpEndpoint.Success (Average)`) * 100 AS 'Delivery Success Rate (%)'
       from: Metric


### PR DESCRIPTION
### Relevant information

This PR attempts to fix the issue of summary metrics not showing up for the AWS_FIREHOSE_LOG_FORWARDER entity.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
