### PR TITLE
fix: Update Infra Nginx queries

### DIFF
--- a/entity-types/infra-nginxserver/golden_metrics.stg.yml
+++ b/entity-types/infra-nginxserver/golden_metrics.stg.yml
@@ -8,8 +8,9 @@ requests:
       eventId: entityGuid
       eventName: entityName
     opentelemetry:
-      select: average(requestsPerSecond)
-      from: (SELECT rate(sum(nginx.requests), 1 second) AS requestsPerSecond FROM Metric WHERE instrumentation.provider = 'opentelemetry' FACET entity.guid, entity.name TIMESERIES AUTO)
+      select: sum(`nginx.requests`) / sum((endTimestamp - timestamp) / 1000)
+      from: Metric
+      where: instrumentation.provider = 'opentelemetry' AND metricName = 'nginx.requests'
       eventId: entity.guid
       eventName: entity.name
 
@@ -25,7 +26,7 @@ activeConnections:
     opentelemetry:
       select: average(nginx.connections_current)
       from: Metric
-      where: state = 'active' AND instrumentation.provider = 'opentelemetry'
+      where: state = 'active' AND instrumentation.provider = 'opentelemetry' AND metricName = 'nginx.connections_current'
       eventId: entity.guid
       eventName: entity.name
 
@@ -39,8 +40,9 @@ connectionsAccepted:
       eventId: entityGuid
       eventName: entityName
     opentelemetry:
-      select: average(connectionsAcceptedPerSecond)
-      from: (SELECT rate(sum(nginx.connections_accepted), 1 second) AS connectionsAcceptedPerSecond FROM Metric WHERE instrumentation.provider = 'opentelemetry' FACET entity.guid, entity.name TIMESERIES AUTO)
+      select: sum(`nginx.connections_accepted`) / sum((endTimestamp - timestamp) / 1000)
+      from: Metric
+      where: instrumentation.provider = 'opentelemetry' AND metricName = 'nginx.connections_accepted'
       eventId: entity.guid
       eventName: entity.name
 
@@ -54,7 +56,7 @@ connectionsDropped:
       eventId: entityGuid
       eventName: entityName
     opentelemetry:
-      select: average(connectionsDroppedPerSecond)
-      from: (SELECT abs(rate(sum(nginx.connections_accepted), 1 second) - rate(sum(nginx.connections_handled), 1 second)) AS connectionsDroppedPerSecond FROM Metric WHERE instrumentation.provider = 'opentelemetry' FACET entity.guid, entity.name TIMESERIES AUTO)
-      eventId: entity.guid
+      select: (sum(connections_accepted) - sum(connections_handled)) / sum((endTimestamp - timestamp) / 1000)
+      from: Metric
+      where: instrumentation.provider = 'opentelemetry' AND (metricName = 'nginx.connections_accepted' OR metricName = 'nginx.connections_handled')
       eventName: entity.name

--- a/entity-types/infra-nginxserver/opentelemetry_dashboard.stg.json
+++ b/entity-types/infra-nginxserver/opentelemetry_dashboard.stg.json
@@ -15,7 +15,7 @@
       "title" : "Requests per second",
       "rawConfiguration" : {
         "nrqlQueries" : [ {
-          "query" : "FROM (FROM Metric SELECT rate(sum(nginx.requests), 1 second) AS requestsPerSecond WHERE instrumentation.provider = 'opentelemetry' FACET entity.guid TIMESERIES AUTO) SELECT average(requestsPerSecond) TIMESERIES AUTO",
+          "query" : "FROM Metric SELECT sum(`nginx.requests`) / sum((endTimestamp - timestamp) / 1000) AS 'Requests per second' WHERE instrumentation.provider = 'opentelemetry' AND metricName = 'nginx.requests' TIMESERIES AUTO",
           "accountId": 0} ]
       }
     }, {
@@ -31,7 +31,7 @@
       "title" : "Active Connections",
       "rawConfiguration" : {
         "nrqlQueries" : [ {
-          "query" : "FROM Metric SELECT average(nginx.connections_current) WHERE state = 'active' AND instrumentation.provider = 'opentelemetry' TIMESERIES AUTO",
+          "query" : "FROM Metric SELECT average(nginx.connections_current) AS 'Active Connections' WHERE state = 'active' AND instrumentation.provider = 'opentelemetry' AND metricName = 'nginx.connections_current' TIMESERIES AUTO",
           "accountId": 0} ]
       }
     }, {
@@ -47,7 +47,7 @@
       "title" : "Connections Accepted per second",
       "rawConfiguration" : {
         "nrqlQueries" : [ {
-          "query" : "FROM (FROM Metric SELECT rate(sum(nginx.connections_accepted), 1 second) AS connectionsAcceptedPerSecond WHERE instrumentation.provider = 'opentelemetry' FACET entity.guid TIMESERIES AUTO) SELECT average(connectionsAcceptedPerSecond) TIMESERIES AUTO",
+          "query" : "FROM Metric SELECT sum(`nginx.connections_accepted`) / sum((endTimestamp - timestamp) / 1000) AS 'Connections Accepted per second' WHERE instrumentation.provider = 'opentelemetry' AND metricName = 'nginx.connections_accepted' TIMESERIES AUTO",
           "accountId": 0} ]
       }
     }, {
@@ -63,7 +63,7 @@
       "title" : "Connections Dropped per second",
       "rawConfiguration" : {
         "nrqlQueries" : [ {
-          "query" : "FROM (FROM Metric SELECT abs(rate(sum(nginx.connections_accepted), 1 second) - rate(sum(nginx.connections_handled), 1 second)) AS connectionsDroppedPerSecond WHERE instrumentation.provider = 'opentelemetry' FACET entity.guid TIMESERIES AUTO) SELECT average(connectionsDroppedPerSecond) TIMESERIES AUTO",
+          "query" : "FROM Metric SELECT (sum(connections_accepted) - sum(connections_handled)) / sum((endTimestamp - timestamp) / 1000) AS 'Connections Dropped per second from OTEL' WHERE instrumentation.provider = 'opentelemetry' AND (metricName = 'nginx.connections_accepted' OR metricName = 'nginx.connections_handled') TIMESERIES AUTO",
           "accountId": 0} ]
       }
     } ]


### PR DESCRIPTION
### Relevant information
## Context: 
Currently the Golden metrics and Summary metrics of Infra Nginx Otel entity are not getting populated as shown below because we are using sub queries. (ENV: staging)

<img width="3454" height="1652" alt="image" src="https://github.com/user-attachments/assets/0e17caf4-8a14-4e25-92ae-e872be6fa1ed" />

Changes in this PR:
- Update the Nginx Otel golden metrics queries to use `sum(metricName)/sum((endTimestamp - timestamp) / 1000)` to calculate average value.
- Update the Nginx Otel dashboards queries to use the same logic mentioned above to calculate average value.
Note: The above changes should be done in staging ENV.

Requests per second
<img width="3808" height="1768" alt="image" src="https://github.com/user-attachments/assets/817862fe-6520-45ad-86f7-9c6ba8e5c6ba" />

Active Connections
<img width="3716" height="1650" alt="image" src="https://github.com/user-attachments/assets/b32cd5e8-e245-4b46-8b75-0cfa2f64cd67" />

Connections Accepted per second
<img width="3702" height="1470" alt="image" src="https://github.com/user-attachments/assets/2c315018-7212-4141-b658-cd3cba75e374" />

Connections Dropped per second
<img width="3728" height="1508" alt="image" src="https://github.com/user-attachments/assets/f219bd8a-230c-4d37-b5e4-5813542659af" />



<!--
  Describe what you have done.
  Provide details that are relevant to the PR

  Always think that the person reviewing the PR doesn't have the context you have.

  Links to examples, documentation and similar resources make the process easier to review.
-->

<!--
  Contributions to this repository are reviewed at least twice a week

  There's no further action required once the PR has been created.
 -->

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
