### PR TITLE
Update Nginx Otel Entity definition

### DIFF
--- a/entity-types/infra-nginxserver/definition.stg.yml
+++ b/entity-types/infra-nginxserver/definition.stg.yml
@@ -11,18 +11,17 @@ synthesis:
   rules:
   - compositeIdentifier:
       separator: ":"
-      attributes: 
+      attributes:
         - host.id
-        - nginx.server.address
         - nginx.server.port
-    name: nginx.server.address
+    name: nginx.displayName
     encodeIdentifierInGUID: true
     conditions:
       - attribute: eventType
         value: Metric
-      - attribute: nginx.server.address
-        present: true
       - attribute: nginx.server.port
+        present: true
+      - attribute: nginx.displayName
         present: true
       # All metrics from the receiver starts with the 'nginx.' prefix.
       - attribute: metricName
@@ -35,7 +34,6 @@ synthesis:
         value: "otelcol/nginxreceiver"
     tags:
       # Default resource attributes
-      nginx.server.address:
       nginx.server.port:
       # OTel attributes
       # The library name contains the name of the receiver that is used to identify the source

--- a/entity-types/infra-nginxserver/tests/Metric.stg.json
+++ b/entity-types/infra-nginxserver/tests/Metric.stg.json
@@ -1,26 +1,26 @@
 [
     {
         "description": "The current number of nginx connections by state",
-        "host.id": "ec27acd2e211af64573a8974868d24a",
-        "host.name": "ip-10-10-100-31.us-east-2.compute.internal",
+        "host.id": "ec27acd2e211af64572ae2764868d24a",
+        "host.name": "ip-10-10-49-31.us-east-2.compute.internal",
         "instrumentation.provider": "opentelemetry",
         "metricName": "nginx.connections_current",
         "newrelic.source": "api.metrics.otlp",
         "nginx.connections_current": {
             "type": "gauge",
             "count": 1,
-            "sum": 122,
-            "min": 122,
-            "max": 122,
-            "latest": 122
+            "sum": 1,
+            "min": 1,
+            "max": 1,
+            "latest": 1
         },
-        "nginx.server.address": "127.0.0.1",
+        "nginx.displayName": "server:ec27acd2e211af64572ae2764868d24a:80",
         "nginx.server.port": "80",
         "os.type": "linux",
         "otel.library.name": "otelcol/nginxreceiver",
         "otel.library.version": "0.82.0",
         "state": "active",
-        "timestamp": 1756181637258,
+        "timestamp": 1757422823441,
         "unit": "connections"
     }
 ]


### PR DESCRIPTION
### Relevant information

Changes in this PR:
1. Remove `nginx.server.address` from composite Identifier of Nginx otel entity definition
2. Use `nginx.displayName` as name in the entity synthesis rule because the value of `nginx.server.address` might not be unique i.e localhost/127.0.0.1 can be used on multiple hosts.
Note: `nginx.displayName` will be created in the processor of otel collector and it will contain `host.id` to build a unique name per host. The above changes are for staging ENV.

<!--
  Describe what you have done.
  Provide details that are relevant to the PR

  Always think that the person reviewing the PR doesn't have the context you have.

  Links to examples, documentation and similar resources make the process easier to review.
-->

<!--
  Contributions to this repository are reviewed at least twice a week

  There's no further action required once the PR has been created.
 -->

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
