### PR TITLE
Creates entity synthesis rule for OCI Functions out of logs

### DIFF
--- a/entity-types/infra-ocifunction/definition.yml
+++ b/entity-types/infra-ocifunction/definition.yml
@@ -33,4 +33,19 @@ synthesis:
       prefix: "ocid1.fnfunc"
     - attribute: oci.namespace
       value: "oci_faas"
+  # Synthesis out of logs. Ref: https://docs.oracle.com/en-us/iaas/Content/Logging/Reference/details_for_functions.htm
+  - identifier: data.functionId
+    name: subject
+    legacyFeatures:
+      overrideGuidType: true
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: eventType
+      prefix: Log
+    - attribute: data.functionId
+      prefix: ocid1.fnfunc
+    - attribute: type
+      prefix: com.oraclecloud.functions.application.
+    - attribute: logging.testing.synthesize.oci.entities
+      value: true
 


### PR DESCRIPTION
### Relevant information

Introduces a new synthesis rule for OCI Function logs, currently under development.

The rule will only be applied if the attribute `logging.testing.synthesize.oci.entities` is fed to the ESE, and the Logs pipeline will only do so based on a FF, which will only be initially enabled for our testing accounts.

Therefore, it is completely safe to merge this PR as it will not cause any accidentally synthesis/materialization for any user.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
