### PR TITLE
feat(nginx): Add candidate synthesis for INFRAHOST to NGINXSERVER

### DIFF
--- a/entity-types/infra-nginxserver/opentelemetry_dashboard.stg.json
+++ b/entity-types/infra-nginxserver/opentelemetry_dashboard.stg.json
@@ -31,7 +31,7 @@
         "column" : 4,
         "row" : 1,
         "height" : 2,
-        "width" : 6
+        "width" : 9
       },
       "title" : "Total number of connections accepted vs handled",
       "rawConfiguration" : {

--- a/relationships/synthesis/INFRA-HOST-to-INFRA-NGINXSERVER.stg.yml
+++ b/relationships/synthesis/INFRA-HOST-to-INFRA-NGINXSERVER.stg.yml
@@ -1,4 +1,5 @@
 relationships:
+  # Local scenario: NGINX server running on the same host as the OpenTelemetry collector
   - name: hostHostsNginxServer
     version: "1"
     origins:
@@ -12,22 +13,17 @@ relationships:
         anyOf: [ "opentelemetry" ]
       - attribute: host.id
         present: true
+      - attribute: nginx.server.endpoint
+        regex: "^https?://(localhost|127\\.0\\.0\\.1)(:|/|$)"
     relationship:
       expires: PT75M
       relationshipType: HOSTS
       source:
-        buildGuid:
-          account:
-            attribute: accountId
-          domain:
-            value: INFRA
-          type:
-            value: HOST
-            valueInGuid: NA
-          identifier:
-            fragments:
-              - attribute: host.id
-            hashAlgorithm: FARM_HASH
+        lookupGuid:
+          candidateCategory: HOST
+          fields:
+            - field: hostId
+              attribute: host.id
       target:
         extractGuid:
           attribute: entity.guid
@@ -46,22 +42,77 @@ relationships:
         anyOf: [ "opentelemetry" ]
       - attribute: host.id
         present: true
+      - attribute: nginx.server.endpoint
+        regex: "^https?://(localhost|127\\.0\\.0\\.1)(:|/|$)"
     relationship:
       expires: PT75M
       relationshipType: HOSTS
       source:
-        buildGuid:
-          account:
-            attribute: accountId
-          domain:
-            value: INFRA
-          type:
-            value: HOST
-            valueInGuid: NA
-          identifier:
-            fragments:
-              - attribute: host.id
-            hashAlgorithm: FARM_HASH
+        lookupGuid:
+          candidateCategory: HOST
+          fields:
+            - field: hostId
+              attribute: host.id
+      target:
+        extractGuid:
+          attribute: entity.guid
+          entityType:
+            value: NGINXSERVER
+  
+  # Remote scenario: NGINX server is running on a host and it is being monitored by OpenTelemetry collector running on another host
+  - name: hostMeasuresRemoteNginxServer
+    version: "1"
+    origins:
+      - OpenTelemetry
+    conditions:
+      - attribute: eventType
+        anyOf: [ "Metric" ]
+      - attribute: metricName
+        startsWith: nginx.
+      - attribute: instrumentation.provider
+        anyOf: [ "opentelemetry" ]
+      - attribute: host.id
+        present: true
+      - attribute: nginx.server.endpoint
+        regex: "^https?://(?!(localhost|127\\.0\\.0\\.1|::1|0\\.0\\.0\\.0)(:|/|$))"
+    relationship:
+      expires: PT75M
+      relationshipType: MEASURES
+      source:
+        lookupGuid:
+          candidateCategory: HOST
+          fields:
+            - field: hostId
+              attribute: host.id
+      target:
+        extractGuid:
+          attribute: entity.guid
+          entityType:
+            value: NGINXSERVER
+  - name: hostMeasuresRemoteNginxPlusServer
+    version: "1"
+    origins:
+      - OpenTelemetry
+    conditions:
+      - attribute: eventType
+        anyOf: [ "Metric" ]
+      - attribute: metricName
+        startsWith: nginxplus_
+      - attribute: instrumentation.provider
+        anyOf: [ "opentelemetry" ]
+      - attribute: host.id
+        present: true
+      - attribute: nginx.server.endpoint
+        regex: "^https?://(?!(localhost|127\\.0\\.0\\.1|::1|0\\.0\\.0\\.0)(:|/|$))"
+    relationship:
+      expires: PT75M
+      relationshipType: MEASURES
+      source:
+        lookupGuid:
+          candidateCategory: HOST
+          fields:
+            - field: hostId
+              attribute: host.id
       target:
         extractGuid:
           attribute: entity.guid


### PR DESCRIPTION
### Relevant information

### Changes in this PR

1. Update the width of 2nd widget to fit the entity overview page in NGINX OTel dashboard
2. Add candidate synthesis for INFRAHOST to NGINXSERVER
3. Add HOSTS relationship b/w INFRAHOST and NGINXSERVER when both otelcol and nginx are running on same host 
4. ADD MEASURES relationship b/w INFRAHOST and NGINXSERVER when otelcol and nginx are running on different hosts

Note - The above changes are only for staging.

<!--
  Describe what you have done.
  Provide details that are relevant to the PR

  Always think that the person reviewing the PR doesn't have the context you have.

  Links to examples, documentation and similar resources make the process easier to review.
-->

<!--
  Contributions to this repository are reviewed at least twice a week

  There's no further action required once the PR has been created.
 -->

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
