### PR TITLE
fix: Remove stg from definitions

### DIFF
--- a/entity-types/ext-calico/definition.yml
+++ b/entity-types/ext-calico/definition.yml
@@ -42,7 +42,7 @@ synthesis:
 
 dashboardTemplates:
   prometheus:
-    template: dashboard.stg.json
+    template: dashboard.json
 
 configuration:
   entityExpirationTime: EIGHT_DAYS

--- a/entity-types/ext-keda/definition.yml
+++ b/entity-types/ext-keda/definition.yml
@@ -43,7 +43,7 @@ synthesis:
 
 dashboardTemplates:
   prometheus:
-    template: dashboard.stg.json
+    template: dashboard.json
 
 configuration:
   entityExpirationTime: EIGHT_DAYS

--- a/entity-types/ext-nginx_ingress_controller/definition.yml
+++ b/entity-types/ext-nginx_ingress_controller/definition.yml
@@ -43,7 +43,7 @@ synthesis:
 
 dashboardTemplates:
   prometheus:
-    template: dashboard.stg.json
+    template: dashboard.json
 
 configuration:
   entityExpirationTime: EIGHT_DAYS

--- a/entity-types/ext-prometheus_server/definition.yml
+++ b/entity-types/ext-prometheus_server/definition.yml
@@ -23,7 +23,7 @@ synthesis:
       ttl: P1D
 dashboardTemplates:
   prometheus:
-    template: dashboard.stg.json
+    template: dashboard.json
 configuration:
   entityExpirationTime: EIGHT_DAYS
   alertable: true


### PR DESCRIPTION
### Relevant information
Remove stg from definition files 

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
