### PR TITLE
fix: Remove widget

### DIFF
--- a/entity-types/ext-calico/dashboard.json
+++ b/entity-types/ext-calico/dashboard.json
@@ -1,6 +1,6 @@
 {
   "name": "Calico Metrics Dashboard",
-  "description": "A dashboard for monitoring Calico metrics from Prometheus.",
+  "description": "A dashboard for monitoring Calico metrics.",
   "pages":
     [
       {
@@ -210,7 +210,7 @@
                 }
             },
             {
-              "title": "Active IP Table Chains by Instance, IP Version",
+              "title": "Active IP Tables Rules by Type",
               "layout": { "column": 7, "row": 20, "width": 6, "height": 4 },
               "visualization": { "id": "viz.line" },
               "rawConfiguration":
@@ -219,7 +219,7 @@
                     [
                       {
                         "accountId": 0,
-                        "query": "SELECT sum(chains) FROM ( FROM Metric SELECT latest(felix_iptables_chains) AS 'chains' FACET instance, ip_version, table LIMIT MAX ) facet concat(prometheus_server,' - ',instance) , concat('ip_version: ',ip_version)"
+                        "query": "SELECT latest(felix_iptables_rules) FROM Metric TIMESERIES"
                       }
                     ],
                   "yAxisLeft": { "zero": true }
@@ -258,24 +258,8 @@
                 }
             },
             {
-              "title": "Active IP Tables Rules by Type",
-              "layout": { "column": 1, "row": 28, "width": 6, "height": 4 },
-              "visualization": { "id": "viz.line" },
-              "rawConfiguration":
-                {
-                  "nrqlQueries":
-                    [
-                      {
-                        "accountId": 0,
-                        "query": "SELECT latest(felix_iptables_rules) FROM Metric TIMESERIES"
-                      }
-                    ],
-                  "yAxisLeft": { "zero": true }
-                }
-            },
-            {
               "title": "Calico BPF",
-              "layout": { "column": 7, "row": 28, "width": 6, "height": 4 },
+              "layout": { "column": 1, "row": 28, "width": 6, "height": 4 },
               "visualization": { "id": "viz.line" },
               "rawConfiguration":
                 {
@@ -291,7 +275,7 @@
             },
             {
               "title": "Failed BPF Endpoints",
-              "layout": { "column": 1, "row": 32, "width": 6, "height": 4 },
+              "layout": { "column": 7, "row": 28, "width": 6, "height": 4 },
               "visualization": { "id": "viz.line" },
               "rawConfiguration":
                 {
@@ -307,7 +291,7 @@
             },
             {
               "title": "BPF IPsets",
-              "layout": { "column": 7, "row": 32, "width": 6, "height": 4 },
+              "layout": { "column": 1, "row": 32, "width": 6, "height": 4 },
               "visualization": { "id": "viz.line" },
               "rawConfiguration":
                 {


### PR DESCRIPTION
### Relevant information
Removing widget that facets by instance because otel uses different naming convention for instance

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
