### PR TITLE
Update ext-service opentelemetry golden metrics to be based on apm.service.transaction.duration

### DIFF
--- a/entity-types/ext-service/golden_metrics.yml
+++ b/entity-types/ext-service/golden_metrics.yml
@@ -3,9 +3,8 @@ throughput:
   unit: REQUESTS_PER_MINUTE
   queries:
     opentelemetry:
-      select: rate(count(%.server%duration), 1 minute)
+      select: rate(count(apm.service.transaction.duration), 1 minute)
       from: Metric
-      where: http.server.duration IS NOT NULL OR http.server.request.duration IS NOT NULL OR rpc.server.duration IS NOT NULL
     newrelic-opentelemetry:
       select: rate(count(apm.service.transaction.duration), 1 minute)
       from: Metric
@@ -23,9 +22,8 @@ errorRate:
   unit: PERCENTAGE
   queries:
     opentelemetry:
-      select: filter(count(%.server%duration), WHERE numeric(http.status_code) >= 500 OR numeric(http.response.status_code) >= 500) * 100 / count(%.server%duration)
+      select: sum(apm.service.error.count) * 100 / count(apm.service.transaction.duration)
       from: Metric
-      where: http.server.duration IS NOT NULL OR http.server.request.duration IS NOT NULL
     newrelic-opentelemetry:
       select: sum(apm.service.error.count) * 100 / count(apm.service.transaction.duration)
       from: Metric
@@ -43,11 +41,10 @@ responseTimeMs:
   unit: MS
   queries:
     opentelemetry:
-      select: average(convert(%.server%duration, unit OR 's', 'ms'))
+      select: average(convert(apm.service.transaction.duration, unit OR 's', 'ms'))
       from: Metric
-      where: http.server.duration IS NOT NULL OR http.server.request.duration IS NOT NULL OR rpc.server.duration IS NOT NULL
     newrelic-opentelemetry:
-      select: average(convert(apm.service.transaction.duration, unit, 'ms'))
+      select: average(convert(apm.service.transaction.duration, unit OR 's', 'ms'))
       from: Metric
     kamon-agent:
       select: average(http.server.requests)


### PR DESCRIPTION
Replaces #2099 

**DO NOT RELEASE TO PRODUCTION UNTIL FULLY VALIDATED**