### PR TITLE
fix(oci): Enhance OCI Entity Mapping with Ingested Data

### DIFF
--- a/entity-types/infra-ocihealthcheck/definition.yml
+++ b/entity-types/infra-ocihealthcheck/definition.yml
@@ -28,3 +28,13 @@ synthesis:
       prefix: "ocid1.httpmonitor"
     - attribute: oci.namespace
       value: "oci_healthchecks"
+  - identifier: oci.resourceId
+    name: oci.resourceDisplayName
+    legacyFeatures:
+      overrideGuidType: true
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: oci.resourceId
+      prefix: "ocid1.pingmonitor"
+    - attribute: oci.namespace
+      value: "oci_healthchecks"

--- a/entity-types/infra-ociobjectstorage/definition.yml
+++ b/entity-types/infra-ociobjectstorage/definition.yml
@@ -15,13 +15,13 @@ synthesis:
     newrelic.cloudIntegrations.providerAccountName:
       entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
   rules:
-  - identifier: oci.resourceId
+  - identifier: oci.resourceID
     name: oci.resourceDisplayName
     legacyFeatures:
       overrideGuidType: true
     encodeIdentifierInGUID: true
     conditions:
-    - attribute: oci.resourceId
+    - attribute: oci.resourceID
       prefix: "ocid1.bucket"
     - attribute: oci.namespace
       value: "oci_objectstorage"

--- a/entity-types/infra-ociobjectstorage/tests/Metric.json
+++ b/entity-types/infra-ociobjectstorage/tests/Metric.json
@@ -3,7 +3,7 @@
     "oci.compartmentId": "ocid1.compartment.oc1..aaaaaaaabbbbbbccccccccdddddddeeeeeeefffffffgggggggghhhhhhhhiiiiiiiiijjjjjjjj",
     "oci.namespace": "oci_objectstorage",
     "oci.region": "ap-hyderabad-1",
-    "oci.resourceId": "ocid1.bucket.oc1.ap-hyderabad-1.aaaaaaaabbbbbbccccccccdddddddeeeeeeefffffffgggggggghhhhhhhhiiiiiiiiijjjjjjjj",
+    "oci.resourceID": "ocid1.bucket.oc1.ap-hyderabad-1.aaaaaaaabbbbbbccccccccdddddddeeeeeeefffffffgggggggghhhhhhhhiiiiiiiiijjjjjjjj",
     "oci.resourceDisplayName": "test",
     "oci.displayName": "test",
     "collector.name": "oci-monitor",


### PR DESCRIPTION
### Description

This PR updates the OCI entities based on the data ingested from the OCI platform.

### Relevant information

- Add synthesis rule for ping monitor
- Modify resourceId to resourceID for objectstorage

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
