### PR TITLE
fix: Set multiValue to false for providerAccountName in OCI entity definitions to avoid duplicate tag creation

### DIFF
--- a/entity-types/infra-ociapigateway/definition.yml
+++ b/entity-types/infra-ociapigateway/definition.yml
@@ -14,6 +14,7 @@ synthesis:
   tags:
     newrelic.cloudIntegrations.providerAccountName:
       entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
+      multiValue: false
   rules:
   - identifier: oci.resourceId
     name: oci.resourceName

--- a/entity-types/infra-ociblockstore/definition.yml
+++ b/entity-types/infra-ociblockstore/definition.yml
@@ -16,6 +16,7 @@ synthesis:
   tags:
     newrelic.cloudIntegrations.providerAccountName:
       entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
+      multiValue: false
   rules:
   - identifier: oci.resourceId
     name: oci.resourceId

--- a/entity-types/infra-ociconnector/definition.yml
+++ b/entity-types/infra-ociconnector/definition.yml
@@ -13,6 +13,7 @@ synthesis:
   tags:
     newrelic.cloudIntegrations.providerAccountName:
       entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
+      multiValue: false
   rules:
   - identifier: oci.connectorId
     name: oci.connectorName

--- a/entity-types/infra-ocicontainerinstance/definition.yml
+++ b/entity-types/infra-ocicontainerinstance/definition.yml
@@ -12,6 +12,7 @@ synthesis:
   tags:
     newrelic.cloudIntegrations.providerAccountName:
       entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
+      multiValue: false
   rules:
   - identifier: oci.resourceId
     name: oci.resourceDisplayName

--- a/entity-types/infra-ocifunction/definition.yml
+++ b/entity-types/infra-ocifunction/definition.yml
@@ -14,6 +14,7 @@ synthesis:
   tags:
     newrelic.cloudIntegrations.providerAccountName:
       entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
+      multiValue: false
   rules:
   - identifier: oci.resourceId
     name: oci.resourceName

--- a/entity-types/infra-ocihealthcheck/definition.yml
+++ b/entity-types/infra-ocihealthcheck/definition.yml
@@ -14,6 +14,7 @@ synthesis:
   tags:
     newrelic.cloudIntegrations.providerAccountName:
       entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
+      multiValue: false
   rules:
   - identifier: oci.resourceId
     name: oci.resourceDisplayName

--- a/entity-types/infra-ociinstancepool/definition.yml
+++ b/entity-types/infra-ociinstancepool/definition.yml
@@ -13,6 +13,7 @@ synthesis:
   tags:
     newrelic.cloudIntegrations.providerAccountName:
       entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
+      multiValue: false
   rules:
   - compositeIdentifier:
       separator: "/"

--- a/entity-types/infra-ocikubernetes/definition.yml
+++ b/entity-types/infra-ocikubernetes/definition.yml
@@ -16,6 +16,7 @@ synthesis:
   tags:
     newrelic.cloudIntegrations.providerAccountName:
       entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
+      multiValue: false
   rules:
   - identifier: oci.clusterId
     name: oci.resourceDisplayName

--- a/entity-types/infra-ociloadbalancer/definition.yml
+++ b/entity-types/infra-ociloadbalancer/definition.yml
@@ -13,6 +13,7 @@ synthesis:
   tags:
     newrelic.cloudIntegrations.providerAccountName:
       entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
+      multiValue: false
   rules:
   - identifier: oci.resourceId
     name: oci.lbName

--- a/entity-types/infra-ocinlb/definition.yml
+++ b/entity-types/infra-ocinlb/definition.yml
@@ -12,6 +12,7 @@ synthesis:
   tags:
     newrelic.cloudIntegrations.providerAccountName:
       entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
+      multiValue: false
   rules:
   - identifier: oci.resourceId
     name: oci.resourceName

--- a/entity-types/infra-ociobjectstoragebucket/definition.yml
+++ b/entity-types/infra-ociobjectstoragebucket/definition.yml
@@ -12,6 +12,7 @@ synthesis:
   tags:
     newrelic.cloudIntegrations.providerAccountName:
       entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
+      multiValue: false
   rules:
   - identifier: oci.resourceID
     name: oci.resourceDisplayName

--- a/entity-types/infra-ocipostgresqldatabase/definition.yml
+++ b/entity-types/infra-ocipostgresqldatabase/definition.yml
@@ -15,6 +15,7 @@ synthesis:
   tags:
     newrelic.cloudIntegrations.providerAccountName:
       entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
+      multiValue: false
   rules:
   - identifier: oci.resourceId
     name: oci.resourceName

--- a/entity-types/infra-ociqueue/definition.yml
+++ b/entity-types/infra-ociqueue/definition.yml
@@ -12,6 +12,7 @@ synthesis:
   tags:
     newrelic.cloudIntegrations.providerAccountName:
       entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
+      multiValue: false
   rules:
   - identifier: oci.resourceId
     name: oci.queueName

--- a/entity-types/infra-ocistreaming/definition.yml
+++ b/entity-types/infra-ocistreaming/definition.yml
@@ -12,6 +12,7 @@ synthesis:
   tags:
     newrelic.cloudIntegrations.providerAccountName:
       entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
+      multiValue: false
   rules:
   - identifier: oci.resourceId
     name: oci.resourceId


### PR DESCRIPTION
Set multiValue to false for providerAccountName in OCI entity definitions to avoid duplicate tag creation

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
