### PR TITLE
feat: Add new lookup defining container candidate relationship for cgroups v2

### DIFF
--- a/relationships/candidates/CONTAINER.yml
+++ b/relationships/candidates/CONTAINER.yml
@@ -14,3 +14,23 @@ lookups:
       action: CREATE_UNINSTRUMENTED
       uninstrumented:
         type: CONTAINER
+  - entityTypes:
+      - domain: INFRA
+        type: CONTAINER
+    tags:
+      matchingMode: ALL
+      predicates:
+        - tagKeys: [ "k8s.clusterName" ]
+          field: k8sClusterName
+        - tagKeys: [ "k8s.namespaceName" ]
+          field: k8sNamespaceName
+        - tagKeys: [ "k8s.podName" ]
+          field: k8sPodName
+        - tagKeys: [ "k8s.containerName" ]
+          field: k8sContainerName
+    onMatch:
+      onMultipleMatches: RELATE_ALL
+    onMiss:
+      action: CREATE_UNINSTRUMENTED
+      uninstrumented:
+        type: CONTAINER


### PR DESCRIPTION
### Relevant information

Add a new lookup in for the CONTAINER candidate relationship definition to allow creating relationship between K8s container and Services without container id, using the clusterName, namespaceName, podName and containerName instead.

This rule should enabled cgroups v2 containers to be related to services without the need of container id. 

The previous attempt of including this rule was done here: https://github.com/newrelic/entity-definitions/pull/1763

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
