### PR TITLE
Collapse case-insensitive anyOf

### DIFF
--- a/relationships/synthesis/INFRA-ELASTICSEARCHCLUSTER-to-INFRA-ELASTICSEARCHNODE.stg.yml
+++ b/relationships/synthesis/INFRA-ELASTICSEARCHCLUSTER-to-INFRA-ELASTICSEARCHNODE.stg.yml
@@ -7,7 +7,7 @@ relationships:
       - attribute: eventType
         anyOf: [ "ElasticsearchNodeSample" ]
       - attribute: nr.entityType
-        anyOf: ["ElasticsearchNode","ELASTICSEARCHNODE"]
+        anyOf: ["ELASTICSEARCHNODE"]
       - attribute: entityKey
         regex: ".*:clustername=([^:]+)"
     relationship:

--- a/relationships/synthesis/INFRA-HOST-to-INFRA-ELASTICSEARCHNODE.stg.yml
+++ b/relationships/synthesis/INFRA-HOST-to-INFRA-ELASTICSEARCHNODE.stg.yml
@@ -7,7 +7,7 @@ relationships:
       - attribute: eventType
         anyOf: [ "ElasticsearchNodeSample" ]
       - attribute: nr.entityType
-        anyOf: ["ElasticsearchNode","ELASTICSEARCHNODE"]
+        anyOf: ["ELASTICSEARCHNODE"]
       - attribute: reportingAgent
         present: true
     relationship:
@@ -40,7 +40,7 @@ relationships:
       - attribute: eventType
         anyOf: [ "ElasticsearchNodeSample" ]
       - attribute: nr.entityType
-        anyOf: ["ElasticsearchNode","ELASTICSEARCHNODE"]
+        anyOf: ["ELASTICSEARCHNODE"]
       - attribute: fullHostname
         present: true
       - attribute: reportingAgent

--- a/relationships/synthesis/INFRA-HOST-to-INFRA-KAFKABROKER.stg.yml
+++ b/relationships/synthesis/INFRA-HOST-to-INFRA-KAFKABROKER.stg.yml
@@ -8,7 +8,7 @@ relationships:
       - attribute: eventType
         anyOf: ["KafkaBrokerSample"]
       - attribute: nr.entityType
-        anyOf: ["KafkaBroker","KAFKABROKER"]
+        anyOf: ["KAFKABROKER"]
       - attribute: hostname
         present: true
       # Local detection - broker address is localhost
@@ -43,7 +43,7 @@ relationships:
       - attribute: eventType
         anyOf: ["KafkaBrokerSample"]
       - attribute: nr.entityType
-        anyOf: ["KafkaBroker","KAFKABROKER"]
+        anyOf: ["KAFKABROKER"]
       - attribute: hostname
         present: true
       # Local detection - broker address is localhost
@@ -79,7 +79,7 @@ relationships:
       - attribute: eventType
         anyOf: ["KafkaBrokerSample"]
       - attribute: nr.entityType
-        anyOf: ["KafkaBroker","KAFKABROKER"]
+        anyOf: ["KAFKABROKER"]
       - attribute: hostname
         present: true
       - attribute: displayName
@@ -113,7 +113,7 @@ relationships:
       - attribute: eventType
         anyOf: ["KafkaBrokerSample"]
       - attribute: nr.entityType
-        anyOf: ["KafkaBroker","KAFKABROKER"]
+        anyOf: ["KAFKABROKER"]
       - attribute: hostname
         present: true
       - attribute: displayName

--- a/relationships/synthesis/INFRA-HOST-to-INFRA-RABBITMQNODE.stg.yml
+++ b/relationships/synthesis/INFRA-HOST-to-INFRA-RABBITMQNODE.stg.yml
@@ -8,7 +8,7 @@ relationships:
       - attribute: eventType
         anyOf: ["RabbitmqNodeSample"]
       - attribute: nr.entityType
-        anyOf: ["RabbitMqNode","RABBITMQNODE"]
+        anyOf: ["RABBITMQNODE"]
       - attribute: hostname
         present: true
       # Local detection - broker address is localhost
@@ -44,7 +44,7 @@ relationships:
       - attribute: eventType
         anyOf: ["RabbitmqNodeSample"]
       - attribute: nr.entityType
-        anyOf: ["RabbitMqNode","RABBITMQNODE"]
+        anyOf: ["RABBITMQNODE"]
       - attribute: hostname
         present: true
       - attribute: displayName
@@ -80,7 +80,7 @@ relationships:
       - attribute: eventType
         anyOf: ["RabbitmqNodeSample"]
       - attribute: nr.entityType
-        anyOf: ["RabbitMqNode","RABBITMQNODE"]
+        anyOf: ["RABBITMQNODE"]
       - attribute: hostname
         present: true
       # Local detection - broker address is localhost
@@ -116,7 +116,7 @@ relationships:
       - attribute: eventType
         anyOf: ["RabbitmqNodeSample"]
       - attribute: nr.entityType
-        anyOf: ["RabbitMqNode","RABBITMQNODE"]
+        anyOf: ["RABBITMQNODE"]
       - attribute: hostname
         present: true
       - attribute: displayName

--- a/relationships/synthesis/INFRA-HOST-to-INFRA-REDISINSTANCE.stg.yml
+++ b/relationships/synthesis/INFRA-HOST-to-INFRA-REDISINSTANCE.stg.yml
@@ -7,7 +7,7 @@ relationships:
       - attribute: eventType
         anyOf: [ "RedisSample" ]
       - attribute: nr.entityType
-        anyOf: ["RedisInstance","REDISINSTANCE"]
+        anyOf: ["REDISINSTANCE"]
       - attribute: reportingAgent
         present: true
     relationship:
@@ -40,7 +40,7 @@ relationships:
       - attribute: eventType
         anyOf: [ "RedisSample" ]
       - attribute: nr.entityType
-        anyOf: ["RedisInstance","REDISINSTANCE"]
+        anyOf: ["REDISINSTANCE"]
       - attribute: fullHostname
         present: true
       - attribute: reportingAgent

--- a/relationships/synthesis/INFRA-KAFKABROKER-to-INFRA-KAFKATOPIC.stg.yml
+++ b/relationships/synthesis/INFRA-KAFKABROKER-to-INFRA-KAFKATOPIC.stg.yml
@@ -7,7 +7,7 @@ relationships:
       - attribute: eventType
         anyOf: [ "KafkaBrokerSample" ]
       - attribute: nr.entityType
-        anyOf: [ "KafkaBroker","KAFKABROKER" ]
+        anyOf: [ "KAFKABROKER" ]
       - attribute: clusterName
         present: true
     relationship:
@@ -44,7 +44,7 @@ relationships:
       - attribute: eventType
         anyOf: [ "KafkaBrokerSample" ]
       - attribute: nr.entityType
-        anyOf: [ "KafkaBroker","KAFKABROKER" ]
+        anyOf: [ "KAFKABROKER" ]
       - attribute: clusterName
         present: true
     relationship:

--- a/relationships/synthesis/INFRA-RABBITMQNODE-to-INFRA-RABBITMQQUEUE.stg.yml
+++ b/relationships/synthesis/INFRA-RABBITMQNODE-to-INFRA-RABBITMQQUEUE.stg.yml
@@ -53,7 +53,7 @@ relationships:
       - attribute: eventType
         anyOf: [ "RabbitmqQueueSample" ]
       - attribute: nr.entityType
-        anyOf: [ "RabbitmqQueue","RABBITMQQUEUE" ]
+        anyOf: [ "RABBITMQQUEUE" ]
     relationship:
       expires: PT75M
       relationshipType: CONTAINS


### PR DESCRIPTION
### Relevant information

The `anyOf` condition [defaults to case-insensitivity](https://github.com/newrelic/entity-definitions/blob/main/docs/relationships/relationship_synthesis.md#operations). That means that a condition that defines multiple options that differ only on case will waste effort. In several cases, this is the difference between a single-item lookup and a stream operation. 

These changes should make relationship synthesis more efficient.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* n/a The value of the attribute marked as `identifier` will be unique and valid. 
* n/a I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
