### PR TITLE
fix(otel): restore normal Kafka relationships on staging

### DIFF
--- a/relationships/synthesis/INFRA-HOST-to-INFRA-KAFKABROKER.stg.yml
+++ b/relationships/synthesis/INFRA-HOST-to-INFRA-KAFKABROKER.stg.yml
@@ -250,19 +250,18 @@ relationships:
       expires: PT75M
       relationshipType: MEASURES
       source:
-        lookupGuid:
-          buildGuid:
-            account:
-              attribute: accountId
-            domain:
-              value: INFRA
-            type:
-              value: HOST
-              valueInGuid: NA
-            identifier:
-              fragments:
-                - attribute: host.id
-              hashAlgorithm: FARM_HASH
+        buildGuid:
+          account:
+            attribute: accountId
+          domain:
+            value: INFRA
+          type:
+            value: HOST
+            valueInGuid: NA
+          identifier:
+            fragments:
+              - attribute: host.id
+            hashAlgorithm: FARM_HASH
       target:
         extractGuid:
           attribute: entity.guid


### PR DESCRIPTION
### Changes:
- Moved back to normal synthetic relationships from candidate rels for OTel Kafka.

### Relevant information

<!--
  Describe what you have done.
  Provide details that are relevant to the PR

  Always think that the person reviewing the PR doesn't have the context you have.

  Links to examples, documentation and similar resources make the process easier to review.
-->

<!--
  Contributions to this repository are reviewed at least twice a week

  There's no further action required once the PR has been created.
 -->

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
