### PR TITLE
clarify infra-container status

### DIFF
--- a/entity-types/infra-container/definition.yml
+++ b/entity-types/infra-container/definition.yml
@@ -531,7 +531,7 @@ synthesis:
       k8s.node.name:
         entityTagNames: [k8s.nodeName]
 
-  # Docker Container from Samples
+  # Docker Container from Samples - NOT in use yet - see FF EntitySynthesis/ExtractEntityFromInfraTelemetry
   - identifier: entityId
     name: name
     legacyFeatures:
@@ -592,7 +592,7 @@ synthesis:
         entityTagName: aws.region
     prefixedTags:
       label.:
-  # K8s Container from Samples
+  # K8s Container from Samples - NOT in use yet - see FF EntitySynthesis/ExtractEntityFromInfraTelemetry
   - identifier: entityId
     name: containerName
     legacyFeatures:


### PR DESCRIPTION
not a code change, just adding to the **comment** to clarify the current status of Entity Synthesis for infra telemetry (Infra Data Platform / IDP).

This change was agreed with both Mikel Angulo (PM for K8s) and Faddy back in March, but PR 1961 got stuck/abandoned.

### Relevant information
The current entity synthesis rules for infra telemetry is confusing, because it tricks colleagues into believing that this would be active, and that changes to these rules would actually do something. That's not the case, and for that reason we clarify the status better in the comment that is the header for each of these 2 sections, for event types `ContainerSample` and for `K8sContainerSample`.