### PR TITLE
update golden metrics to container.cpu.usage instead of container.cpu…

### DIFF
--- a/entity-types/infra-container/golden_metrics.yml
+++ b/entity-types/infra-container/golden_metrics.yml
@@ -12,8 +12,8 @@ cpuUtilization:
     newRelic:
       select: max(docker.container.cpuPercent) or max(k8s.container.cpuCoresUtilization) AS 'CPU Utilization (%)'
     opentelemetry:
-      # via dockerstatsreceiver & kubeletstatsreceiver – which send equivalent value named container.cpu.utilization
-      select: max(container.cpu.utilization) AS 'CPU Utilization (%)'
+      # via dockerstatsreceiver & kubeletstatsreceiver – which send equivalent value named container.cpu.usage, container.cpu.utilization (deprecated)
+      select: max(container.cpu.usage or container.cpu.utilization) AS 'CPU Utilization (%)'
 memoryUsage:
   title: Memory usage (bytes)
   unit: BYTES

--- a/entity-types/infra-container/tests/k8s-kubeletstats-opentelemetry-preview.json
+++ b/entity-types/infra-container/tests/k8s-kubeletstats-opentelemetry-preview.json
@@ -5,8 +5,8 @@
 		"k8s.pod.name": "tree-afge",
 		"k8s.container.name": "peach-332",
 		"newrelic.source": "api.metrics.otlp",
-		"metricName": "container.cpu.utilization",
-		"container.cpu.utilization": {
+		"metricName": "container.cpu.usage",
+		"container.cpu.usage": {
 			"type": "gauge",
 			"count": 1,
 			"sum": 9.04E-6,
@@ -46,7 +46,7 @@
 		"cloud.availability_zone": "us-central1-a",
 		"cloud.platform": "gcp_kubernetes_engine",
 		"cloud.provider": "gcp",
-		"container.cpu.utilization": {
+		"container.cpu.usage": {
 			"type": "gauge",
 			"count": 1,
 			"sum": 0.004455446,
@@ -54,7 +54,7 @@
 			"max": 0.004455446,
 			"latest": 0.004455446
 		},
-		"description": "Container CPU utilization",
+		"description": "Container CPU usage",
 		"host.id": "4918625919469772836",
 		"host.name": "gke-oie-opentelemetry-de-default-pool-e6e59b37-m7id",
 		"instrumentation.provider": "opentelemetry",
@@ -63,7 +63,7 @@
 		"k8s.namespace.name": "kube-system",
 		"k8s.pod.name": "pdcsi-node-mchpg",
 		"k8s.pod.uid": "b4b90f60-e6b2-4dc2-a39b-4097c3f15a10",
-		"metricName": "container.cpu.utilization",
+		"metricName": "container.cpu.usage",
 		"newrelic.chart.version": "0.8.5",
 		"newrelic.source": "api.metrics.otlp",
 		"otel.library.name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver",


### PR DESCRIPTION
….utilization


### Relevant information

update to latest semantic convention for CPU utilization https://opentelemetry.io/docs/specs/semconv/system/container-metrics/#metric-containercpuusage 


### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
