### PR TITLE
feat(nginx): add nginx otel log entity synthesis and k8s-pod to OTel NGINXSERVER relation synthesis rules

### DIFF
--- a/entity-types/infra-nginxserver/definition.stg.yml
+++ b/entity-types/infra-nginxserver/definition.stg.yml
@@ -127,6 +127,28 @@ synthesis:
       nginx.server.endpoint:
       otel.library.name:
         entityTagName: instrumentation.name
+  - compositeIdentifier:
+      separator: ":"
+      attributes:
+        - nginx.deployment.name
+        - nginx.server.endpoint
+    name: nginx.display.name
+    encodeIdentifierInGUID: true
+    conditions:
+      - attribute: eventType
+        value: Log
+      - attribute: newrelic.source
+        value: 'api.logs.otlp'
+      - attribute: nginx.deployment.name
+        present: true
+      - attribute: nginx.server.endpoint
+        present: true
+      - attribute: nginx.display.name
+        present: true
+      - attribute: instrumentation.provider
+        value: opentelemetry
+    tags:
+      nginx.server.endpoint:
 
   tags:
     # For OpenTelemetry

--- a/entity-types/infra-nginxserver/golden_metrics.stg.yml
+++ b/entity-types/infra-nginxserver/golden_metrics.stg.yml
@@ -56,7 +56,7 @@ connectionsDropped:
       eventId: entityGuid
       eventName: entityName
     opentelemetry:
-      select: ((sum(`nginx.connections_accepted`) - sum(`nginx.connections_handled`)) OR sum(`nginxplus_connections_dropped`)) / sum((endTimestamp - timestamp) / 1000)
+      select: ((sum(`nginx.connections_accepted`) - sum(`nginx.connections_handled`)) + sum(`nginxplus_connections_dropped`)) / sum((endTimestamp - timestamp) / 1000)
       from: Metric
       where: instrumentation.provider = 'opentelemetry' AND ((nginxplus_connections_dropped is NULL AND metricName = 'nginx.connections_accepted' OR metricName = 'nginx.connections_handled') OR (metricName = 'nginxplus_connections_dropped' AND nginx.connections_accepted is NULL AND nginx.connections_handled is NULL))
       eventName: entity.name

--- a/entity-types/infra-nginxserver/opentelemetry_dashboard.stg.json
+++ b/entity-types/infra-nginxserver/opentelemetry_dashboard.stg.json
@@ -28,10 +28,10 @@
         "height" : 3,
         "width" : 6
       },
-      "title" : "Connections Waiting per second",
+      "title" : "Connections Waiting",
       "rawConfiguration" : {
         "nrqlQueries" : [ {
-          "query" : "FROM Metric SELECT rate(sum(`nginx.connections_current` or `nginxplus_connections_idle`), 1 second) AS `Waiting` WHERE ((metricName = 'nginx.connections_current' AND state = 'waiting' AND nginxplus_connections_idle is NULL) OR (metricName = 'nginxplus_connections_idle' AND nginx.connections_current is NULL)) AND instrumentation.provider = 'opentelemetry' TIMESERIES AUTO",
+          "query" : "FROM Metric SELECT average(`nginx.connections_current` or `nginxplus_connections_idle`) AS `Waiting` WHERE ((metricName = 'nginx.connections_current' AND state = 'waiting' AND nginxplus_connections_idle is NULL) OR (metricName = 'nginxplus_connections_idle' AND nginx.connections_current is NULL)) AND instrumentation.provider = 'opentelemetry' TIMESERIES AUTO",
           "accountId": 0} ]
       }
     }, {
@@ -47,7 +47,7 @@
       "title" : "Active vs Dropped Connections",
       "rawConfiguration" : {
         "nrqlQueries" : [ {
-          "query" : "FROM Metric, Metric SELECT filter(average(`nginx.connections_current` OR `nginxplus_connections_active`), WHERE ((nginxplus_connections_active IS NULL AND state = 'active' AND metricName = 'nginx.connections_current') OR (nginx.connections_current is NULL AND metricName = 'nginxplus_connections_active')) AND instrumentation.provider = 'opentelemetry') AS 'Active connections', filter(((sum(`nginx.connections_accepted`) - sum(`nginx.connections_handled`)) + sum(`nginxplus_connections_dropped`)) / sum((endTimestamp - timestamp) / 1000), WHERE ((nginxplus_connections_dropped is NULL AND metricName = 'nginx.connections_accepted' OR metricName = 'nginx.connections_handled') OR (metricName = 'nginxplus_connections_dropped' AND nginx.connections_accepted is NULL AND nginx.connections_handled is NULL)) AND instrumentation.provider = 'opentelemetry') AS 'Connections dropped' TIMESERIES AUTO",
+          "query" : "FROM Metric, Metric SELECT filter(average(`nginx.connections_current` OR `nginxplus_connections_active`), WHERE ((nginxplus_connections_active IS NULL AND state = 'active' AND metricName = 'nginx.connections_current') OR (nginx.connections_current is NULL AND metricName = 'nginxplus_connections_active')) AND instrumentation.provider = 'opentelemetry') AS 'Active connections', filter((abs(sum(`nginx.connections_accepted`) - sum(`nginx.connections_handled`)) + sum(`nginxplus_connections_dropped`)) / sum((endTimestamp - timestamp) / 1000), WHERE ((nginxplus_connections_dropped is NULL AND metricName = 'nginx.connections_accepted' OR metricName = 'nginx.connections_handled') OR (metricName = 'nginxplus_connections_dropped' AND nginx.connections_accepted is NULL AND nginx.connections_handled is NULL)) AND instrumentation.provider = 'opentelemetry') AS 'Connections dropped' TIMESERIES AUTO",
           "accountId": 0} ]
       }
     }, {
@@ -63,7 +63,7 @@
       "title" : "Connections Accepted vs Handled",
       "rawConfiguration" : {
         "nrqlQueries" : [ {
-          "query" : "FROM Metric, Metric SELECT filter(sum(`nginx.connections_accepted` OR `nginxplus_connections_accepted`) / sum((endTimestamp - timestamp) / 1000), WHERE ((nginxplus_connections_accepted is NULL AND metricName = 'nginx.connections_accepted') OR (nginx.connections_accepted is NULL AND metricName = 'nginxplus_connections_accepted')) AND instrumentation.provider = 'opentelemetry') AS 'Connections accepted', filter(((sum(`nginxplus_connections_accepted`) - sum(`nginxplus_connections_dropped`)) + sum(`nginx.connections_handled`)) / sum((endTimestamp - timestamp) / 1000), WHERE instrumentation.provider = 'opentelemetry' AND (((metricName = 'nginxplus_connections_accepted' OR metricName = 'nginxplus_connections_dropped') AND nginx.connections_handled is NULL) OR (nginxplus_connections_accepted is NULL AND nginxplus_connections_dropped is NULL AND metricName = 'nginx.connections_handled'))) AS 'Connections handled' TIMESERIES AUTO",
+          "query" : "FROM Metric, Metric SELECT filter(sum(`nginx.connections_accepted` OR `nginxplus_connections_accepted`) / sum((endTimestamp - timestamp) / 1000), WHERE ((nginxplus_connections_accepted is NULL AND metricName = 'nginx.connections_accepted') OR (nginx.connections_accepted is NULL AND metricName = 'nginxplus_connections_accepted')) AND instrumentation.provider = 'opentelemetry') AS 'Connections accepted', filter((abs(sum(`nginxplus_connections_accepted`) - sum(`nginxplus_connections_dropped`)) + sum(`nginx.connections_handled`)) / sum((endTimestamp - timestamp) / 1000), WHERE instrumentation.provider = 'opentelemetry' AND (((metricName = 'nginxplus_connections_accepted' OR metricName = 'nginxplus_connections_dropped') AND nginx.connections_handled is NULL) OR (nginxplus_connections_accepted is NULL AND nginxplus_connections_dropped is NULL AND metricName = 'nginx.connections_handled'))) AS 'Connections handled' TIMESERIES AUTO",
           "accountId": 0} ]
       }
     }, {
@@ -118,7 +118,7 @@
       "title" : "Total Number of connections Accepted vs Handled",
       "rawConfiguration" : {
         "nrqlQueries" : [ {
-          "query" : "FROM Metric SELECT sum(`nginx.connections_accepted` OR `nginxplus_connections_accepted`) AS 'Total Number of connections accepted', (sum(`nginx.connections_handled`) + (sum(`nginxplus_connections_accepted`) - sum(`nginxplus_connections_dropped`))) AS 'Total Number of handled connections' WHERE ((nginxplus_connections_accepted is NULL AND metricName = 'nginx.connections_accepted') OR (nginx.connections_accepted is NULL AND metricName = 'nginxplus_connections_accepted')) OR ((nginxplus_connections_accepted is NULL AND nginxplus_connections_dropped is NULL AND metricName = 'nginx.connections_handled') OR ((metricName = 'nginxplus_connections_accepted' OR metricName = 'nginxplus_connections_dropped') AND nginx.connections_handled is NULL)) AND instrumentation.provider = 'opentelemetry'",
+          "query" : "FROM Metric SELECT sum(`nginx.connections_accepted` OR `nginxplus_connections_accepted`) AS 'Total Number of connections accepted', (sum(`nginx.connections_handled`) + abs(sum(`nginxplus_connections_accepted`) - sum(`nginxplus_connections_dropped`))) AS 'Total Number of handled connections' WHERE ((nginxplus_connections_accepted is NULL AND metricName = 'nginx.connections_accepted') OR (nginx.connections_accepted is NULL AND metricName = 'nginxplus_connections_accepted')) OR ((nginxplus_connections_accepted is NULL AND nginxplus_connections_dropped is NULL AND metricName = 'nginx.connections_handled') OR ((metricName = 'nginxplus_connections_accepted' OR metricName = 'nginxplus_connections_dropped') AND nginx.connections_handled is NULL)) AND instrumentation.provider = 'opentelemetry'",
           "accountId": 0} ]
       }
     }, {

--- a/entity-types/infra-nginxserver/tests/Log.stg.json
+++ b/entity-types/infra-nginxserver/tests/Log.stg.json
@@ -1,0 +1,11 @@
+[
+    {
+        "instrumentation.provider": "opentelemetry",
+        "message": "1.1.1.13 - - [18/Nov/2025:06:03:32 +0000] \"GET /v1/api HTTP/1.1\" 404 134 \"https://reddit.com/\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.1 Safari/605.1.15\"",
+        "newrelic.source": "api.logs.otlp",
+        "nginx.deployment.name": "nginx-2",
+        "nginx.display.name": "server:nginx-2",
+        "nginx.server.endpoint": "http://127.0.0.1:8081/status",
+        "timestamp": 1763445843047
+    }
+]

--- a/relationships/synthesis/INFRA-KUBERNETES_POD-to-INFRA-NGINXSERVER.stg.yml
+++ b/relationships/synthesis/INFRA-KUBERNETES_POD-to-INFRA-NGINXSERVER.stg.yml
@@ -1,0 +1,44 @@
+relationships:
+  - name: k8sPodContainsNginxServer
+    version: "1"
+    origins:
+      - OpenTelemetry
+    conditions: 
+      - attribute: eventType
+        anyOf: [ "Metric" ]
+      - attribute: metricName
+        startsWith: nginx.
+      - attribute: instrumentation.provider
+        anyOf: [ "opentelemetry" ]
+      - attribute: k8s.cluster.name
+        present: true
+      - attribute: k8s.namespace.name
+        present: true
+      - attribute: k8s.pod.name
+        present: true
+    relationship:
+      expires: P75M
+      relationshipType: CONTAINS
+      source:
+        buildGuid:
+          account:
+            lookup: true  
+          domain:
+            value: INFRA
+          type:
+            value: KUBERNETES_POD
+            valueInGuid: NA
+          identifier:
+            fragments:
+              - value: "k8s:"
+              - attribute: k8s.cluster.name
+              - value: ":"
+              - attribute: k8s.namespace.name
+              - value: ":pod:"
+              - attribute: k8s.pod.name
+            hashAlgorithm: FARM_HASH
+      target:
+        extractGuid:
+          attribute: entity.guid
+          entityType:
+            value: NGINXSERVER


### PR DESCRIPTION
### Relevant information

### Changes in this PR
- Add Log entity synthesis rule for NGINX OTel instrumentation 
- Use abs func when calculating dropped connections in case of Open source NGINX and handled connections in case of NGINX PLUS
- Add Relationship synthesis rule for INFRA-KUBERNETES_POD and INFRA-NGINXSERVER

Note: The mentioned changes are only for staging.

<!--
  Describe what you have done.
  Provide details that are relevant to the PR

  Always think that the person reviewing the PR doesn't have the context you have.

  Links to examples, documentation and similar resources make the process easier to review.
-->

<!--
  Contributions to this repository are reviewed at least twice a week

  There's no further action required once the PR has been created.
 -->

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
