### PR TITLE
fix: Replace deprecated metrics from coredns queries

### DIFF
--- a/entity-types/ext-coredns/dashboard.json
+++ b/entity-types/ext-coredns/dashboard.json
@@ -141,7 +141,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "FROM Metric SELECT rate(sum(coredns_forward_requests_total), 1 second)  TIMESERIES "
+                "query": "FROM Metric SELECT rate(sum(coredns_proxy_request_duration_seconds_count), 1 second) FACET to WHERE proxy_name='forward' TIMESERIES"
               }
             ],
             "yAxisLeft": {
@@ -243,7 +243,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT histogrampercentile(coredns_forward_request_duration_seconds_bucket, (100 * 0.99), (100 * 0.5)) FROM Metric SINCE 60 MINUTES AGO UNTIL NOW FACET to LIMIT 100 TIMESERIES 300000 SLIDE BY 10000"
+                "query": "SELECT histogrampercentile(coredns_proxy_request_duration_seconds_bucket, (100 * 0.99), (100 * 0.5)) FROM Metric SINCE 60 MINUTES AGO UNTIL NOW FACET to, rcode LIMIT 100 WHERE proxy_name='forward' TIMESERIES 300000 SLIDE BY 10000"
               }
             ],
             "yAxisLeft": {

--- a/entity-types/ext-coredns/golden_metrics.yml
+++ b/entity-types/ext-coredns/golden_metrics.yml
@@ -1,27 +1,32 @@
 panics:
   title: CoreDNS panics as 'Panics'
-  unit: 'COUNT'
+  unit: "COUNT"
   query:
     select: sum(coredns_panics_total)
     from: Metric
 responseCodes:
   title: CoreDNS response codes as 'Response codes'
-  unit: 'COUNT'
+  unit: "COUNT"
   query:
     select: sum(coredns_dns_responses_total)
     from: Metric
     facet: rcode
 requestTypes:
   title: CoreDNS request types as 'Requests per second'
-  unit: 'REQUESTS_PER_SECOND'
+  unit: "REQUESTS_PER_SECOND"
   query:
     select: rate(sum(coredns_dns_requests_total), 1 second)
     from: Metric
     facet: type
 requestLatency:
   title: CoreDNS request latency as 'Average request latency(MS)'
-  unit: 'MS'
-  query:
-    select: sum(coredns_dns_request_duration_seconds_sum * 1000) / count(coredns_dns_request_duration_seconds_count)
-    from: Metric
-    facet: server, zone
+  unit: "MS"
+  queries:
+    newRelic:
+      select: sum(coredns_dns_request_duration_seconds_sum * 1000) / count(coredns_dns_request_duration_seconds_count)
+      from: Metric
+      facet: server, zone
+    opentelemetry:
+      select: sum(coredns_dns_request_duration_seconds_sum * 1000) / count(coredns_dns_request_duration_seconds)
+      from: Metric
+      facet: server, zone

--- a/entity-types/ext-coredns/opentelemetry_dashboard.json
+++ b/entity-types/ext-coredns/opentelemetry_dashboard.json
@@ -141,7 +141,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "FROM Metric SELECT rate(sum(coredns_forward_requests_total), 1 second)  TIMESERIES "
+                "query": "FROM Metric SELECT rate(sum(coredns_proxy_request_duration_seconds), 1 second) FACET to WHERE proxy_name='forward' TIMESERIES"
               }
             ],
             "yAxisLeft": {
@@ -243,7 +243,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT percentile(coredns_forward_request_duration_seconds, 99, 50) FROM Metric SINCE 60 MINUTES AGO UNTIL NOW FACET to LIMIT 100 TIMESERIES 300000 SLIDE BY 10000"
+                "query": "SELECT percentile(coredns_proxy_request_duration_seconds, (100 * 0.99), (100 * 0.5)) FROM Metric SINCE 60 MINUTES AGO UNTIL NOW FACET to, rcode LIMIT 100 WHERE proxy_name='forward' TIMESERIES 300000 SLIDE BY 10000"
               }
             ],
             "yAxisLeft": {


### PR DESCRIPTION
### Relevant information
Replace deprecated metrics from coredns queries 

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
