### PR TITLE
feat(col-o11y): tag ext-service with newrelic.service.type

### DIFF
--- a/entity-types/ext-service/definition.yml
+++ b/entity-types/ext-service/definition.yml
@@ -92,6 +92,8 @@ synthesis:
       service.namespace:
       faas.name:
       faas.id:
+      newrelic.service.type:
+        ttl: P1D
 
     # telemetry from kamon-agent provider
   - identifier: service.name

--- a/entity-types/ext-service/tests/Metric.json
+++ b/entity-types/ext-service/tests/Metric.json
@@ -1,0 +1,47 @@
+[
+  {
+    "_testcase": "OTel Collector v0.129.0",
+    "description": "Total physical memory (resident set size) [alpha]",
+    "instrumentation.provider": "opentelemetry",
+    "metricName": "otelcol_process_memory_rss",
+    "newrelic.source": "api.metrics.otlp",
+    "otel.library.name": "go.opentelemetry.io/collector/service",
+    "otel.library.version": "",
+    "otelcol_process_memory_rss": {
+      "type": "gauge",
+      "count": 1,
+      "sum": 205807616,
+      "min": 205807616,
+      "max": 205807616,
+      "latest": 205807616
+    },
+    "service.instance.id": "99832a72-8bc9-4538-8aaa-064df8956038",
+    "service.name": "service-name-foobar-1",
+    "service.version": "0.129.0",
+    "timestamp": 1756852978241,
+    "unit": "By"
+  },
+  {
+    "_testcase": "OTel Collector v0.129.0 w/ newrelic.service.type",
+    "description": "Total physical memory (resident set size) [alpha]",
+    "instrumentation.provider": "opentelemetry",
+    "metricName": "otelcol_process_memory_rss",
+    "newrelic.source": "api.metrics.otlp",
+    "otel.library.name": "go.opentelemetry.io/collector/service",
+    "otel.library.version": "",
+    "otelcol_process_memory_rss": {
+      "type": "gauge",
+      "count": 1,
+      "sum": 205807616,
+      "min": 205807616,
+      "max": 205807616,
+      "latest": 205807616
+    },
+    "service.instance.id": "99832a72-8bc9-4538-8aaa-064df8956038",
+    "service.name": "service-name-foobar-1",
+    "service.version": "0.129.0",
+    "timestamp": 1756852978241,
+    "unit": "By",
+    "newrelic.service.type": "otel_collector"
+  }
+]


### PR DESCRIPTION
### Relevant information
- Add `newrelic.service.type` attribute as tag to ext-service entities to allow distinguishing different types of services, e.g.  [collector](https://opentelemetry.io/docs/collector/) vs non-specific service instrumented with OTel.
- Adding it only to the synthesis rule for collectors for now but others may follow later.
- Intentionally not reusing `newrelic.entity.type` as that attribute has semantics that are interpreted across entity types whereas `newrelic.service.type` will have its semantics scoped to just a specific entity type, i.e. ext-service in this instance. Other 'service' entities may reuse this attribute and define their own semantics which is also why it was chosen over `newrelic.ext_service.type` which is less readable and unnecessarily detailed.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
