### PR TITLE
fix(infra-elasticsearch): Remove metric synthesis condition to collect all metrics

### DIFF
--- a/entity-types/infra-elasticsearchnode/definition.stg.yml
+++ b/entity-types/infra-elasticsearchnode/definition.stg.yml
@@ -24,9 +24,6 @@ synthesis:
     conditions:
     - attribute: eventType
       value: Metric
-    # All metrics from the receiver starts with the 'elasticsearch.' prefix.
-    - attribute: metricName
-      prefix: elasticsearch.
     - attribute: instrumentation.provider
       value: opentelemetry
     # This filters only metrics coming from elasticsearch receiver, given that metrics


### PR DESCRIPTION


### Relevant information
Removed the "prefix: elasticsearch." condition in metric synthesis condition so that jvm metrics will also be synthesised for widget population
Right now due to `prefix: elasticsearch.` condition metrics with specified prefix are only synthesised and because of that jvm related widgets are not getting data
<img width="1194" height="299" alt="image" src="https://github.com/user-attachments/assets/320c4653-0f80-4d0d-bd4f-0242e219c6d3" />


<!--
  Describe what you have done.
  Provide details that are relevant to the PR

  Always think that the person reviewing the PR doesn't have the context you have.

  Links to examples, documentation and similar resources make the process easier to review.
-->

<!--
  Contributions to this repository are reviewed at least twice a week

  There's no further action required once the PR has been created.
 -->

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
