### PR TITLE
feat(nginx): update nginx otel dashboard and add relationship synthesis rule

### DIFF
--- a/entity-types/infra-nginxserver/golden_metrics.stg.yml
+++ b/entity-types/infra-nginxserver/golden_metrics.stg.yml
@@ -16,7 +16,7 @@ requests:
 
 activeConnections:
   title: Active connections
-  unit: COUNT
+  unit: OPERATIONS_PER_SECOND
   queries:
     newRelic:
       select: average(net.connectionsActive)

--- a/entity-types/infra-nginxserver/opentelemetry_dashboard.stg.json
+++ b/entity-types/infra-nginxserver/opentelemetry_dashboard.stg.json
@@ -4,11 +4,87 @@
     "name" : "NGINX Metrics",
     "widgets" : [ {
       "visualization" : {
-        "id" : "viz.line"
+        "id" : "viz.billboard"
       },
       "layout" : {
         "column" : 1,
         "row" : 1,
+        "height" : 2,
+        "width" : 3
+      },
+      "title" : "Total number of client requests",
+      "rawConfiguration" : {
+        "billboardSettings": {
+          "visual": {
+            "display": "value"
+          }
+        },
+        "nrqlQueries" : [ {
+          "query" : "FROM Metric SELECT sum(`nginx.requests` OR `nginxplus_http_requests_total`) AS 'Total requests' WHERE instrumentation.provider = 'opentelemetry' AND ((metricName = 'nginx.requests' AND nginxplus_http_requests_total is NULL) OR (metricName = 'nginxplus_http_requests_total' AND nginx.requests is NULL))",
+          "accountId": 0} ]
+      }
+    }, {
+      "visualization" : {
+        "id" : "viz.table"
+      },
+      "layout" : {
+        "column" : 4,
+        "row" : 1,
+        "height" : 2,
+        "width" : 6
+      },
+      "title" : "Total number of connections accepted vs handled",
+      "rawConfiguration" : {
+        "nrqlQueries" : [ {
+          "query" : "FROM Metric SELECT sum(`nginx.connections_accepted` OR `nginxplus_connections_accepted`) AS 'Total number of connections accepted', (sum(`nginx.connections_handled`) + abs(sum(`nginxplus_connections_accepted`) - sum(`nginxplus_connections_dropped`))) AS 'Total number of handled connections' WHERE ((nginxplus_connections_accepted is NULL AND metricName = 'nginx.connections_accepted') OR (nginx.connections_accepted is NULL AND metricName = 'nginxplus_connections_accepted')) OR ((nginxplus_connections_accepted is NULL AND nginxplus_connections_dropped is NULL AND metricName = 'nginx.connections_handled') OR ((metricName = 'nginxplus_connections_accepted' OR metricName = 'nginxplus_connections_dropped') AND nginx.connections_handled is NULL)) AND instrumentation.provider = 'opentelemetry'",
+          "accountId": 0} ]
+      }
+    }, {
+      "visualization" : {
+        "id" : "viz.billboard"
+      },
+      "layout" : {
+        "column" : 1,
+        "row" : 3,
+        "height" : 3,
+        "width" : 6
+      },
+      "title" : "Active connections",
+      "rawConfiguration" : {
+        "nrqlQueries" : [ {
+          "query" : "FROM Metric SELECT average(`nginx.connections_current` OR `nginxplus_connections_active`) AS 'Active connections' WHERE ((nginxplus_connections_active IS NULL AND state = 'active' AND metricName = 'nginx.connections_current') OR (nginx.connections_current is NULL AND metricName = 'nginxplus_connections_active')) AND instrumentation.provider = 'opentelemetry' TIMESERIES AUTO",
+          "accountId": 0} ]
+      }
+    }, {
+      "visualization" : {
+         "id" : "viz.billboard"
+      },
+      "layout" : {
+        "column" : 7,
+        "row" : 3,
+        "height" : 3,
+        "width" : 6
+      },
+      "title" : "Dropped connections",
+      "rawConfiguration" : {
+        "dataFormatters": [
+          {
+            "name": "Dropped connections",
+            "precision": null,
+            "type": "decimal"
+          }
+        ],
+        "nrqlQueries" : [ {
+          "query" : "FROM Metric SELECT (abs(sum(`nginx.connections_accepted`) - sum(`nginx.connections_handled`)) + sum(`nginxplus_connections_dropped`)) / sum((endTimestamp - timestamp) / 1000) AS 'Connections Dropped' WHERE (((metricName = 'nginx.connections_accepted' OR metricName = 'nginx.connections_handled') AND nginxplus_connections_dropped is NULL) OR (nginx.connections_accepted is NULL AND nginx.connections_handled is NULL AND metricName = 'nginxplus_connections_dropped')) AND instrumentation.provider = 'opentelemetry' TIMESERIES AUTO",
+          "accountId": 0} ]
+      }
+    }, {
+      "visualization" : {
+        "id" : "viz.line"
+      },
+      "layout" : {
+        "column" : 1,
+        "row" : 6,
         "height" : 3,
         "width" : 6
       },
@@ -24,7 +100,7 @@
       },
       "layout" : {
         "column" : 7,
-        "row" : 1,
+        "row" : 6,
         "height" : 3,
         "width" : 6
       },
@@ -40,7 +116,7 @@
       },
       "layout" : {
         "column" : 1,
-        "row" : 4,
+        "row" : 9,
         "height" : 3,
         "width" : 6
       },
@@ -56,82 +132,11 @@
       },
       "layout" : {
         "column" : 7,
-        "row" : 4,
+        "row" : 9,
         "height" : 3,
         "width" : 6
       },
       "title" : "Connections accepted vs handled",
-      "rawConfiguration" : {
-        "nrqlQueries" : [ {
-          "query" : "FROM Metric, Metric SELECT filter(sum(`nginx.connections_accepted` OR `nginxplus_connections_accepted`) / sum((endTimestamp - timestamp) / 1000), WHERE ((nginxplus_connections_accepted is NULL AND metricName = 'nginx.connections_accepted') OR (nginx.connections_accepted is NULL AND metricName = 'nginxplus_connections_accepted')) AND instrumentation.provider = 'opentelemetry') AS 'Connections accepted', filter((abs(sum(`nginxplus_connections_accepted`) - sum(`nginxplus_connections_dropped`)) + sum(`nginx.connections_handled`)) / sum((endTimestamp - timestamp) / 1000), WHERE instrumentation.provider = 'opentelemetry' AND (((metricName = 'nginxplus_connections_accepted' OR metricName = 'nginxplus_connections_dropped') AND nginx.connections_handled is NULL) OR (nginxplus_connections_accepted is NULL AND nginxplus_connections_dropped is NULL AND metricName = 'nginx.connections_handled'))) AS 'Connections handled' TIMESERIES AUTO",
-          "accountId": 0} ]
-      }
-    }, {
-      "visualization" : {
-        "id" : "viz.billboard"
-      },
-      "layout" : {
-        "column" : 1,
-        "row" : 7,
-        "height" : 3,
-        "width" : 6
-      },
-      "title" : "Active connections",
-      "rawConfiguration" : {
-        "nrqlQueries" : [ {
-          "query" : "FROM Metric SELECT average(`nginx.connections_current` OR `nginxplus_connections_active`) AS 'Active connections' WHERE ((nginxplus_connections_active IS NULL AND state = 'active' AND metricName = 'nginx.connections_current') OR (nginx.connections_current is NULL AND metricName = 'nginxplus_connections_active')) AND instrumentation.provider = 'opentelemetry' TIMESERIES AUTO",
-          "accountId": 0} ]
-      }
-    }, {
-      "visualization" : {
-        "id" : "viz.billboard"
-      },
-      "layout" : {
-        "column" : 7,
-        "row" : 7,
-        "height" : 3,
-        "width" : 6
-      },
-      "title" : "Connections dropped",
-      "rawConfiguration" : {
-        "dataFormatters": [
-          {
-            "name": "Connections dropped",
-            "precision": null,
-            "type": "decimal"
-          }
-        ],
-        "nrqlQueries" : [ {
-          "query" : "FROM Metric SELECT (sum(`nginxplus_connections_dropped`) + abs(sum(`nginx.connections_accepted`) - sum(`nginx.connections_handled`))) / sum((endTimestamp - timestamp) / 1000) AS 'Connections dropped' WHERE (((metricName = 'nginx.connections_accepted' OR metricName = 'nginx.connections_handled') AND nginxplus_connections_dropped is NULL) OR (nginx.connections_accepted is NULL AND nginx.connections_handled is NULL AND metricName = 'nginxplus_connections_dropped')) AND instrumentation.provider = 'opentelemetry' TIMESERIES AUTO",
-          "accountId": 0} ]
-      }
-    }, {
-      "visualization" : {
-        "id" : "viz.table"
-      },
-      "layout" : {
-        "column" : 1,
-        "row" : 10,
-        "height" : 2,
-        "width" : 6
-      },
-      "title" : "Total number of connections accepted vs handled",
-      "rawConfiguration" : {
-        "nrqlQueries" : [ {
-          "query" : "FROM Metric SELECT sum(`nginx.connections_accepted` OR `nginxplus_connections_accepted`) AS 'Total number of connections accepted', (sum(`nginx.connections_handled`) + abs(sum(`nginxplus_connections_accepted`) - sum(`nginxplus_connections_dropped`))) AS 'Total number of handled connections' WHERE ((nginxplus_connections_accepted is NULL AND metricName = 'nginx.connections_accepted') OR (nginx.connections_accepted is NULL AND metricName = 'nginxplus_connections_accepted')) OR ((nginxplus_connections_accepted is NULL AND nginxplus_connections_dropped is NULL AND metricName = 'nginx.connections_handled') OR ((metricName = 'nginxplus_connections_accepted' OR metricName = 'nginxplus_connections_dropped') AND nginx.connections_handled is NULL)) AND instrumentation.provider = 'opentelemetry'",
-          "accountId": 0} ]
-      }
-    }, {
-      "visualization" : {
-        "id" : "viz.billboard"
-      },
-      "layout" : {
-        "column" : 7,
-        "row" : 10,
-        "height" : 2,
-        "width" : 6
-      },
-      "title" : "Total number of client requests",
       "rawConfiguration" : {
         "billboardSettings": {
           "visual": {
@@ -139,7 +144,7 @@
           }
         },
         "nrqlQueries" : [ {
-          "query" : "FROM Metric SELECT sum(`nginx.requests` OR `nginxplus_http_requests_total`) AS 'Total requests' WHERE instrumentation.provider = 'opentelemetry' AND ((metricName = 'nginx.requests' AND nginxplus_http_requests_total is NULL) OR (metricName = 'nginxplus_http_requests_total' AND nginx.requests is NULL))",
+          "query" : "FROM Metric, Metric SELECT filter(sum(`nginx.connections_accepted` OR `nginxplus_connections_accepted`) / sum((endTimestamp - timestamp) / 1000), WHERE ((nginxplus_connections_accepted is NULL AND metricName = 'nginx.connections_accepted') OR (nginx.connections_accepted is NULL AND metricName = 'nginxplus_connections_accepted')) AND instrumentation.provider = 'opentelemetry') AS 'Connections accepted', filter((abs(sum(`nginxplus_connections_accepted`) - sum(`nginxplus_connections_dropped`)) + sum(`nginx.connections_handled`)) / sum((endTimestamp - timestamp) / 1000), WHERE instrumentation.provider = 'opentelemetry' AND (((metricName = 'nginxplus_connections_accepted' OR metricName = 'nginxplus_connections_dropped') AND nginx.connections_handled is NULL) OR (nginxplus_connections_accepted is NULL AND nginxplus_connections_dropped is NULL AND metricName = 'nginx.connections_handled'))) AS 'Connections handled' TIMESERIES AUTO",
           "accountId": 0} ]
       }
     } ]

--- a/relationships/synthesis/INFRA_DOCKER_CONTAINER-to-INFRA-NGINXSERVER.stg.yml
+++ b/relationships/synthesis/INFRA_DOCKER_CONTAINER-to-INFRA-NGINXSERVER.stg.yml
@@ -1,0 +1,67 @@
+relationships:
+  - name: containerHostsNginxServer
+    version: "1"
+    origins:
+      - OpenTelemetry
+    conditions:
+      - attribute: eventType
+        anyOf: [ "Metric" ]
+      - attribute: metricName
+        startsWith: nginx.
+      - attribute: instrumentation.provider
+        anyOf: [ "opentelemetry" ]
+      - attribute: container.id
+        present: true
+    relationship:
+      expires: PT75M
+      relationshipType: HOSTS
+      source:
+        buildGuid:
+          account:
+            attribute: accountId
+          domain:
+            value: INFRA
+          type:
+            value: CONTAINER
+          identifier:
+            fragments:
+              - attribute: container.id
+            hashAlgorithm: FARM_HASH
+      target:
+        extractGuid:
+          attribute: entity.guid
+          entityType:
+            value: NGINXSERVER
+  - name: containerHostsNginxPlusServer
+    version: "1"
+    origins:
+      - OpenTelemetry
+    conditions:
+      - attribute: eventType
+        anyOf: [ "Metric" ]
+      - attribute: metricName
+        startsWith: nginxplus_
+      - attribute: instrumentation.provider
+        anyOf: [ "opentelemetry" ]
+      - attribute: container.id
+        present: true
+    relationship:
+      expires: PT75M
+      relationshipType: HOSTS
+      source:
+        buildGuid:
+          account:
+            attribute: accountId
+          domain:
+            value: INFRA
+          type:
+            value: CONTAINER
+          identifier:
+            fragments:
+              - attribute: container.id
+            hashAlgorithm: FARM_HASH
+      target:
+        extractGuid:
+          attribute: entity.guid
+          entityType:
+            value: NGINXSERVER


### PR DESCRIPTION
### Relevant information

### Changes in this PR

- move line charts to down and move billboard numbers to top in NGINX OTel dashboard
- add relationship synthesis rule for linking INFRA CONTAINER to INFRA NGINXSERVER entity
- update active connections metric unit to OPERATIONS_PER_SECOND to match the unit in already existing file `entity-definitions/entity-types/infra-nginxserver/golden_metrics.yml`

Note: The above changes are specific for staging.

<!--
  Describe what you have done.
  Provide details that are relevant to the PR

  Always think that the person reviewing the PR doesn't have the context you have.

  Links to examples, documentation and similar resources make the process easier to review.
-->

<!--
  Contributions to this repository are reviewed at least twice a week

  There's no further action required once the PR has been created.
 -->

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
