### PR TITLE
Removes feature-flagged logging.testing.synthesize.oci.entities attribute from OCI entity synthesis rules

### DIFF
--- a/entity-types/infra-ocifunction/definition.yml
+++ b/entity-types/infra-ocifunction/definition.yml
@@ -38,6 +38,4 @@ synthesis:
       prefix: ocid1.fnfunc.
     - attribute: type
       prefix: com.oraclecloud.functions.application.
-    - attribute: logging.testing.synthesize.oci.entities
-      value: "true"
 

--- a/entity-types/infra-ocilbaas/definition.yml
+++ b/entity-types/infra-ocilbaas/definition.yml
@@ -37,5 +37,3 @@ synthesis:
         prefix: ocid1.loadbalancer.
       - attribute: type
         prefix: com.oraclecloud.loadbalancer.
-      - attribute: logging.testing.synthesize.oci.entities
-        value: "true"

--- a/entity-types/infra-ociobjectstorage/definition.yml
+++ b/entity-types/infra-ociobjectstorage/definition.yml
@@ -36,5 +36,3 @@ synthesis:
         prefix: ocid1.bucket.
       - attribute: type
         prefix: com.oraclecloud.objectstorage.
-      - attribute: logging.testing.synthesize.oci.entities
-        value: "true"

--- a/entity-types/infra-ociserviceconnectorhub/definition.yml
+++ b/entity-types/infra-ociserviceconnectorhub/definition.yml
@@ -37,5 +37,3 @@ synthesis:
         prefix: ocid1.serviceconnector.
       - attribute: type
         value: com.oraclecloud.sch.serviceconnector.runlog
-      - attribute: logging.testing.synthesize.oci.entities
-        value: "true"


### PR DESCRIPTION
The feature-flagged attribute `logging.testing.synthesize.oci.entities` is no longer required for the OCI entity synthesis rules included in this PR, as they have been successfully tested.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
