### PR TITLE
fix: Removed host relationship for APM to infra

### DIFF
--- a/relationships/synthesis/APM-APPLICATION-to-INFRA-LAMBDAFUNCTION.yml
+++ b/relationships/synthesis/APM-APPLICATION-to-INFRA-LAMBDAFUNCTION.yml
@@ -28,33 +28,6 @@ relationships:
             - field: awsLambdaArn
               attribute: cloud.resource_id
 
-  - name: awsLambdaFunctionHOSTSApm
-    version: "1"
-    entitlements:
-      matching: anyOf
-      values:
-        - auto_discovery_entities_ccu
-        - auto_discovery_entities_ccu_discount_usage
-    origins:
-      - Distributed Tracing
-    conditions:
-      - attribute: eventType
-        anyOf: [ "Span" ]
-      - attribute: aws.lambda.arn
-        regex: "^arn:aws:lambda:([^:]*):([0-9]*):function:([^:]*)$"
-    relationship:
-      expires: PT75M
-      relationshipType: HOSTS
-      source:
-        lookupGuid:
-          candidateCategory: AWSLAMBDAFUNCTION
-          fields:
-            - field: awsLambdaArn
-              attribute: aws.lambda.arn
-      target:
-        extractGuid:
-          attribute: entity.guid
-
   - name: awsLambdaFunctionIsAPM
     version: "1"
     origins:


### PR DESCRIPTION
Ticket: https://new-relic.atlassian.net/browse/NR-499225

We added IS relationship now host relationship not required. 


### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
