### PR TITLE
feat: Add multivalue false property to container tags

### DIFF
--- a/entity-types/infra-container/definition.yml
+++ b/entity-types/infra-container/definition.yml
@@ -3,657 +3,676 @@ type: CONTAINER
 
 synthesis:
   rules:
-  # Dockerstats receiver from otel collector.
-  - identifier: container.id
-    name: container.name
-    encodeIdentifierInGUID: true
-    conditions:
-      - attribute: eventType
-        value: Metric
-      # All metrics from the receiver starts with the 'container.' prefix.
-      - attribute: metricName
-        prefix: container.
-      - attribute: instrumentation.provider
-        value: opentelemetry
-      # This filters only metrics comming from docker receiver, given that metrics
-      # could deffer between different runtime receivers.
-      - attribute: otel.library.name
-        value: otelcol/dockerstatsreceiver
-    tags:
-      # Default resource attributes
-      container.runtime:
-      container.image.name:
-      container.hostname:
-      # Optional resource attribute
-      container.image.id:
-      # Environment resource attributes
-      host.type:
-      cloud.provider:
-      cloud.account.id:
-      cloud.region:
-      host.id:
-      host.name:
-      # The library name contains the name of the receiver that is used to identify the source
-      # and select the dashboard.
-      otel.library.name:
-        entityTagName: instrumentation.name
-  # kube-state-metrics data via opentelemetry prometheusReceiver
-  - compositeIdentifier:
-      separator: ":"
-      attributes:
-        - k8s.cluster.name
-        - k8s.namespace.name
-        - k8s.pod.name
-        - k8s.container.name
-    encodeIdentifierInGUID: true
-    name: k8s.container.name
-    conditions:
-      # kube-state-metrics container prefix
-      - attribute: metricName
-        prefix: kube_pod_container_
-      # identifier attributes
-      - attribute: k8s.container.name
-        present: true
-      - attribute: k8s.pod.name
-        present: true
-      - attribute: k8s.namespace.name
-        present: true
-      - attribute: k8s.cluster.name
-        present: true
-      # open telemetry
-      - attribute: newrelic.source
-        value: 'api.metrics.otlp'
-      # if service.name is present, handle as one
-      - attribute: service.name
-        present: false
-    tags:
-      container_id:
-        entityTagNames: [k8s.containerId]
-        multiValue: false
-      image:
-        entityTagNames: [k8s.containerImage]
-      k8s.container.name:
-        entityTagNames: [k8s.containerName]
-      k8s.pod.name:
-        entityTagNames: [k8s.podName]
-      k8s.namespace.name:
-        entityTagNames: [k8s.namespaceName]
-      k8s.cluster.name:
-        entityTagNames: [k8s.clusterName]
-      k8s.deployment.name:
-        entityTagNames: [k8s.deploymentName]
-      k8s.daemonset.name:
-        entityTagNames: [k8s.daemonsetName]
-      newrelic.chart.version:
-        entityTagNames: [newrelic.chartVersion]
-        ttl: P1D
-
+    # Dockerstats receiver from otel collector.
+    - identifier: container.id
+      name: container.name
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: eventType
+          value: Metric
+        # All metrics from the receiver starts with the 'container.' prefix.
+        - attribute: metricName
+          prefix: container.
+        - attribute: instrumentation.provider
+          value: opentelemetry
+        # This filters only metrics comming from docker receiver, given that metrics
+        # could deffer between different runtime receivers.
+        - attribute: otel.library.name
+          value: otelcol/dockerstatsreceiver
+      tags:
+        # Default resource attributes
+        container.runtime:
+        container.image.name:
+        container.hostname:
+        # Optional resource attribute
+        container.image.id:
+        # Environment resource attributes
+        host.type:
+        cloud.provider:
+        cloud.account.id:
+        cloud.region:
+        host.id:
+        host.name:
+        # The library name contains the name of the receiver that is used to identify the source
+        # and select the dashboard.
+        otel.library.name:
+          entityTagName: instrumentation.name
     # kube-state-metrics data via opentelemetry prometheusReceiver
-  - compositeIdentifier:
-      separator: ":"
-      attributes:
-        - k8s.cluster.name
-        - k8s.namespace.name
-        - k8s.pod.name
-        - k8s.container.name
-    encodeIdentifierInGUID: true
-    name: k8s.container.name
-    conditions:
-      # kube-state-metrics container prefix
-      - attribute: metricName
-        prefix: kube_pod_container_
-      # identifier attributes
-      - attribute: k8s.container.name
-        present: true
-      - attribute: k8s.pod.name
-        present: true
-      - attribute: k8s.namespace.name
-        present: true
-      - attribute: k8s.cluster.name
-        present: true
-      # open telemetry
-      - attribute: newrelic.source
-        value: 'api.metrics.otlp'
-      # if newrelic.entity.type is present, it's not a service
-      - attribute: service.name
-        present: true
-      - attribute: newrelic.entity.type
-        present: true
-    tags:
-      container_id:
-        entityTagNames: [k8s.containerId]
-        multiValue: false
-      image:
-        entityTagNames: [k8s.containerImage]
-      k8s.container.name:
-        entityTagNames: [k8s.containerName]
-      k8s.pod.name:
-        entityTagNames: [k8s.podName]
-      k8s.namespace.name:
-        entityTagNames: [k8s.namespaceName]
-      k8s.cluster.name:
-        entityTagNames: [k8s.clusterName]
-      k8s.deployment.name:
-        entityTagNames: [k8s.deploymentName]
-      k8s.daemonset.name:
-        entityTagNames: [k8s.daemonsetName]
-      newrelic.chart.version:
-        entityTagNames: [newrelic.chartVersion]
-        ttl: P1D
+    - compositeIdentifier:
+        separator: ":"
+        attributes:
+          - k8s.cluster.name
+          - k8s.namespace.name
+          - k8s.pod.name
+          - k8s.container.name
+      encodeIdentifierInGUID: true
+      name: k8s.container.name
+      conditions:
+        # kube-state-metrics container prefix
+        - attribute: metricName
+          prefix: kube_pod_container_
+        # identifier attributes
+        - attribute: k8s.container.name
+          present: true
+        - attribute: k8s.pod.name
+          present: true
+        - attribute: k8s.namespace.name
+          present: true
+        - attribute: k8s.cluster.name
+          present: true
+        # open telemetry
+        - attribute: newrelic.source
+          value: "api.metrics.otlp"
+        # if service.name is present, handle as one
+        - attribute: service.name
+          present: false
+      tags:
+        container_id:
+          entityTagNames: [k8s.containerId]
+          multiValue: false
+        image:
+          entityTagNames: [k8s.containerImage]
+        k8s.container.name:
+          entityTagNames: [k8s.containerName]
+        k8s.pod.name:
+          entityTagNames: [k8s.podName]
+          multiValue: false
+        k8s.namespace.name:
+          entityTagNames: [k8s.namespaceName]
+          multiValue: false
+        k8s.cluster.name:
+          entityTagNames: [k8s.clusterName]
+        k8s.deployment.name:
+          entityTagNames: [k8s.deploymentName]
+        k8s.daemonset.name:
+          entityTagNames: [k8s.daemonsetName]
+        newrelic.chart.version:
+          entityTagNames: [newrelic.chartVersion]
+          ttl: P1D
 
-    # cAdvisor data via opentelemetry prometheusReceiver
-  - compositeIdentifier:
-      separator: ":"
-      attributes:
-        - k8s.cluster.name
-        - k8s.namespace.name
-        - k8s.pod.name
-        - k8s.container.name
-    encodeIdentifierInGUID: true
-    name: k8s.container.name
-    conditions:
-      # cadvisor container prefix
-      - attribute: metricName
-        prefix: container_
-      # identifier attributes
-      - attribute: k8s.container.name
-        present: true
-      - attribute: k8s.pod.name
-        present: true
-      - attribute: k8s.namespace.name
-        present: true
-      - attribute: k8s.cluster.name
-        present: true
-      # if image is present, it's a container, else a pod
-      - attribute: image
-        present: true
-      # open telemetry
-      - attribute: newrelic.source
-        value: 'api.metrics.otlp'
-      # if service.name is present, handle as one
-      - attribute: service.name
-        present: false
-    tags:
-      k8s.container.name:
-        entityTagNames: [k8s.containerName]
-      k8s.pod.name:
-        entityTagNames: [k8s.podName]
-      k8s.namespace.name:
-        entityTagNames: [k8s.namespaceName]
-      k8s.cluster.name:
-        entityTagNames: [k8s.clusterName]
-      k8s.node.name:
-        entityTagNames: [k8s.nodeName]
-      k8s.deployment.name:
-        entityTagNames: [k8s.deploymentName]
-      k8s.daemonset.name:
-        entityTagNames: [k8s.daemonsetName]
-      newrelic.chart.version:
-        entityTagNames: [newrelic.chartVersion]
-        ttl: P1D
+      # kube-state-metrics data via opentelemetry prometheusReceiver
+    - compositeIdentifier:
+        separator: ":"
+        attributes:
+          - k8s.cluster.name
+          - k8s.namespace.name
+          - k8s.pod.name
+          - k8s.container.name
+      encodeIdentifierInGUID: true
+      name: k8s.container.name
+      conditions:
+        # kube-state-metrics container prefix
+        - attribute: metricName
+          prefix: kube_pod_container_
+        # identifier attributes
+        - attribute: k8s.container.name
+          present: true
+        - attribute: k8s.pod.name
+          present: true
+        - attribute: k8s.namespace.name
+          present: true
+        - attribute: k8s.cluster.name
+          present: true
+        # open telemetry
+        - attribute: newrelic.source
+          value: "api.metrics.otlp"
+        # if newrelic.entity.type is present, it's not a service
+        - attribute: service.name
+          present: true
+        - attribute: newrelic.entity.type
+          present: true
+      tags:
+        container_id:
+          entityTagNames: [k8s.containerId]
+          multiValue: false
+        image:
+          entityTagNames: [k8s.containerImage]
+        k8s.container.name:
+          entityTagNames: [k8s.containerName]
+        k8s.pod.name:
+          entityTagNames: [k8s.podName]
+          multiValue: false
+        k8s.namespace.name:
+          entityTagNames: [k8s.namespaceName]
+          multiValue: false
+        k8s.cluster.name:
+          entityTagNames: [k8s.clusterName]
+        k8s.deployment.name:
+          entityTagNames: [k8s.deploymentName]
+        k8s.daemonset.name:
+          entityTagNames: [k8s.daemonsetName]
+        newrelic.chart.version:
+          entityTagNames: [newrelic.chartVersion]
+          ttl: P1D
 
-    # cAdvisor data via opentelemetry prometheusReceiver
-  - compositeIdentifier:
-      separator: ":"
-      attributes:
-        - k8s.cluster.name
-        - k8s.namespace.name
-        - k8s.pod.name
-        - k8s.container.name
-    encodeIdentifierInGUID: true
-    name: k8s.container.name
-    conditions:
-      # cadvisor container prefix
-      - attribute: metricName
-        prefix: container_
-      # identifier attributes
-      - attribute: k8s.container.name
-        present: true
-      - attribute: k8s.pod.name
-        present: true
-      - attribute: k8s.namespace.name
-        present: true
-      - attribute: k8s.cluster.name
-        present: true
-      # if image is present, it's a container, else a pod
-      - attribute: image
-        present: true
-      # open telemetry
-      - attribute: newrelic.source
-        value: 'api.metrics.otlp'
-      # if newrelic.entity.type is present, it's not a service
-      - attribute: service.name
-        present: true
-      - attribute: newrelic.entity.type
-        present: true
-    tags:
-      k8s.container.name:
-        entityTagNames: [k8s.containerName]
-      k8s.pod.name:
-        entityTagNames: [k8s.podName]
-      k8s.namespace.name:
-        entityTagNames: [k8s.namespaceName]
-      k8s.cluster.name:
-        entityTagNames: [k8s.clusterName]
-      k8s.node.name:
-        entityTagNames: [k8s.nodeName]
-      k8s.deployment.name:
-        entityTagNames: [k8s.deploymentName]
-      k8s.daemonset.name:
-        entityTagNames: [k8s.daemonsetName]
-      newrelic.chart.version:
-        entityTagNames: [newrelic.chartVersion]
-        ttl: P1D
+      # cAdvisor data via opentelemetry prometheusReceiver
+    - compositeIdentifier:
+        separator: ":"
+        attributes:
+          - k8s.cluster.name
+          - k8s.namespace.name
+          - k8s.pod.name
+          - k8s.container.name
+      encodeIdentifierInGUID: true
+      name: k8s.container.name
+      conditions:
+        # cadvisor container prefix
+        - attribute: metricName
+          prefix: container_
+        # identifier attributes
+        - attribute: k8s.container.name
+          present: true
+        - attribute: k8s.pod.name
+          present: true
+        - attribute: k8s.namespace.name
+          present: true
+        - attribute: k8s.cluster.name
+          present: true
+        # if image is present, it's a container, else a pod
+        - attribute: image
+          present: true
+        # open telemetry
+        - attribute: newrelic.source
+          value: "api.metrics.otlp"
+        # if service.name is present, handle as one
+        - attribute: service.name
+          present: false
+      tags:
+        k8s.container.name:
+          entityTagNames: [k8s.containerName]
+        k8s.pod.name:
+          entityTagNames: [k8s.podName]
+          multiValue: false
+        k8s.namespace.name:
+          entityTagNames: [k8s.namespaceName]
+          multiValue: false
+        k8s.cluster.name:
+          entityTagNames: [k8s.clusterName]
+        k8s.node.name:
+          entityTagNames: [k8s.nodeName]
+        k8s.deployment.name:
+          entityTagNames: [k8s.deploymentName]
+        k8s.daemonset.name:
+          entityTagNames: [k8s.daemonsetName]
+        newrelic.chart.version:
+          entityTagNames: [newrelic.chartVersion]
+          ttl: P1D
 
-  # kube-state-metrics data via opentelemetry prometheusReceiver preview
-  - compositeIdentifier:
-      separator: ":"
-      attributes:
-        - k8s.cluster.name
-        - namespace
-        - pod
-        - container
-    encodeIdentifierInGUID: true
-    name: container
-    conditions:
-      # kube-state-metrics container prefix
-      - attribute: metricName
-        prefix: kube_pod_container_
-      # identifier attributes
-      - attribute: container
-        present: true
-      - attribute: pod
-        present: true
-      - attribute: namespace
-        present: true
-      - attribute: k8s.cluster.name
-        present: true
-      # open telemetry
-      - attribute: newrelic.source
-        value: 'api.metrics.otlp'
-      # if service.name is present, handle as one
-      - attribute: service.name
-        present: false
-      # value added for test entities only
-      - attribute: newrelicOnly
-        value: "true"
-    tags:
-      container_id:
-        entityTagNames: [k8s.containerId]
-        multiValue: false
-      image:
-        entityTagNames: [k8s.containerImage]
-      container:
-        entityTagNames: [k8s.containerName]
-      pod:
-        entityTagNames: [k8s.podName]
-      namespace:
-        entityTagNames: [k8s.namespaceName]
-      k8s.cluster.name:
-        entityTagNames: [k8s.clusterName]
-      k8s.deployment.name:
-        entityTagNames: [k8s.deploymentName]
+      # cAdvisor data via opentelemetry prometheusReceiver
+    - compositeIdentifier:
+        separator: ":"
+        attributes:
+          - k8s.cluster.name
+          - k8s.namespace.name
+          - k8s.pod.name
+          - k8s.container.name
+      encodeIdentifierInGUID: true
+      name: k8s.container.name
+      conditions:
+        # cadvisor container prefix
+        - attribute: metricName
+          prefix: container_
+        # identifier attributes
+        - attribute: k8s.container.name
+          present: true
+        - attribute: k8s.pod.name
+          present: true
+        - attribute: k8s.namespace.name
+          present: true
+        - attribute: k8s.cluster.name
+          present: true
+        # if image is present, it's a container, else a pod
+        - attribute: image
+          present: true
+        # open telemetry
+        - attribute: newrelic.source
+          value: "api.metrics.otlp"
+        # if newrelic.entity.type is present, it's not a service
+        - attribute: service.name
+          present: true
+        - attribute: newrelic.entity.type
+          present: true
+      tags:
+        k8s.container.name:
+          entityTagNames: [k8s.containerName]
+        k8s.pod.name:
+          entityTagNames: [k8s.podName]
+          multiValue: false
+        k8s.namespace.name:
+          entityTagNames: [k8s.namespaceName]
+          multiValue: false
+        k8s.cluster.name:
+          entityTagNames: [k8s.clusterName]
+        k8s.node.name:
+          entityTagNames: [k8s.nodeName]
+        k8s.deployment.name:
+          entityTagNames: [k8s.deploymentName]
+        k8s.daemonset.name:
+          entityTagNames: [k8s.daemonsetName]
+        newrelic.chart.version:
+          entityTagNames: [newrelic.chartVersion]
+          ttl: P1D
 
+    # kube-state-metrics data via opentelemetry prometheusReceiver preview
+    - compositeIdentifier:
+        separator: ":"
+        attributes:
+          - k8s.cluster.name
+          - namespace
+          - pod
+          - container
+      encodeIdentifierInGUID: true
+      name: container
+      conditions:
+        # kube-state-metrics container prefix
+        - attribute: metricName
+          prefix: kube_pod_container_
+        # identifier attributes
+        - attribute: container
+          present: true
+        - attribute: pod
+          present: true
+        - attribute: namespace
+          present: true
+        - attribute: k8s.cluster.name
+          present: true
+        # open telemetry
+        - attribute: newrelic.source
+          value: "api.metrics.otlp"
+        # if service.name is present, handle as one
+        - attribute: service.name
+          present: false
+        # value added for test entities only
+        - attribute: newrelicOnly
+          value: "true"
+      tags:
+        container_id:
+          entityTagNames: [k8s.containerId]
+          multiValue: false
+        image:
+          entityTagNames: [k8s.containerImage]
+        container:
+          entityTagNames: [k8s.containerName]
+        pod:
+          entityTagNames: [k8s.podName]
+          multiValue: false
+        namespace:
+          entityTagNames: [k8s.namespaceName]
+          multiValue: false
+        k8s.cluster.name:
+          entityTagNames: [k8s.clusterName]
+        k8s.deployment.name:
+          entityTagNames: [k8s.deploymentName]
 
-  # kube-state-metrics data via opentelemetry prometheusReceiver preview
-  - compositeIdentifier:
-      separator: ":"
-      attributes:
-        - k8s.cluster.name
-        - namespace
-        - pod
-        - container
-    encodeIdentifierInGUID: true
-    name: container
-    conditions:
-      # kube-state-metrics container prefix
-      - attribute: metricName
-        prefix: kube_pod_container_
-      # identifier attributes
-      - attribute: container
-        present: true
-      - attribute: pod
-        present: true
-      - attribute: namespace
-        present: true
-      - attribute: k8s.cluster.name
-        present: true
-      # open telemetry
-      - attribute: newrelic.source
-        value: 'api.metrics.otlp'
-      # value added for test entities only
-      - attribute: newrelicOnly
-        value: "true"
-      # if newrelic.entity.type is present, it's not a service
-      - attribute: service.name
-        present: true
-      - attribute: newrelic.entity.type
-        present: true
-    tags:
-      container_id:
-        entityTagNames: [k8s.containerId]
-        multiValue: false
-      image:
-        entityTagNames: [k8s.containerImage]
-      container:
-        entityTagNames: [k8s.containerName]
-      pod:
-        entityTagNames: [k8s.podName]
-      namespace:
-        entityTagNames: [k8s.namespaceName]
-      k8s.cluster.name:
-        entityTagNames: [k8s.clusterName]
-      k8s.deployment.name:
-        entityTagNames: [k8s.deploymentName]
+    # kube-state-metrics data via opentelemetry prometheusReceiver preview
+    - compositeIdentifier:
+        separator: ":"
+        attributes:
+          - k8s.cluster.name
+          - namespace
+          - pod
+          - container
+      encodeIdentifierInGUID: true
+      name: container
+      conditions:
+        # kube-state-metrics container prefix
+        - attribute: metricName
+          prefix: kube_pod_container_
+        # identifier attributes
+        - attribute: container
+          present: true
+        - attribute: pod
+          present: true
+        - attribute: namespace
+          present: true
+        - attribute: k8s.cluster.name
+          present: true
+        # open telemetry
+        - attribute: newrelic.source
+          value: "api.metrics.otlp"
+        # value added for test entities only
+        - attribute: newrelicOnly
+          value: "true"
+        # if newrelic.entity.type is present, it's not a service
+        - attribute: service.name
+          present: true
+        - attribute: newrelic.entity.type
+          present: true
+      tags:
+        container_id:
+          entityTagNames: [k8s.containerId]
+          multiValue: false
+        image:
+          entityTagNames: [k8s.containerImage]
+        container:
+          entityTagNames: [k8s.containerName]
+        pod:
+          entityTagNames: [k8s.podName]
+          multiValue: false
+        namespace:
+          entityTagNames: [k8s.namespaceName]
+          multiValue: false
+        k8s.cluster.name:
+          entityTagNames: [k8s.clusterName]
+        k8s.deployment.name:
+          entityTagNames: [k8s.deploymentName]
 
-  # cAdvisor data via opentelemetry prometheusReceiver preview
-  - compositeIdentifier:
-      separator: ":"
-      attributes:
-        - k8s.cluster.name
-        - namespace
-        - pod
-        - container
-    encodeIdentifierInGUID: true
-    name: container
-    conditions:
-      # cadvisor container prefix
-      - attribute: metricName
-        prefix: container_
-      # identifier attributes
-      - attribute: container
-        present: true
-      - attribute: pod
-        present: true
-      - attribute: namespace
-        present: true
-      - attribute: k8s.cluster.name
-        present: true
-      # open telemetry
-      - attribute: newrelic.source
-        value: 'api.metrics.otlp'
-      # if service.name is present, handle as one
-      - attribute: service.name
-        present: false
-      # value added for test entities only
-      - attribute: newrelicOnly
-        value: "true"
-    tags:
-      container:
-        entityTagNames: [k8s.containerName]
-      pod:
-        entityTagNames: [k8s.podName]
-      namespace:
-        entityTagNames: [k8s.namespaceName]
-      k8s.cluster.name:
-        entityTagNames: [k8s.clusterName]
-      k8s.node.name:
-        entityTagNames: [k8s.nodeName]
-      k8s.deployment.name:
-        entityTagNames: [k8s.deploymentName]
+    # cAdvisor data via opentelemetry prometheusReceiver preview
+    - compositeIdentifier:
+        separator: ":"
+        attributes:
+          - k8s.cluster.name
+          - namespace
+          - pod
+          - container
+      encodeIdentifierInGUID: true
+      name: container
+      conditions:
+        # cadvisor container prefix
+        - attribute: metricName
+          prefix: container_
+        # identifier attributes
+        - attribute: container
+          present: true
+        - attribute: pod
+          present: true
+        - attribute: namespace
+          present: true
+        - attribute: k8s.cluster.name
+          present: true
+        # open telemetry
+        - attribute: newrelic.source
+          value: "api.metrics.otlp"
+        # if service.name is present, handle as one
+        - attribute: service.name
+          present: false
+        # value added for test entities only
+        - attribute: newrelicOnly
+          value: "true"
+      tags:
+        container:
+          entityTagNames: [k8s.containerName]
+        pod:
+          entityTagNames: [k8s.podName]
+          multiValue: false
+        namespace:
+          entityTagNames: [k8s.namespaceName]
+          multiValue: false
+        k8s.cluster.name:
+          entityTagNames: [k8s.clusterName]
+        k8s.node.name:
+          entityTagNames: [k8s.nodeName]
+        k8s.deployment.name:
+          entityTagNames: [k8s.deploymentName]
 
+    # cAdvisor data via opentelemetry prometheusReceiver preview
+    - compositeIdentifier:
+        separator: ":"
+        attributes:
+          - k8s.cluster.name
+          - namespace
+          - pod
+          - container
+      encodeIdentifierInGUID: true
+      name: container
+      conditions:
+        # cadvisor container prefix
+        - attribute: metricName
+          prefix: container_
+        # identifier attributes
+        - attribute: container
+          present: true
+        - attribute: pod
+          present: true
+        - attribute: namespace
+          present: true
+        - attribute: k8s.cluster.name
+          present: true
+        # open telemetry
+        - attribute: newrelic.source
+          value: "api.metrics.otlp"
+        # value added for test entities only
+        - attribute: newrelicOnly
+          value: "true"
+        # if newrelic.entity.type is present, it's not a service
+        - attribute: service.name
+          present: true
+        - attribute: newrelic.entity.type
+          present: true
+      tags:
+        container:
+          entityTagNames: [k8s.containerName]
+        pod:
+          entityTagNames: [k8s.podName]
+          multiValue: false
+        namespace:
+          entityTagNames: [k8s.namespaceName]
+          multiValue: false
+        k8s.cluster.name:
+          entityTagNames: [k8s.clusterName]
+        k8s.node.name:
+          entityTagNames: [k8s.nodeName]
+        k8s.deployment.name:
+          entityTagNames: [k8s.deploymentName]
 
-  # cAdvisor data via opentelemetry prometheusReceiver preview
-  - compositeIdentifier:
-      separator: ":"
-      attributes:
-        - k8s.cluster.name
-        - namespace
-        - pod
-        - container
-    encodeIdentifierInGUID: true
-    name: container
-    conditions:
-      # cadvisor container prefix
-      - attribute: metricName
-        prefix: container_
-      # identifier attributes
-      - attribute: container
-        present: true
-      - attribute: pod
-        present: true
-      - attribute: namespace
-        present: true
-      - attribute: k8s.cluster.name
-        present: true
-      # open telemetry
-      - attribute: newrelic.source
-        value: 'api.metrics.otlp'
-      # value added for test entities only
-      - attribute: newrelicOnly
-        value: "true"
-      # if newrelic.entity.type is present, it's not a service
-      - attribute: service.name
-        present: true
-      - attribute: newrelic.entity.type
-        present: true
-    tags:
-      container:
-        entityTagNames: [k8s.containerName]
-      pod:
-        entityTagNames: [k8s.podName]
-      namespace:
-        entityTagNames: [k8s.namespaceName]
-      k8s.cluster.name:
-        entityTagNames: [k8s.clusterName]
-      k8s.node.name:
-        entityTagNames: [k8s.nodeName]
-      k8s.deployment.name:
-        entityTagNames: [k8s.deploymentName]
+    # kubeletstatsreceiver data via opentelemetry
+    - compositeIdentifier:
+        separator: ":"
+        attributes:
+          - k8s.cluster.name
+          - k8s.namespace.name
+          - k8s.pod.name
+          - k8s.container.name
+      encodeIdentifierInGUID: true
+      name: k8s.container.name
+      conditions:
+        # kubeletstats container prefix
+        - attribute: metricName
+          prefix: container.
+        # identifier attributes
+        - attribute: k8s.container.name
+          present: true
+        - attribute: k8s.pod.name
+          present: true
+        - attribute: k8s.namespace.name
+          present: true
+        - attribute: k8s.cluster.name
+          present: true
+        # open telemetry
+        - attribute: newrelic.source
+          value: "api.metrics.otlp"
+        # if service.name is present, handle as one
+        - attribute: service.name
+          present: false
+      tags:
+        k8s.container.name:
+          entityTagNames: [k8s.containerName]
+        k8s.pod.name:
+          entityTagNames: [k8s.podName]
+          multiValue: false
+        k8s.namespace.name:
+          entityTagNames: [k8s.namespaceName]
+          multiValue: false
+        k8s.cluster.name:
+          entityTagNames: [k8s.clusterName]
+        k8s.deployment.name:
+          entityTagNames: [k8s.deploymentName]
+        k8s.node.name:
+          entityTagNames: [k8s.nodeName]
 
+    # kubeletstatsreceiver data via opentelemetry
+    - compositeIdentifier:
+        separator: ":"
+        attributes:
+          - k8s.cluster.name
+          - k8s.namespace.name
+          - k8s.pod.name
+          - k8s.container.name
+      encodeIdentifierInGUID: true
+      name: k8s.container.name
+      conditions:
+        # kubeletstats container prefix
+        - attribute: metricName
+          prefix: container.
+        # identifier attributes
+        - attribute: k8s.container.name
+          present: true
+        - attribute: k8s.pod.name
+          present: true
+        - attribute: k8s.namespace.name
+          present: true
+        - attribute: k8s.cluster.name
+          present: true
+        # open telemetry
+        - attribute: newrelic.source
+          value: "api.metrics.otlp"
+        # if newrelic.entity.type is present, it's not a service
+        - attribute: service.name
+          present: true
+        - attribute: newrelic.entity.type
+          present: true
+      tags:
+        k8s.container.name:
+          entityTagNames: [k8s.containerName]
+        k8s.pod.name:
+          entityTagNames: [k8s.podName]
+          multiValue: false
+        k8s.namespace.name:
+          entityTagNames: [k8s.namespaceName]
+          multiValue: false
+        k8s.cluster.name:
+          entityTagNames: [k8s.clusterName]
+        k8s.deployment.name:
+          entityTagNames: [k8s.deploymentName]
+        k8s.node.name:
+          entityTagNames: [k8s.nodeName]
 
-  # kubeletstatsreceiver data via opentelemetry
-  - compositeIdentifier:
-      separator: ":"
-      attributes:
-        - k8s.cluster.name
-        - k8s.namespace.name
-        - k8s.pod.name
-        - k8s.container.name
-    encodeIdentifierInGUID: true
-    name: k8s.container.name
-    conditions:
-      # kubeletstats container prefix
-      - attribute: metricName
-        prefix: container.
-      # identifier attributes
-      - attribute: k8s.container.name
-        present: true
-      - attribute: k8s.pod.name
-        present: true
-      - attribute: k8s.namespace.name
-        present: true
-      - attribute: k8s.cluster.name
-        present: true
-      # open telemetry
-      - attribute: newrelic.source
-        value: 'api.metrics.otlp'
-      # if service.name is present, handle as one
-      - attribute: service.name
-        present: false
-    tags:
-      k8s.container.name:
-        entityTagNames: [k8s.containerName]
-      k8s.pod.name:
-        entityTagNames: [k8s.podName]
-      k8s.namespace.name:
-        entityTagNames: [k8s.namespaceName]
-      k8s.cluster.name:
-        entityTagNames: [k8s.clusterName]
-      k8s.deployment.name:
-        entityTagNames: [k8s.deploymentName]
-      k8s.node.name:
-        entityTagNames: [k8s.nodeName]
-
-
-  # kubeletstatsreceiver data via opentelemetry
-  - compositeIdentifier:
-      separator: ":"
-      attributes:
-        - k8s.cluster.name
-        - k8s.namespace.name
-        - k8s.pod.name
-        - k8s.container.name
-    encodeIdentifierInGUID: true
-    name: k8s.container.name
-    conditions:
-      # kubeletstats container prefix
-      - attribute: metricName
-        prefix: container.
-      # identifier attributes
-      - attribute: k8s.container.name
-        present: true
-      - attribute: k8s.pod.name
-        present: true
-      - attribute: k8s.namespace.name
-        present: true
-      - attribute: k8s.cluster.name
-        present: true
-      # open telemetry
-      - attribute: newrelic.source
-        value: 'api.metrics.otlp'
-      # if newrelic.entity.type is present, it's not a service
-      - attribute: service.name
-        present: true
-      - attribute: newrelic.entity.type
-        present: true
-    tags:
-      k8s.container.name:
-        entityTagNames: [k8s.containerName]
-      k8s.pod.name:
-        entityTagNames: [k8s.podName]
-      k8s.namespace.name:
-        entityTagNames: [k8s.namespaceName]
-      k8s.cluster.name:
-        entityTagNames: [k8s.clusterName]
-      k8s.deployment.name:
-        entityTagNames: [k8s.deploymentName]
-      k8s.node.name:
-        entityTagNames: [k8s.nodeName]
-
-  # Docker Container from Samples
-  - identifier: entityId
-    name: name
-    legacyFeatures:
-      overrideGuidType: true
-      useNonStandardAttributes: true
-    conditions:
-      - attribute: eventType
-        value: ContainerSample
-      - attribute: name
-        present: true
-      - attribute: containerId
-        present: true
-    tags:
-      state:
-        entityTagName: container.state
-      commandLine:
-        entityTagName: docker.commandLine
-      containerId:
-        entityTagName: docker.containerId
-      ecsLaunchType:
-        entityTagName: docker.ecsLaunchType
-      ecsClusterName:
-        entityTagName: docker.ecsClusterName
-      ecsClusterArn:
-        entityTagName: docker.ecsClusterArn
-      ecsContainerName:
-        entityTagName: docker.ecsContainerName
-      ecsTaskArn:
-        entityTagName: docker.ecsTaskArn
-      ecsTaskDefinitionFamily:
-        entityTagName: docker.ecsTaskDefinitionFamily
-      ecsTaskDefinitionVersion:
-        entityTagName: docker.ecsTaskDefinitionVersion
-      health:
-        entityTagName: docker.health
-      shortContainerId:
-        entityTagName: docker.shortContainerId
-      imag:
-        entityTagName: docker.image
-      imageName:
-        entityTagName: docker.imageName
-      host:
-        entityTagName: docker.host
-      status:
-        entityTagName: docker.status
-        multiValue: false
-      instanceType:
-        entityTagName: host.instanceType
-      integrationName:
-        entityTagName: newrelic.integrationName
-      integrationVersion:
-        entityTagName: newrelic.integrationVersion
-      agentVersion:
-        entityTagName: newrelic.agentVersion
-      awsRegion:
-        entityTagName: aws.region
-      provider.awsRegion:
-        entityTagName: aws.region
-    prefixedTags:
-      label.:
-  # K8s Container from Samples
-  - identifier: entityId
-    name: containerName
-    legacyFeatures:
-      overrideGuidType: true
-      useNonStandardAttributes: true
-    conditions:
-      - attribute: eventType
-        value: K8sContainerSample
-      - attribute: containerName
-        present: true
-    tags:
-      clusterName:
-        entityTagName: k8s.clusterName
-      containerID:
-        entityTagName: k8s.containerId
-        multiValue: false
-      containerImage:
-        entityTagName: k8s.containerImage
-      containerImageId:
-        entityTagName: k8s.containerImageId
-      containerName:
-        entityTagName: k8s.containerName
-      deploymentName:
-        entityTagName: k8s.deploymentName
-      daemonsetName:
-        entityTagName: k8s.daemonsetName
-      jobName:
-        entityTagName: k8s.jobName
-      replicasetName:
-        entityTagName: k8s.replicasetName
-      statefulsetName:
-        entityTagName: k8s.statefulsetName
-      namespaceName:
-        entityTagName: k8s.namespaceName
-      namespace:
-        entityTagName: k8s.namespaceName
-      nodeIp:
-        entityTagName: k8s.nodeIp
-      nodeName:
-        entityTagName: k8s.nodeName
-      podName:
-        entityTagName: k8s.podName
-      reason:
-        entityTagName: k8s.reason
-      status:
-        entityTagNames: [k8s.status, container.state]
-        multiValue: false
-      instanceType:
-        entityTagName: host.instanceType
-      integrationName:
-        entityTagName: newrelic.integrationName
-      integrationVersion:
-        entityTagName: newrelic.integrationVersion
-      agentVersion:
-        entityTagName: newrelic.agentVersion
-      awsRegion:
-        entityTagName: aws.region
-      provider.awsRegion:
-        entityTagName: aws.region
-    prefixedTags:
-      label.:
+    # Docker Container from Samples
+    - identifier: entityId
+      name: name
+      legacyFeatures:
+        overrideGuidType: true
+        useNonStandardAttributes: true
+      conditions:
+        - attribute: eventType
+          value: ContainerSample
+        - attribute: name
+          present: true
+        - attribute: containerId
+          present: true
+      tags:
+        state:
+          entityTagName: container.state
+        commandLine:
+          entityTagName: docker.commandLine
+        containerId:
+          entityTagName: docker.containerId
+        ecsLaunchType:
+          entityTagName: docker.ecsLaunchType
+        ecsClusterName:
+          entityTagName: docker.ecsClusterName
+        ecsClusterArn:
+          entityTagName: docker.ecsClusterArn
+        ecsContainerName:
+          entityTagName: docker.ecsContainerName
+        ecsTaskArn:
+          entityTagName: docker.ecsTaskArn
+        ecsTaskDefinitionFamily:
+          entityTagName: docker.ecsTaskDefinitionFamily
+        ecsTaskDefinitionVersion:
+          entityTagName: docker.ecsTaskDefinitionVersion
+        health:
+          entityTagName: docker.health
+        shortContainerId:
+          entityTagName: docker.shortContainerId
+        imag:
+          entityTagName: docker.image
+        imageName:
+          entityTagName: docker.imageName
+        host:
+          entityTagName: docker.host
+        status:
+          entityTagName: docker.status
+          multiValue: false
+        instanceType:
+          entityTagName: host.instanceType
+        integrationName:
+          entityTagName: newrelic.integrationName
+        integrationVersion:
+          entityTagName: newrelic.integrationVersion
+        agentVersion:
+          entityTagName: newrelic.agentVersion
+        awsRegion:
+          entityTagName: aws.region
+        provider.awsRegion:
+          entityTagName: aws.region
+      prefixedTags:
+        label.:
+    # K8s Container from Samples
+    - identifier: entityId
+      name: containerName
+      legacyFeatures:
+        overrideGuidType: true
+        useNonStandardAttributes: true
+      conditions:
+        - attribute: eventType
+          value: K8sContainerSample
+        - attribute: containerName
+          present: true
+      tags:
+        clusterName:
+          entityTagName: k8s.clusterName
+        containerID:
+          entityTagName: k8s.containerId
+          multiValue: false
+        containerImage:
+          entityTagName: k8s.containerImage
+        containerImageId:
+          entityTagName: k8s.containerImageId
+        containerName:
+          entityTagName: k8s.containerName
+        deploymentName:
+          entityTagName: k8s.deploymentName
+        daemonsetName:
+          entityTagName: k8s.daemonsetName
+        jobName:
+          entityTagName: k8s.jobName
+        replicasetName:
+          entityTagName: k8s.replicasetName
+        statefulsetName:
+          entityTagName: k8s.statefulsetName
+        namespaceName:
+          entityTagName: k8s.namespaceName
+          multiValue: false
+        namespace:
+          entityTagName: k8s.namespaceName
+          multiValue: false
+        nodeIp:
+          entityTagName: k8s.nodeIp
+        nodeName:
+          entityTagName: k8s.nodeName
+        podName:
+          entityTagName: k8s.podName
+          multivalue: false
+        reason:
+          entityTagName: k8s.reason
+        status:
+          entityTagNames: [k8s.status, container.state]
+          multiValue: false
+        instanceType:
+          entityTagName: host.instanceType
+        integrationName:
+          entityTagName: newrelic.integrationName
+        integrationVersion:
+          entityTagName: newrelic.integrationVersion
+        agentVersion:
+          entityTagName: newrelic.agentVersion
+        awsRegion:
+          entityTagName: aws.region
+        provider.awsRegion:
+          entityTagName: aws.region
+      prefixedTags:
+        label.:
 
   tags:
     newrelic.integrationName:
@@ -669,8 +688,8 @@ synthesis:
     aws.region:
 
 goldenTags:
-- environment
-- container.state
+  - environment
+  - container.state
 
 configuration:
   entityExpirationTime: FOUR_HOURS


### PR DESCRIPTION
### Relevant information

<!--
  Describe what you have done.
  Provide details that are relevant to the PR

  Always think that the person reviewing the PR doesn't have the context you have.

  Links to examples, documentation and similar resources make the process easier to review.
-->
For container entities, we're seeing multivalues for the `k8s.namespaceName` and `k8s.podName` tags which is incorrect. I added the `multivalue: false` property to the definition to disable this functionality.

<!--
  Contributions to this repository are reviewed at least twice a week

  There's no further action required once the PR has been created.
 -->

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
