### PR TITLE
feat: update nginx otel synthesis rule

### DIFF
--- a/entity-types/infra-nginxserver/definition.stg.yml
+++ b/entity-types/infra-nginxserver/definition.stg.yml
@@ -12,16 +12,18 @@ synthesis:
   - compositeIdentifier:
       separator: ":"
       attributes:
-        - host.id
-        - nginx.server.port
-    name: nginx.displayName
+        - nginx.deployment.name
+        - nginx.server.endpoint
+    name: nginx.display.name
     encodeIdentifierInGUID: true
     conditions:
       - attribute: eventType
         value: Metric
-      - attribute: nginx.server.port
+      - attribute: nginx.deployment.name
         present: true
-      - attribute: nginx.displayName
+      - attribute: nginx.server.endpoint
+        present: true
+      - attribute: nginx.display.name
         present: true
       # All metrics from the receiver starts with the 'nginx.' prefix.
       - attribute: metricName
@@ -34,7 +36,40 @@ synthesis:
         value: "otelcol/nginxreceiver"
     tags:
       # Default resource attributes
-      nginx.server.port:
+      nginx.server.endpoint:
+      # OTel attributes
+      # The library name contains the name of the receiver that is used to identify the source
+      # and select the dashboard.
+      otel.library.name:
+        entityTagName: instrumentation.name
+  - compositeIdentifier:
+      separator: ":"
+      attributes:
+        - nginx.deployment.name
+        - nginx.server.endpoint
+    name: nginx.display.name
+    encodeIdentifierInGUID: true
+    conditions:
+      - attribute: eventType
+        value: Metric
+      - attribute: nginx.deployment.name
+        present: true
+      - attribute: nginx.server.endpoint
+        present: true
+      - attribute: nginx.display.name
+        present: true
+      # All metrics from the receiver starts with the 'nginx.' prefix.
+      - attribute: metricName
+        prefix: nginx.
+      - attribute: instrumentation.provider
+        value: opentelemetry
+      # This filters only metrics coming from nginx receiver, given that metrics
+      # could differ between different runtime receivers.
+      - attribute: otel.library.name
+        value: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiver"
+    tags:
+      # Default resource attributes
+      nginx.server.endpoint:
       # OTel attributes
       # The library name contains the name of the receiver that is used to identify the source
       # and select the dashboard.

--- a/entity-types/infra-nginxserver/tests/Metric.stg.json
+++ b/entity-types/infra-nginxserver/tests/Metric.stg.json
@@ -1,8 +1,6 @@
 [
     {
         "description": "The current number of nginx connections by state",
-        "host.id": "ec27acd2e211af64572ae2764868d24a",
-        "host.name": "ip-10-10-49-31.us-east-2.compute.internal",
         "instrumentation.provider": "opentelemetry",
         "metricName": "nginx.connections_current",
         "newrelic.source": "api.metrics.otlp",
@@ -14,13 +12,35 @@
             "max": 1,
             "latest": 1
         },
-        "nginx.displayName": "server:ec27acd2e211af64572ae2764868d24a:80",
-        "nginx.server.port": "80",
-        "os.type": "linux",
+        "nginx.deployment.name": "nginx-3",
+        "nginx.display.name": "server:nginx-3",
+        "nginx.server.endpoint": "http://127.0.0.1:8081/basic_status",
         "otel.library.name": "otelcol/nginxreceiver",
         "otel.library.version": "0.82.0",
         "state": "active",
         "timestamp": 1757422823441,
+        "unit": "connections"
+    },
+    {
+        "description": "The current number of nginx connections by state",
+        "instrumentation.provider": "opentelemetry",
+        "metricName": "nginx.connections_current",
+        "newrelic.source": "api.metrics.otlp",
+        "nginx.connections_current": {
+            "type": "gauge",
+            "count": 1,
+            "sum": 1,
+            "min": 1,
+            "max": 1,
+            "latest": 1
+        },
+        "nginx.deployment.name": "nginx-1",
+        "nginx.display.name": "server:nginx-1",
+        "nginx.server.endpoint": "http://nginx:8080/basic_status",
+        "otel.library.name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiver",
+        "otel.library.version": "0.121.0",
+        "state": "active",
+        "timestamp": 1758198462460,
         "unit": "connections"
     }
 ]


### PR DESCRIPTION
### Relevant information

## Changes 

1. Use `nginx.deployment.name` and `nginx.server.endpoint` as a composite identifier.
2. Rename `nginx.displayName` to `nginx.display.name` to maintain consistency.
3. Make the synthesis rule work for older and new version of otel collector by defining the possible `otel.library.name` values.

`nginx.deployment.name` will be a unique input value from customer across the Infra space for an account.


<!--
  Describe what you have done.
  Provide details that are relevant to the PR

  Always think that the person reviewing the PR doesn't have the context you have.

  Links to examples, documentation and similar resources make the process easier to review.
-->

<!--
  Contributions to this repository are reviewed at least twice a week

  There's no further action required once the PR has been created.
 -->

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
