### PR TITLE
feat(nginx): add relationship synthesis for OTEL Infra host to Infra nginxserver entities

### DIFF
--- a/relationships/synthesis/INFRA-HOST-to-INFRA-NGINXSERVER.stg.yml
+++ b/relationships/synthesis/INFRA-HOST-to-INFRA-NGINXSERVER.stg.yml
@@ -1,0 +1,35 @@
+relationships:
+  - name: hostHostsNginxServer
+    version: "1"
+    origins:
+      - OpenTelemetry
+    conditions:
+      - attribute: eventType
+        anyOf: [ "Metric" ]
+      - attribute: metricName
+        startsWith: nginx.
+      - attribute: instrumentation.provider
+        anyOf: [ "opentelemetry" ]
+      - attribute: host.id
+        present: true
+    relationship:
+      expires: P75M
+      relationshipType: HOSTS
+      source:
+        buildGuid:
+          account:
+            attribute: accountId
+          domain:
+            value: INFRA
+          type:
+            value: HOST
+            valueInGuid: NA
+          identifier:
+            fragments:
+              - attribute: host.id
+            hashAlgorithm: FARM_HASH
+      target:
+        extractGuid:
+          attribute: entity.guid
+          entityType:
+            value: NGINXSERVER


### PR DESCRIPTION
### Relevant information

## Changes in this PR

- Add relationship synthesis rule to link OTEL Infra host entity and OTEL NGINXSERVER entity

<!--
  Describe what you have done.
  Provide details that are relevant to the PR

  Always think that the person reviewing the PR doesn't have the context you have.

  Links to examples, documentation and similar resources make the process easier to review.
-->

<!--
  Contributions to this repository are reviewed at least twice a week

  There's no further action required once the PR has been created.
 -->

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
