### PR TITLE
Allow to disable synthesis rules & filter relationships by entitlement

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,13 @@ Whenever there's a contribution via pull request, some validations are automatic
 You can execute the validations locally using our dockerized validator:
 
 ```
-docker-compose run validate-definitions
+docker compose run validate-definitions
 ```
 
 Remember that you may need to rebuild the images to pick up validation changes if you have run this in the past.
 
 ```
-docker-compose build validate-definitions
+docker compose build validate-definitions
 ```
 
 Read more about the [current validations](/validator/README.md).

--- a/docs/entities/synthesis.md
+++ b/docs/entities/synthesis.md
@@ -16,6 +16,13 @@ synthesis:
     name: hostname
 ```
 
+It can also be explicitly defined that synthesis is not allowed for a specific type.
+
+```yaml
+synthesis:
+  disabled: true
+```
+
 | **Name** | **Type** | **Required** | **Description**  |
 | -------- | -------- | ------------ | ---------------- |
 | name    | String | Yes | The attribute to use for the entity name. |
@@ -24,6 +31,7 @@ synthesis:
 | encodeIdentifierInGUID | Boolean | No | If true, the identifier value will be hashed to respect the [GUID limits][guid_spec]. Defaults to `false`. |
 | conditions | List | No | The list of conditions to apply in the data point to match the rule. Defaults to an empty list. |
 | tags     | List   | No | The list of attributes to copy as entity tags if the rule matches. Defaults to an empty list. |
+
 
 ### Identifier
 

--- a/docs/relationships/relationship_synthesis.md
+++ b/docs/relationships/relationship_synthesis.md
@@ -182,7 +182,7 @@ The mapping of origins to sources allows for performance improvements when evalu
 
 ```yaml
 entitlements:
-  - testEntitlement
+  - advanced_ccu
 ```
 
 The account must have at least one of the specificed entitlements in order to generate a relationship.
@@ -191,7 +191,14 @@ The entitlements to use is a closed list defined below:
 
 | **Entitlement** | **Description** |
 |-----------------|-----------------|
-| testEntitlement | Only for testing purposes. A rule with this entitlement will **NEVER** match. |
+|catalog_ccu||
+|advanced_maps_ccu||
+|auto_discovery_entities_ccu||
+|ngep_nrql_access_layer_ccu||
+|catalogs_discount_usage||
+|advanced_maps_discount_usage||
+|advanced_ccu||
+|auto_discovery_entities_ccu_discount_usage||
 
 
 ### Conditions

--- a/docs/relationships/relationship_synthesis.md
+++ b/docs/relationships/relationship_synthesis.md
@@ -177,15 +177,26 @@ The mapping of origins to sources allows for performance improvements when evalu
 
 ### Entitlements
 
-**This is an experimental feature and not ready to use**
-**PR's using this feature will be rejected**
+Optionally, you can create a rule that will only match if the account of the telemetry has the required entitlements.
+
 
 ```yaml
 entitlements:
-  - advanced_ccu
+  matching: anyOf
+  values:
+    - advanced_ccu
 ```
 
-The account must have at least one of the specificed entitlements in order to generate a relationship.
+#### Matching
+
+Defines how the entitlements will be matched.
+Only `anyOf` is allowed.
+
+#### Values
+
+Defines the names of the entitlements to match.
+The account producing the telemetry must contain the entitlements in order for the rule to match.
+
 
 The entitlements to use is a closed list defined below:
 
@@ -199,6 +210,8 @@ The entitlements to use is a closed list defined below:
 |advanced_maps_discount_usage||
 |advanced_ccu||
 |auto_discovery_entities_ccu_discount_usage||
+
+If you need an entitlement not in the list reach us.
 
 
 ### Conditions

--- a/docs/relationships/relationship_synthesis.md
+++ b/docs/relationships/relationship_synthesis.md
@@ -204,14 +204,14 @@ The entitlements to use is a closed list defined below:
 
 | **Entitlement** | **Description** |
 |-----------------|-----------------|
-|catalog_ccu||
-|advanced_maps_ccu||
-|auto_discovery_entities_ccu||
-|ngep_nrql_access_layer_ccu||
-|catalogs_discount_usage||
-|advanced_maps_discount_usage||
-|advanced_ccu||
-|auto_discovery_entities_ccu_discount_usage||
+| advanced_ccu    | Controls whether certain advanced capabilities are accessible in the product |
+| catalog_ccu     | Controls whether customers can use Catalogs in the product |
+| catalogs_discount_usage | Trial version of the above |
+| auto_discovery_entities_ccu | Controls whether customers can enable and use Auto Discovery |
+| auto_discovery_entities_ccu_discount_usage | Trial version of the previous one |
+| advanced_maps_ccu | Controls whether customers can use advanced maps (infrastructure maps and Dynamic Flow Maps) |
+| advanced_maps_discount_usage | Trial version of the previous one |
+| ngep_nrql_access_layer_ccu | No definition provided |
 
 If you need an entitlement not in the list reach us.
 

--- a/docs/relationships/relationship_synthesis.md
+++ b/docs/relationships/relationship_synthesis.md
@@ -82,7 +82,9 @@ relationships:
     origins:
       - OpenTelemetry
     entitlements:
-      - testEntitlement
+      matching: anyOf
+      values:
+        - advanced_ccu
     conditions:
       - attribute: entity.type
         anyOf: [ "PIXIE_DNS" ]

--- a/docs/relationships/relationship_synthesis.md
+++ b/docs/relationships/relationship_synthesis.md
@@ -81,6 +81,8 @@ relationships:
     version: "1"
     origins:
       - OpenTelemetry
+    entitlements:
+      - testEntitlement
     conditions:
       - attribute: entity.type
         anyOf: [ "PIXIE_DNS" ]
@@ -172,6 +174,25 @@ The full list of supported origins (as of July 2023) is the following:
 One rule can be applied to multiple sources, as shown in the example. These origins are used by our internal services 
 to filter which rules to evaluate and which ones to ignore. 
 The mapping of origins to sources allows for performance improvements when evaluating rules via the matching system.
+
+### Entitlements
+
+**This is an experimental feature and not ready to use**
+**PR's using this feature will be rejected**
+
+```yaml
+entitlements:
+  - testEntitlement
+```
+
+The account must have at least one of the specificed entitlements in order to generate a relationship.
+
+The entitlements to use is a closed list defined below:
+
+| **Entitlement** | **Description** |
+|-----------------|-----------------|
+| testEntitlement | Only for testing purposes. A rule with this entitlement will **NEVER** match. |
+
 
 ### Conditions
 

--- a/entity-types/uninstrumented-awsappsyncapi/definition.yml
+++ b/entity-types/uninstrumented-awsappsyncapi/definition.yml
@@ -4,3 +4,7 @@ type: AWSAPPSYNCAPI
 configuration:
   entityExpirationTime: DAILY
   alertable: false
+
+synthesis:
+  # Uninstrumented can't use synthesis
+  disabled: true

--- a/entity-types/uninstrumented-awsautoscalinggroup/definition.stg.yml
+++ b/entity-types/uninstrumented-awsautoscalinggroup/definition.stg.yml
@@ -4,3 +4,7 @@ type: AWSAUTOSCALINGGROUP
 configuration:
   entityExpirationTime: DAILY
   alertable: false
+
+synthesis:
+  # Uninstrumented can't use synthesis
+  disabled: true

--- a/entity-types/uninstrumented-awsdynamodbtable/definition.yml
+++ b/entity-types/uninstrumented-awsdynamodbtable/definition.yml
@@ -4,3 +4,7 @@ type: AWSDYNAMODBTABLE
 configuration:
   entityExpirationTime: DAILY
   alertable: false
+
+synthesis:
+  # Uninstrumented can't use synthesis
+  disabled: true

--- a/entity-types/uninstrumented-awsec2/definition.yml
+++ b/entity-types/uninstrumented-awsec2/definition.yml
@@ -4,3 +4,7 @@ type: AWSEC2
 configuration:
   entityExpirationTime: DAILY
   alertable: false
+
+synthesis:
+  # Uninstrumented can't use synthesis
+  disabled: true

--- a/entity-types/uninstrumented-awselasticsearchcluster/definition.yml
+++ b/entity-types/uninstrumented-awselasticsearchcluster/definition.yml
@@ -4,3 +4,7 @@ type: AWSELASTICSEARCHCLUSTER
 configuration:
   entityExpirationTime: DAILY
   alertable: false
+
+synthesis:
+  # Uninstrumented can't use synthesis
+  disabled: true

--- a/entity-types/uninstrumented-awskinesisdeliverystream/definition.yml
+++ b/entity-types/uninstrumented-awskinesisdeliverystream/definition.yml
@@ -4,3 +4,7 @@ type: AWSKINESISDELIVERYSTREAM
 configuration:
   entityExpirationTime: DAILY
   alertable: false
+
+synthesis:
+  # Uninstrumented can't use synthesis
+  disabled: true

--- a/entity-types/uninstrumented-awskinesisstream/definition.yml
+++ b/entity-types/uninstrumented-awskinesisstream/definition.yml
@@ -4,3 +4,7 @@ type: AWSKINESISSTREAM
 configuration:
   entityExpirationTime: DAILY
   alertable: false
+
+synthesis:
+  # Uninstrumented can't use synthesis
+  disabled: true

--- a/entity-types/uninstrumented-awslambdaalias/definition.yml
+++ b/entity-types/uninstrumented-awslambdaalias/definition.yml
@@ -4,3 +4,7 @@ type: AWSLAMBDAALIAS
 configuration:
   entityExpirationTime: DAILY
   alertable: false
+
+synthesis:
+  # Uninstrumented can't use synthesis
+  disabled: true

--- a/entity-types/uninstrumented-awslambdafunction/definition.yml
+++ b/entity-types/uninstrumented-awslambdafunction/definition.yml
@@ -4,3 +4,7 @@ type: AWSLAMBDAFUNCTION
 configuration:
   entityExpirationTime: DAILY
   alertable: false
+
+synthesis:
+  # Uninstrumented can't use synthesis
+  disabled: true

--- a/entity-types/uninstrumented-awsredshiftcluster/definition.yml
+++ b/entity-types/uninstrumented-awsredshiftcluster/definition.yml
@@ -4,3 +4,7 @@ type: AWSREDSHIFTCLUSTER
 configuration:
   entityExpirationTime: DAILY
   alertable: false
+
+synthesis:
+  # Uninstrumented can't use synthesis
+  disabled: true

--- a/entity-types/uninstrumented-awss3bucket/definition.yml
+++ b/entity-types/uninstrumented-awss3bucket/definition.yml
@@ -4,3 +4,7 @@ type: AWSS3BUCKET
 configuration:
   entityExpirationTime: DAILY
   alertable: false
+
+synthesis:
+  # Uninstrumented can't use synthesis
+  disabled: true

--- a/entity-types/uninstrumented-awssnstopic/definition.yml
+++ b/entity-types/uninstrumented-awssnstopic/definition.yml
@@ -4,3 +4,7 @@ type: AWSSNSTOPIC
 configuration:
   entityExpirationTime: DAILY
   alertable: false
+
+synthesis:
+  # Uninstrumented can't use synthesis
+  disabled: true

--- a/entity-types/uninstrumented-awssqsqueue/definition.yml
+++ b/entity-types/uninstrumented-awssqsqueue/definition.yml
@@ -4,3 +4,7 @@ type: AWSSQSQUEUE
 configuration:
   entityExpirationTime: DAILY
   alertable: false
+
+synthesis:
+  # Uninstrumented can't use synthesis
+  disabled: true

--- a/entity-types/uninstrumented-azureappserviceplan/definition.yml
+++ b/entity-types/uninstrumented-azureappserviceplan/definition.yml
@@ -4,3 +4,7 @@ type: AZUREAPPSERVICEPLAN
 configuration:
   entityExpirationTime: DAILY
   alertable: false
+
+synthesis:
+  # Uninstrumented can't use synthesis
+  disabled: true

--- a/entity-types/uninstrumented-azurerediscache/definition.yml
+++ b/entity-types/uninstrumented-azurerediscache/definition.yml
@@ -4,3 +4,7 @@ type: AZUREREDISCACHE
 configuration:
   entityExpirationTime: DAILY
   alertable: false
+
+synthesis:
+  # Uninstrumented can't use synthesis
+  disabled: true

--- a/entity-types/uninstrumented-azureservicebusnamespace/definition.yml
+++ b/entity-types/uninstrumented-azureservicebusnamespace/definition.yml
@@ -4,3 +4,7 @@ type: AZURESERVICEBUSNAMESPACE
 configuration:
   entityExpirationTime: DAILY
   alertable: false
+
+synthesis:
+  # Uninstrumented can't use synthesis
+  disabled: true

--- a/entity-types/uninstrumented-container/definition.yml
+++ b/entity-types/uninstrumented-container/definition.yml
@@ -4,3 +4,7 @@ type: CONTAINER
 configuration:
   entityExpirationTime: FOUR_HOURS
   alertable: false
+
+synthesis:
+  # Uninstrumented can't use synthesis
+  disabled: true

--- a/entity-types/uninstrumented-database/definition.yml
+++ b/entity-types/uninstrumented-database/definition.yml
@@ -4,3 +4,7 @@ type: DATABASE
 configuration:
   entityExpirationTime: DAILY
   alertable: false
+
+synthesis:
+  # Uninstrumented can't use synthesis
+  disabled: true

--- a/entity-types/uninstrumented-ebpfclient/definition.yml
+++ b/entity-types/uninstrumented-ebpfclient/definition.yml
@@ -4,3 +4,7 @@ type: EBPFCLIENT
 configuration:
   entityExpirationTime: DAILY
   alertable: false
+
+synthesis:
+  # Uninstrumented can't use synthesis
+  disabled: true

--- a/entity-types/uninstrumented-ebpfserver/definition.yml
+++ b/entity-types/uninstrumented-ebpfserver/definition.yml
@@ -4,3 +4,7 @@ type: EBPFSERVER
 configuration:
   entityExpirationTime: DAILY
   alertable: false
+
+synthesis:
+  # Uninstrumented can't use synthesis
+  disabled: true

--- a/entity-types/uninstrumented-host/definition.yml
+++ b/entity-types/uninstrumented-host/definition.yml
@@ -4,3 +4,7 @@ type: HOST
 configuration:
   entityExpirationTime: FOUR_HOURS
   alertable: false
+
+synthesis:
+  # Uninstrumented can't use synthesis
+  disabled: true

--- a/entity-types/uninstrumented-httpservice/definition.yml
+++ b/entity-types/uninstrumented-httpservice/definition.yml
@@ -4,3 +4,7 @@ type: HTTPSERVICE
 configuration:
   entityExpirationTime: FOUR_HOURS
   alertable: false
+
+synthesis:
+  # Uninstrumented can't use synthesis
+  disabled: true

--- a/entity-types/uninstrumented-kafkatopic/definition.yml
+++ b/entity-types/uninstrumented-kafkatopic/definition.yml
@@ -4,3 +4,7 @@ type: KAFKATOPIC
 configuration:
   entityExpirationTime: DAILY
   alertable: false
+
+synthesis:
+  # Uninstrumented can't use synthesis
+  disabled: true

--- a/entity-types/uninstrumented-kiosk/definition.stg.yml
+++ b/entity-types/uninstrumented-kiosk/definition.stg.yml
@@ -4,3 +4,7 @@ type: KIOSK
 configuration:
   entityExpirationTime: FOUR_HOURS
   alertable: true
+
+synthesis:
+  # Uninstrumented can't use synthesis
+  disabled: true

--- a/entity-types/uninstrumented-kubernetescluster/definition.yml
+++ b/entity-types/uninstrumented-kubernetescluster/definition.yml
@@ -4,3 +4,7 @@ type: KUBERNETESCLUSTER
 configuration:
   entityExpirationTime: FOUR_HOURS
   alertable: false
+
+synthesis:
+  # Uninstrumented can't use synthesis
+  disabled: true

--- a/entity-types/uninstrumented-memcached/definition.yml
+++ b/entity-types/uninstrumented-memcached/definition.yml
@@ -4,3 +4,7 @@ type: MEMCACHED
 configuration:
   entityExpirationTime: DAILY
   alertable: false
+
+synthesis:
+  # Uninstrumented can't use synthesis
+  disabled: true

--- a/entity-types/uninstrumented-mqbroker/definition.yml
+++ b/entity-types/uninstrumented-mqbroker/definition.yml
@@ -4,3 +4,7 @@ type: MQBROKER
 configuration:
   entityExpirationTime: DAILY
   alertable: false
+
+synthesis:
+  # Uninstrumented can't use synthesis
+  disabled: true

--- a/entity-types/uninstrumented-redis/definition.yml
+++ b/entity-types/uninstrumented-redis/definition.yml
@@ -4,3 +4,7 @@ type: REDIS
 configuration:
   entityExpirationTime: DAILY
   alertable: false
+
+synthesis:
+  # Uninstrumented can't use synthesis
+  disabled: true

--- a/relationships/synthesis/APM-APPLICATION-to-INFRA-AZURESERVICEBUSNAMESPACE.yml
+++ b/relationships/synthesis/APM-APPLICATION-to-INFRA-AZURESERVICEBUSNAMESPACE.yml
@@ -8,7 +8,6 @@ relationships:
         anyOf: [ "Span" ]
       - attribute: server.address
         regex: '^[a-z0-9\-]+\.servicebus\.windows\.net$'
-        present: true
       - attribute: span.kind
         anyOf: [ "producer" ] 
       - attribute: name 
@@ -37,7 +36,6 @@ relationships:
         anyOf: [ "Span" ]
       - attribute: server.address
         regex: '^[a-z0-9\-]+\.servicebus\.windows\.net$'
-        present: true
       - attribute: span.kind
         anyOf: [ "consumer" ] 
       - attribute: name 

--- a/relationships/synthesis/ROKU-VIDEO-to-VIDEO-ACTION.yml
+++ b/relationships/synthesis/ROKU-VIDEO-to-VIDEO-ACTION.yml
@@ -3,6 +3,10 @@ relationships:
     version: "1"
     origins:
       - APM Metrics
+    entitlements:
+      matching: anyOf
+      values:
+        - advanced_ccu
     conditions:
       - attribute: eventType
         anyOf: ["VideoAction"]

--- a/relationships/synthesis/ROKU-VIDEO-to-VIDEO-ACTION.yml
+++ b/relationships/synthesis/ROKU-VIDEO-to-VIDEO-ACTION.yml
@@ -3,10 +3,6 @@ relationships:
     version: "1"
     origins:
       - APM Metrics
-    entitlements:
-      matching: anyOf
-      values:
-        - advanced_ccu
     conditions:
       - attribute: eventType
         anyOf: ["VideoAction"]

--- a/validator/README.md
+++ b/validator/README.md
@@ -20,13 +20,13 @@ If you want to validate definition files manually, for example before opening a 
 2. Execute the following command:
 
 ```
-docker-compose run validate-definitions
+docker compose run validate-definitions
 ```
 
 If you added or modified a dashboard and its validation is failing you can try to fix it by running the following:
 
 ```
-docker-compose run sanitize-dashboards
+docker compose run sanitize-dashboards
 ```
 
 ### Local setup

--- a/validator/schemas/entity-schema-v1.json
+++ b/validator/schemas/entity-schema-v1.json
@@ -76,6 +76,11 @@
           "required": [
             "rules"
           ]
+        },
+        {
+          "required": [
+            "disabled"
+          ]
         }
       ],
       "properties": {
@@ -337,6 +342,13 @@
         },
         "tags": {
           "$ref": "#/synthesis/rules/items/tags"
+        },
+        "disabled": {
+          "$id": "#/synthesis/disabled",
+          "type": "boolean",
+          "title": "Disabled rules",
+          "description": "When true synthesis rules for this type are not allowed.",
+          "default": false
         },
         "additionalProperties": false
       },

--- a/validator/schemas/relationship-synthesis-schema-v1.json
+++ b/validator/schemas/relationship-synthesis-schema-v1.json
@@ -67,6 +67,9 @@
         "origins": {
           "$ref": "#/definitions/origins"
         },
+        "entitlements": {
+          "$ref": "#/definitions/entitlements"
+        },
         "name": {
           "$ref": "#/definitions/name"
         },
@@ -109,6 +112,16 @@
           "Distributed Tracing",
           "Metric API",
           "AIOPS"
+        ]
+      }
+    },
+    "entitlements": {
+      "$id": "#/definitions/entitlements",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "testEntitlement"
         ]
       }
     },

--- a/validator/schemas/relationship-synthesis-schema-v1.json
+++ b/validator/schemas/relationship-synthesis-schema-v1.json
@@ -120,7 +120,10 @@
       "type": "object",
       "properties": {
         "matching": {
-          "type": "string"
+          "type": "string",
+          "enum": [
+            "anyOf"
+          ]
         },
         "values": {
           "type": "array",

--- a/validator/schemas/relationship-synthesis-schema-v1.json
+++ b/validator/schemas/relationship-synthesis-schema-v1.json
@@ -117,13 +117,33 @@
     },
     "entitlements": {
       "$id": "#/definitions/entitlements",
-      "type": "array",
-      "items": {
-        "type": "string",
-        "enum": [
-          "testEntitlement"
-        ]
-      }
+      "type": "object",
+      "properties": {
+        "matching": {
+          "type": "string"
+        },
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "catalog_ccu",
+              "advanced_maps_ccu",
+              "auto_discovery_entities_ccu",
+              "ngep_nrql_access_layer_ccu",
+              "catalogs_discount_usage",
+              "advanced_maps_discount_usage",
+              "advanced_ccu",
+              "auto_discovery_entities_ccu_discount_usage"
+            ]
+          }
+        }
+      },
+      "required": [
+        "matching",
+        "values"
+      ],
+      "additionalProperties": false
     },
     "name": {
       "$id": "#/definitions/name",

--- a/validator/tools/validate_rules.js
+++ b/validator/tools/validate_rules.js
@@ -140,6 +140,21 @@ const RULES = [
         throw new Error(`We don't allow custom golden metrics & tags for ${domainType}. Please open an issue if you want to change this type.`);
       }
     }
+  },
+  {
+    name: 'UNINSTRUMENTED entities must not use synthesis',
+    apply: def => {
+      synthesisBlock = def.synthesis || {}
+
+      if (def.domain === 'UNINSTRUMENTED' &&
+        (synthesisBlock.disabled !== true ||
+        synthesisBlock.name !== undefined ||
+        synthesisBlock.rules !== undefined)
+      ) {
+        throw new Error(`Synthesis rules is not allowed for UNINSTRUMENTED types.`)
+      }
+
+    }
   }
 ];
 

--- a/validator/tools/validate_rules.js
+++ b/validator/tools/validate_rules.js
@@ -69,6 +69,10 @@ const RULES = [
     name: 'Entities with the same identifier and conditions must have the same domain and type',
     apply: def => {
       if ('synthesis' in def) {
+        if (def.synthesis.disabled === true) {
+          return;
+        }
+
         if (def.synthesis.rules !== undefined) {
           def.synthesis.rules.forEach((rule) => {
             const identifier = rule.identifier;


### PR DESCRIPTION
### Relevant information

This covers NR-442517

First, synthesis rules can now be explicitly disabled for a type. This will help owners to signal they don't want synthesis support on their types.

Second, we allow to filter relationship synthesis rules by an entitlement. This will allow to gate some relationships to specific account features.

**NOTE** Do not merge yet. We are testing the features.

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
