### PR TITLE
chore: Remove entity synthesis for host type

### DIFF
--- a/entity-types/infra-host/definition.yml
+++ b/entity-types/infra-host/definition.yml
@@ -525,16 +525,6 @@ synthesis:
         # Used in AWSEC2.yml for entity relationship candidates
         aws.ec2.InstanceId:
 
-    - identifier: oci.resourceId
-      name: oci.resourceDisplayName
-      legacyFeatures:
-        overrideGuidType: true
-      encodeIdentifierInGUID: true
-      conditions:
-      - attribute: oci.resourceId
-        prefix: "ocid1.instance"
-      - attribute: eventType
-        value: Metric
 configuration:
   entityExpirationTime: EIGHT_DAYS
   alertable: true

--- a/entity-types/infra-host/golden_metrics.yml
+++ b/entity-types/infra-host/golden_metrics.yml
@@ -45,11 +45,6 @@ cpuUsage:
       from: GcpVirtualMachineSample
       eventId: entityGuid
       eventName: entityName          
-    oci:
-      select: average(`oci.computeagent.cpu.utilization`)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name 
 memoryUsage:
   title: Memory usage (%)
   unit: PERCENTAGE
@@ -67,11 +62,6 @@ memoryUsage:
       eventName: entity.name
     prometheus:
       select: (sum(node_memory_MemTotal_bytes) - sum(node_memory_MemAvailable_bytes)) * 100 / sum(node_memory_MemTotal_bytes)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name
-    oci:
-      select: average(`oci.computeagent.memory.utilization`)
       from: Metric
       eventId: entity.guid
       eventName: entity.name
@@ -145,11 +135,6 @@ networkTrafficTx:
       from: GcpVirtualMachineSample
       eventId: entityGuid
       eventName: entityName        
-    oci:
-      select: average(`oci.computeagent.network.bytes.out`)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name   
 networkTrafficRx:
   title: Network receive traffic (bytes/s)
   unit: BYTES_PER_SECOND
@@ -198,8 +183,3 @@ networkTrafficRx:
       from: GcpVirtualMachineSample
       eventId: entityGuid
       eventName: entityName      
-    oci:
-      select: average(`oci.computeagent.network.bytes.in`)
-      from: Metric
-      eventId: entity.guid
-      eventName: entity.name


### PR DESCRIPTION
### Relevant information

Remove entity synthesis for host type

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
