### PR TITLE
Add ttl P1D to prometheus entities

### DIFF
--- a/entity-types/ext-argocd/definition.stg.yml
+++ b/entity-types/ext-argocd/definition.stg.yml
@@ -14,21 +14,29 @@ synthesis:
     # prometheus
     cluster_name:
       entityTagName: k8s.clusterName
+      ttl: P1D
     namespace:
       entityTagName: k8s.namespaceName
+      ttl: P1D
     node:
       entityTagName: k8s.nodeName
+      ttl: P1D  
     pod:
       entityTagName: k8s.podName
 
     # otel
     k8s.cluster.name:
       entityTagName: k8s.clusterName
+      ttl: P1D
     k8s.namespace.name:
       entityTagName: k8s.namespaceName
+      ttl: P1D
     k8s.node.name:
       entityTagName: k8s.nodeName
+      ttl: P1D
     k8s.pod.name:
+      entityTagName: k8s.podName
+      ttl: P1D
       entityTagName: k8s.podName
 
 goldenTags:

--- a/entity-types/ext-calico/definition.stg.yml
+++ b/entity-types/ext-calico/definition.stg.yml
@@ -14,23 +14,32 @@ synthesis:
     # prometheus
     cluster_name:
       entityTagName: k8s.clusterName
+      ttl: P1D
     instance:
     namespace:
       entityTagName: k8s.namespaceName
+      ttl: P1D
     node:
       entityTagName: k8s.nodeName
+      ttl: P1D
     pod:
       entityTagName: k8s.podName
+      ttl: P1D
     prometheus_server:
 
     # otel
     k8s.cluster.name:
       entityTagName: k8s.clusterName
+      ttl: P1D
     k8s.namespace.name:
       entityTagName: k8s.namespaceName
+      ttl: P1D
     k8s.node.name:
       entityTagName: k8s.nodeName
+      ttl: P1D
     k8s.pod.name:
+      entityTagName: k8s.podName
+      ttl: P1D
       entityTagName: k8s.podName
 
 dashboardTemplates:

--- a/entity-types/ext-coredns/definition.stg.yml
+++ b/entity-types/ext-coredns/definition.stg.yml
@@ -13,22 +13,31 @@ synthesis:
     # prometheus
     cluster_name:
       entityTagName: k8s.clusterName
+      ttl: P1D
     namespace:
       entityTagName: k8s.namespaceName
+      ttl: P1D
     node:
       entityTagName: k8s.nodeName
+      ttl: P1D
     pod:
+      entityTagName: k8s.podName
+      ttl: P1D
       entityTagName: k8s.podName
 
     # otel
     k8s.cluster.name:
       entityTagName: k8s.clusterName
+      ttl: P1D
     k8s.namespace.name:
       entityTagName: k8s.namespaceName
+      ttl: P1D
     k8s.node.name:
       entityTagName: k8s.nodeName
+      ttl: P1D
     k8s.pod.name:
-      entityTagName: k8s.podName
+      entityTagName: k8s.podName  
+      ttl: P1D
 
 dashboardTemplates:
   newRelic:

--- a/entity-types/ext-envoy/definition.stg.yml
+++ b/entity-types/ext-envoy/definition.stg.yml
@@ -22,21 +22,30 @@ synthesis:
     # prometheus
     cluster_name:
       entityTagName: k8s.clusterName
+      ttl: P1D
     namespace:
       entityTagName: k8s.namespaceName
+      ttl: P1D
     node:
       entityTagName: k8s.nodeName
+      ttl: P1D
     pod:
       entityTagName: k8s.podName
+      ttl: P1D
 
     # otel
     k8s.cluster.name:
       entityTagName: k8s.clusterName
+      ttl: P1D
     k8s.namespace.name:
       entityTagName: k8s.namespaceName
+      ttl: P1D
     k8s.node.name:
       entityTagName: k8s.nodeName
+      ttl: P1D
     k8s.pod.name:
+      entityTagName: k8s.podName
+      ttl: P1D
       entityTagName: k8s.podName
 
 dashboardTemplates:

--- a/entity-types/ext-istio_ingress/definition.stg.yml
+++ b/entity-types/ext-istio_ingress/definition.stg.yml
@@ -18,21 +18,30 @@ synthesis:
     # prometheus
     cluster_name:
       entityTagName: k8s.clusterName
+      ttl: P1D
     namespace:
       entityTagName: k8s.namespaceName
+      ttl: P1D
     node:
       entityTagName: k8s.nodeName
+      ttl: P1D  
     pod:
       entityTagName: k8s.podName
+      ttl: P1D
 
     # otel
     k8s.cluster.name:
       entityTagName: k8s.clusterName
+      ttl: P1D
     k8s.namespace.name:
       entityTagName: k8s.namespaceName
+      ttl: P1D
     k8s.node.name:
       entityTagName: k8s.nodeName
+      ttl: P1D
     k8s.pod.name:
+      entityTagName: k8s.podName
+      ttl: P1D
       entityTagName: k8s.podName
 
 dashboardTemplates:

--- a/entity-types/ext-istio_service/definition.stg.yml
+++ b/entity-types/ext-istio_service/definition.stg.yml
@@ -31,22 +31,30 @@ synthesis:
     # prometheus
     cluster_name:
       entityTagName: k8s.clusterName
+      ttl: P1D
     deployment:
       entityTagName: k8s.deploymentName
+      ttl: P1D  
     namespace:
       entityTagName: k8s.namespaceName
+      ttl: P1D
     pod:
       entityTagName: k8s.podName
+      ttl: P1D
 
     # otel
     k8s.cluster.name:
       entityTagName: k8s.clusterName
+      ttl: P1D
     k8s.deployment.name:
       entityTagName: k8s.deploymentName
+      ttl: P1D
     k8s.namespace.name:
       entityTagName: k8s.namespaceName
+      ttl: P1D
     k8s.pod.name:
       entityTagName: k8s.podName
+      ttl: P1D
 
     service_istio_io_canonical_revision:
     app:

--- a/entity-types/ext-keda/definition.stg.yml
+++ b/entity-types/ext-keda/definition.stg.yml
@@ -14,23 +14,33 @@ synthesis:
     # prometheus
     cluster_name:
       entityTagName: k8s.clusterName
+      ttl: P1D
     job:
+      entityTagName: k8s.jobName
+      ttl: P1D
     namespace:
       entityTagName: k8s.namespaceName
+      ttl: P1D
     node:
       entityTagName: k8s.nodeName
+      ttl: P1D
     pod:
       entityTagName: k8s.podName
+      ttl: P1D
 
     # otel
     k8s.cluster.name:
       entityTagName: k8s.clusterName
+      ttl: P1D
     k8s.namespace.name:
       entityTagName: k8s.namespaceName
+      ttl: P1D
     k8s.node.name:
       entityTagName: k8s.nodeName
+      ttl: P1D
     k8s.pod.name:
       entityTagName: k8s.podName
+      ttl: P1D
 
 dashboardTemplates:
   prometheus:

--- a/entity-types/ext-nginx_ingress_controller/definition.stg.yml
+++ b/entity-types/ext-nginx_ingress_controller/definition.stg.yml
@@ -14,24 +14,32 @@ synthesis:
     # prometheus
     cluster_name:
       entityTagName: k8s.clusterName
+      ttl: P1D
     instance:
     namespace:
       entityTagName: k8s.namespaceName
+      ttl: P1D
     node:
       entityTagName: k8s.nodeName
+      ttl: P1D
     pod:
       entityTagName: k8s.podName
+      ttl: P1D
     prometheus_server:
 
     # otel
     k8s.cluster.name:
       entityTagName: k8s.clusterName
+      ttl: P1D
     k8s.namespace.name:
       entityTagName: k8s.namespaceName
+      ttl: P1D
     k8s.node.name:
       entityTagName: k8s.nodeName
+      ttl: P1D
     k8s.pod.name:
       entityTagName: k8s.podName
+      ttl: P1D
 
 dashboardTemplates:
   prometheus:

--- a/entity-types/ext-prometheus_server/definition.stg.yml
+++ b/entity-types/ext-prometheus_server/definition.stg.yml
@@ -11,12 +11,16 @@ synthesis:
   tags:
     cluster_name:
       entityTagName: k8s.clusterName
+      ttl: P1D
     namespace:
       entityTagName: k8s.namespaceName
+      ttl: P1D
     node:
       entityTagName: k8s.nodeName
+      ttl: P1D
     pod:
       entityTagName: k8s.podName
+      ttl: P1D
 dashboardTemplates:
   prometheus:
     template: dashboard.stg.json


### PR DESCRIPTION
### Relevant information

Add ttl P1D to all prometheus entities to avoid old tags 

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
