### PR TITLE
feat: update the relationship type

### DIFF
--- a/relationships/synthesis/BROWSER-VIDEO-to-MEDIA-STREAMING.yml
+++ b/relationships/synthesis/BROWSER-VIDEO-to-MEDIA-STREAMING.yml
@@ -13,7 +13,7 @@ relationships:
         anyOf: [ "Browser" ]
     relationship:
       expires: P75M
-      relationshipType: CONTAINS
+      relationshipType: CONNECTS_TO
       source:
         buildGuid:
           account:
@@ -27,14 +27,5 @@ relationships:
               - attribute: parentAppId
             hashAlgorithm: IDENTITY
       target:
-        buildGuid:
-          account:
-            attribute: mediaAccountId
-          domain:
-            value: MEDIA_STREAMING
-          type:
-            value: VIDEO
-          identifier:
-            fragments:
-              - attribute: appName
-            hashAlgorithm: IDENTITY
+        extractGuid:
+          attribute: entity.guid

--- a/relationships/synthesis/MOBILE-VIDEO-to-MEDIA-STREAMING.yml
+++ b/relationships/synthesis/MOBILE-VIDEO-to-MEDIA-STREAMING.yml
@@ -13,7 +13,7 @@ relationships:
         anyOf: ["Android", "IOS"]
     relationship:
       expires: P75M
-      relationshipType: CONTAINS
+      relationshipType: CONNECTS_TO
       source:
         buildGuid:
           account:


### PR DESCRIPTION
Updated the relationship type from CONTAINS to CONNECTS_TO
  
The current implementation model uses the CONTAINS relationship to define the connection between a Standalone Mobile/Browser Agent and a Mobile/Browser Agent. This implies that one is a component or a subset of the other, which is not an accurate representation of the new architecture(Standalone).
Proposed Change:
We need to update this relationship type from CONTAINS to CONNECTS_TO.
CONTAINS (Set-Based Relationship): This relationship is best suited for scenarios where one entity is a composite of other entities. This no longer reflects the independent nature of the agents.
CONNECTS_TO (Network-Based Relationship): This relationship more accurately represents the new, decentralized architecture. It signifies that a Standalone Mobile/Browser Agent is an independent entity that establishes a connection with a Mobile/Browser Agent to interact with it.
-->

<!--


### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
