### PR TITLE
NO-JIRA: Add Uninstrumented AWS Route 53 RecordSet

### DIFF
--- a/entity-types/uninstrumented-awsroute53recordset/definition.yml
+++ b/entity-types/uninstrumented-awsroute53recordset/definition.yml
@@ -1,0 +1,10 @@
+domain: UNINSTRUMENTED
+type: AWSROUTE53RECORDSET
+
+configuration:
+  entityExpirationTime: DAILY
+  alertable: false
+
+synthesis:
+  # Uninstrumented can't use synthesis
+  disabled: true


### PR DESCRIPTION
### Relevant information

Adds uninstrumented entity for AWS Route 53 RecordSet. Validation fails otherwise.

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
