### PR TITLE
[NR-462796] Expanding hostId to cover aws.ec2.hostId

### DIFF
--- a/relationships/candidates/HOST.yml
+++ b/relationships/candidates/HOST.yml
@@ -6,9 +6,9 @@ lookups:
     tags:
       matchingMode: ANY
       predicates:
-        - tagKeys: ["host.id"]
+        - tagKeys: ["host.id", "aws.ec2.host.id"]
           field: cloudProviderId
-        - tagKeys: ["host.id"]
+        - tagKeys: ["host.id", "aws.ec2.host.id"]
           field: host.id
     onMatch:
      onMultipleMatches: RELATE_ALL


### PR DESCRIPTION
### Relevant information
- Expanding host.id to cover Cloudwatch Metrics Stream Tags aws.ec2.host.id

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
