### PR TITLE
filtering out otel jobs

### DIFF
--- a/entity-types/ext-service/definition.yml
+++ b/entity-types/ext-service/definition.yml
@@ -54,6 +54,10 @@ synthesis:
       present: false
     - attribute: newrelic.entity.type
       present: false
+
+      # Filters out opentelemetry scrape Jobs
+    - attribute: job_label
+      present: false
     tags:
       k8s.cluster.name:
         ttl: P1D
@@ -78,6 +82,9 @@ synthesis:
     - attribute: newrelic.entity.type
       present: false
     - attribute: trace_role
+      present: false
+      # Filters out opentelemetry scrape Jobs
+    - attribute: job_label
       present: false
     tags:
       k8s.cluster.name:
@@ -150,7 +157,7 @@ synthesis:
       k8s.deployment.name:
         entityTagName: k8s.deploymentName
         ttl: P1D
-    
+
     # telemetry from NR eBPF agent client
   - identifier: service.name
     name: service.name
@@ -219,6 +226,11 @@ synthesis:
       present: false
     - attribute: ebpf_entity
       present: false
+
+    # Filters out Otel Jobs
+    - attribute: instrumentation.provider
+      value: opentelemetry
+
     tags:
       k8s.cluster.name:
         ttl: P1D


### PR DESCRIPTION
### Relevant information

<!--
  Describe what you have done.
  Provide details that are relevant to the PR

  Always think that the person reviewing the PR doesn't have the context you have.

  Links to examples, documentation and similar resources make the process easier to review.
-->

Filtering out Otel scrape jobs via the job_label attribute. 
Added this rule to the Otel entity synthesis for Otel Service entities. 
Wanted to filter out all Otel Services from the catch all rule with something like. 

    - attribute: instrumentation.provider
      value_not_equal: opentelemetry

However such a config doesn't exist. 
So added the less specific 
    - attribute: job_label
      present: false

to the catch all rule as well. 
<!--
  Contributions to this repository are reviewed at least twice a week

  There's no further action required once the PR has been created.
 -->

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
