### PR TITLE
chore: [NR-443333] Fixes typo in rule for INFRA|OCILBAAS

### DIFF
--- a/entity-types/infra-ocilbaas/definition.yml
+++ b/entity-types/infra-ocilbaas/definition.yml
@@ -33,7 +33,7 @@ synthesis:
     conditions:
       - attribute: eventType
         prefix: Log
-      - attribute: oracle.resourceId
+      - attribute: oracle.resourceid
         prefix: ocid1.loadbalancer.
       - attribute: type
         prefix: com.oraclecloud.loadbalancer.


### PR DESCRIPTION
### Relevant information

Fixes typo in rule for INFRA|OCILBAAS

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
