### PR TITLE
feat: add entity synthesis rules for nginx instrumented using otel prometheus receiver

### DIFF
--- a/entity-types/infra-nginxserver/definition.stg.yml
+++ b/entity-types/infra-nginxserver/definition.stg.yml
@@ -75,6 +75,58 @@ synthesis:
       # and select the dashboard.
       otel.library.name:
         entityTagName: instrumentation.name
+  - compositeIdentifier:
+      separator: ":"
+      attributes:
+        - nginx.deployment.name
+        - nginx.server.endpoint
+    name: nginx.display.name
+    encodeIdentifierInGUID: true
+    conditions:
+      - attribute: eventType
+        value: Metric
+      - attribute: nginx.deployment.name
+        present: true
+      - attribute: nginx.server.endpoint
+        present: true
+      - attribute: nginx.display.name
+        present: true
+      - attribute: metricName
+        prefix: nginxplus_
+      - attribute: instrumentation.provider
+        value: opentelemetry
+      - attribute: otel.library.name
+        value: "otelcol/prometheusreceiver"
+    tags:
+      nginx.server.endpoint:
+      otel.library.name:
+        entityTagName: instrumentation.name
+  - compositeIdentifier:
+      separator: ":"
+      attributes:
+        - nginx.deployment.name
+        - nginx.server.endpoint
+    name: nginx.display.name
+    encodeIdentifierInGUID: true
+    conditions:
+      - attribute: eventType
+        value: Metric
+      - attribute: nginx.deployment.name
+        present: true
+      - attribute: nginx.server.endpoint
+        present: true
+      - attribute: nginx.display.name
+        present: true
+      - attribute: metricName
+        prefix: nginxplus_
+      - attribute: instrumentation.provider
+        value: opentelemetry
+      - attribute: otel.library.name
+        value: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver"
+    tags:
+      nginx.server.endpoint:
+      otel.library.name:
+        entityTagName: instrumentation.name
 
   tags:
     # For OpenTelemetry

--- a/entity-types/infra-nginxserver/golden_metrics.stg.yml
+++ b/entity-types/infra-nginxserver/golden_metrics.stg.yml
@@ -8,9 +8,9 @@ requests:
       eventId: entityGuid
       eventName: entityName
     opentelemetry:
-      select: sum(`nginx.requests`) / sum((endTimestamp - timestamp) / 1000)
+      select: sum(`nginx.requests` OR `nginxplus_http_requests_total`) / sum((endTimestamp - timestamp) / 1000)
       from: Metric
-      where: instrumentation.provider = 'opentelemetry' AND metricName = 'nginx.requests'
+      where: instrumentation.provider = 'opentelemetry' AND ((metricName = 'nginx.requests' AND nginxplus_http_requests_total is NULL) OR (metricName = 'nginxplus_http_requests_total' AND nginx.requests is NULL))
       eventId: entity.guid
       eventName: entity.name
 
@@ -24,9 +24,9 @@ activeConnections:
       eventId: entityGuid
       eventName: entityName
     opentelemetry:
-      select: average(nginx.connections_current)
+      select: average(`nginx.connections_current` OR `nginxplus_connections_active`)
       from: Metric
-      where: state = 'active' AND instrumentation.provider = 'opentelemetry' AND metricName = 'nginx.connections_current'
+      where: ((nginxplus_connections_active IS NULL AND state = 'active' AND metricName = 'nginx.connections_current') OR (nginx.connections_current is NULL AND metricName = 'nginxplus_connections_active')) AND instrumentation.provider = 'opentelemetry'
       eventId: entity.guid
       eventName: entity.name
 
@@ -40,9 +40,9 @@ connectionsAccepted:
       eventId: entityGuid
       eventName: entityName
     opentelemetry:
-      select: sum(`nginx.connections_accepted`) / sum((endTimestamp - timestamp) / 1000)
+      select: sum(`nginx.connections_accepted` OR `nginxplus_connections_accepted`) / sum((endTimestamp - timestamp) / 1000)
       from: Metric
-      where: instrumentation.provider = 'opentelemetry' AND metricName = 'nginx.connections_accepted'
+      where: ((nginxplus_connections_accepted is NULL AND metricName = 'nginx.connections_accepted') OR (nginx.connections_accepted is NULL AND metricName = 'nginxplus_connections_accepted')) AND instrumentation.provider = 'opentelemetry'
       eventId: entity.guid
       eventName: entity.name
 
@@ -56,7 +56,7 @@ connectionsDropped:
       eventId: entityGuid
       eventName: entityName
     opentelemetry:
-      select: (sum(connections_accepted) - sum(connections_handled)) / sum((endTimestamp - timestamp) / 1000)
+      select: ((sum(`nginx.connections_accepted`) - sum(`nginx.connections_handled`)) OR sum(`nginxplus_connections_dropped`)) / sum((endTimestamp - timestamp) / 1000)
       from: Metric
-      where: instrumentation.provider = 'opentelemetry' AND (metricName = 'nginx.connections_accepted' OR metricName = 'nginx.connections_handled')
+      where: instrumentation.provider = 'opentelemetry' AND ((nginxplus_connections_dropped is NULL AND metricName = 'nginx.connections_accepted' OR metricName = 'nginx.connections_handled') OR (metricName = 'nginxplus_connections_dropped' AND nginx.connections_accepted is NULL AND nginx.connections_handled is NULL))
       eventName: entity.name

--- a/entity-types/infra-nginxserver/newrelic_dashboard.stg.json
+++ b/entity-types/infra-nginxserver/newrelic_dashboard.stg.json
@@ -28,7 +28,7 @@
         "height" : 3,
         "width" : 6
       },
-      "title" : "Active Connections",
+      "title" : "Active connections",
       "rawConfiguration" : {
         "nrqlQueries" : [ {
           "query" : "SELECT average(net.connectionsActive) AS `Active connections` FROM NginxSample TIMESERIES AUTO",
@@ -44,7 +44,7 @@
         "height" : 3,
         "width" : 6
       },
-      "title" : "Connections Accepted per second",
+      "title" : "Connections accepted per second",
       "rawConfiguration" : {
         "nrqlQueries" : [ {
           "query" : "SELECT average(net.connectionsAcceptedPerSecond) AS `Connections accepted` FROM NginxSample TIMESERIES AUTO",
@@ -60,7 +60,7 @@
         "height" : 3,
         "width" : 6
       },
-      "title" : "Connections Dropped per second",
+      "title" : "Connections dropped per second",
       "rawConfiguration" : {
         "nrqlQueries" : [ {
           "query" : "SELECT average(net.connectionsDroppedPerSecond) AS `Connections dropped` FROM NginxSample TIMESERIES AUTO",

--- a/entity-types/infra-nginxserver/opentelemetry_dashboard.stg.json
+++ b/entity-types/infra-nginxserver/opentelemetry_dashboard.stg.json
@@ -15,7 +15,7 @@
       "title" : "Requests per second",
       "rawConfiguration" : {
         "nrqlQueries" : [ {
-          "query" : "FROM Metric SELECT sum(`nginx.requests`) / sum((endTimestamp - timestamp) / 1000) AS 'Requests per second' WHERE instrumentation.provider = 'opentelemetry' AND metricName = 'nginx.requests' TIMESERIES AUTO",
+          "query" : "FROM Metric SELECT sum(`nginx.requests` OR `nginxplus_http_requests_total`) / sum((endTimestamp - timestamp) / 1000) AS 'Requests' WHERE instrumentation.provider = 'opentelemetry' AND ((metricName = 'nginx.requests' AND nginxplus_http_requests_total is NULL) OR (metricName = 'nginxplus_http_requests_total' AND nginx.requests is NULL)) TIMESERIES AUTO",
           "accountId": 0} ]
       }
     }, {
@@ -28,10 +28,10 @@
         "height" : 3,
         "width" : 6
       },
-      "title" : "Active Connections",
+      "title" : "Active connections",
       "rawConfiguration" : {
         "nrqlQueries" : [ {
-          "query" : "FROM Metric SELECT average(nginx.connections_current) AS 'Active Connections' WHERE state = 'active' AND instrumentation.provider = 'opentelemetry' AND metricName = 'nginx.connections_current' TIMESERIES AUTO",
+          "query" : "FROM Metric SELECT average(`nginx.connections_current` OR `nginxplus_connections_active`) AS 'Active connections' WHERE ((nginxplus_connections_active IS NULL AND state = 'active' AND metricName = 'nginx.connections_current') OR (nginx.connections_current is NULL AND metricName = 'nginxplus_connections_active')) AND instrumentation.provider = 'opentelemetry' TIMESERIES AUTO",
           "accountId": 0} ]
       }
     }, {
@@ -44,10 +44,10 @@
         "height" : 3,
         "width" : 6
       },
-      "title" : "Connections Accepted per second",
+      "title" : "Connections accepted per second",
       "rawConfiguration" : {
         "nrqlQueries" : [ {
-          "query" : "FROM Metric SELECT sum(`nginx.connections_accepted`) / sum((endTimestamp - timestamp) / 1000) AS 'Connections Accepted per second' WHERE instrumentation.provider = 'opentelemetry' AND metricName = 'nginx.connections_accepted' TIMESERIES AUTO",
+          "query" : "FROM Metric SELECT sum(`nginx.connections_accepted` OR `nginxplus_connections_accepted`) / sum((endTimestamp - timestamp) / 1000) AS 'Connections accepted' WHERE ((nginxplus_connections_accepted is NULL AND metricName = 'nginx.connections_accepted') OR (nginx.connections_accepted is NULL AND metricName = 'nginxplus_connections_accepted')) AND instrumentation.provider = 'opentelemetry' TIMESERIES AUTO",
           "accountId": 0} ]
       }
     }, {
@@ -60,10 +60,10 @@
         "height" : 3,
         "width" : 6
       },
-      "title" : "Connections Dropped per second",
+      "title" : "Connections dropped per second",
       "rawConfiguration" : {
         "nrqlQueries" : [ {
-          "query" : "FROM Metric SELECT (sum(connections_accepted) - sum(connections_handled)) / sum((endTimestamp - timestamp) / 1000) AS 'Connections Dropped per second from OTEL' WHERE instrumentation.provider = 'opentelemetry' AND (metricName = 'nginx.connections_accepted' OR metricName = 'nginx.connections_handled') TIMESERIES AUTO",
+          "query" : "FROM Metric SELECT ((sum(`nginx.connections_accepted`) - sum(`nginx.connections_handled`)) OR sum(`nginxplus_connections_dropped`)) / sum((endTimestamp - timestamp) / 1000) AS 'Connections dropped' WHERE ((nginxplus_connections_dropped is NULL AND metricName = 'nginx.connections_accepted' OR metricName = 'nginx.connections_handled') OR (metricName = 'nginxplus_connections_dropped' AND nginx.connections_accepted is NULL AND nginx.connections_handled is NULL)) AND instrumentation.provider = 'opentelemetry' TIMESERIES AUTO",
           "accountId": 0} ]
       }
     } ]

--- a/entity-types/infra-nginxserver/tests/Metric.stg.json
+++ b/entity-types/infra-nginxserver/tests/Metric.stg.json
@@ -42,5 +42,30 @@
         "state": "active",
         "timestamp": 1758198462460,
         "unit": "connections"
+    },
+    {
+        "description": "Active client connections",
+        "http.scheme": "http",
+        "instrumentation.provider": "opentelemetry",
+        "metricName": "nginxplus_connections_active",
+        "net.host.port": "9113",
+        "newrelic.source": "api.metrics.otlp",
+        "nginx.deployment.name": "nginx-plus-1",
+        "nginx.display.name": "server:nginx-plus-1",
+        "nginx.server.endpoint": "http://127.0.0.1/api/9",
+        "nginxplus_connections_active": {
+            "type": "gauge",
+            "count": 1,
+            "sum": 1,
+            "min": 1,
+            "max": 1,
+            "latest": 1
+        },
+        "os.type": "linux",
+        "otel.library.name": "otelcol/prometheusreceiver",
+        "otel.library.version": "0.82.0",
+        "service.instance.id": "127.0.0.1:9113",
+        "service.name": "",
+        "timestamp": 1761287839186
     }
 ]


### PR DESCRIPTION

### Relevant information

### Changes in this PR:
- Add entity synthesis rules for nginx instrumented using otel prometheus receiver
- Update NGINXSERVER entity golden metrics from source OTEL to work for both nginx-receiver and prometheus-receiver instrumentations
- Update NGINXSERVER entity otel dashboard queries to work for both nginx-receiver and prometheus-receiver instrumentations

### Testing details
- Requests per second before changing query
- <img width="3354" height="1454" alt="image" src="https://github.com/user-attachments/assets/a5f9b517-f125-4883-8986-f29bbdf4b9bd" />
- Requests per second after adding support for nginx prometheus metrics
- <img width="3346" height="1460" alt="image" src="https://github.com/user-attachments/assets/f5ea3fd4-44ac-4425-9a38-3aa57df592d8" />
- Requests per second querying nginx prometheus metrics directly
- <img width="3348" height="1446" alt="image" src="https://github.com/user-attachments/assets/573386a2-69ff-424e-8874-8ecf020d6dad" />
- Requests per second using latest updated query
- <img width="3332" height="1460" alt="image" src="https://github.com/user-attachments/assets/05580b91-bb2f-4272-85e6-17048cd04f86" />
- I have verified the above for all the NGINXSERVER entity golden metrics from source OTEL and updated dashboard queries.

<!--
  Describe what you have done.
  Provide details that are relevant to the PR

  Always think that the person reviewing the PR doesn't have the context you have.

  Links to examples, documentation and similar resources make the process easier to review.
-->

<!--
  Contributions to this repository are reviewed at least twice a week

  There's no further action required once the PR has been created.
 -->

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
