### PR TITLE
[NR-497594] Fix throughput & error rate golden metric definition 

### DIFF
--- a/entity-types/ext-service/golden_metrics.yml
+++ b/entity-types/ext-service/golden_metrics.yml
@@ -37,7 +37,7 @@ errorRate:
       select: (filter(count(http.server.requests), where http.status_code = '5xx') * 100) / count(http.server.requests)
       from: Metric
     micrometer:
-      select: (filter(count(http.server.requests), where exception IS NOT NULL and exception != 'None') * 100) / count(http.server.requests)
+      select: (filter(count(http.server.requests), where exception IS NOT NULL and exception != 'none') * 100) / count(http.server.requests)
       from: Metric
     pixie:
       select: (filter(count(http.server.duration), where numeric(http.status_code) >= 400 AND numeric(http.status_code) != 404) * 100) / count(http.server.duration)


### PR DESCRIPTION
### Relevant information
Customers reported that we are generating metrics where ratio is > 100%. We identified on GoldenSignals side a bad definition. We are generating an "average" doing the `sum(http.server.requests)*100/sum(http.server.request)` however the platform does not support calculate the average from decimals metrics since we need to store the `count` as a long. 

Apart of this technical issue, the golden metric is not well defined.  `http.server.requests` represents the response time, so we were not generating the proper value.
<!--
  Describe what you have done.
  Provide details that are relevant to the PR

  Always think that the person reviewing the PR doesn't have the context you have.

  Links to examples, documentation and similar resources make the process easier to review.
-->

<!--
  Contributions to this repository are reviewed at least twice a week

  There's no further action required once the PR has been created.
 -->

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
