### PR TITLE
feat: Update ext-service definition for otel collector internal telemetry

### DIFF
--- a/entity-types/ext-service/definition.stg.yml
+++ b/entity-types/ext-service/definition.stg.yml
@@ -1,0 +1,305 @@
+domain: EXT
+type: SERVICE
+goldenTags:
+  - instrumentation.provider
+  - k8s.clusterName
+  - k8s.namespaceName
+synthesis:
+  rules:
+    # telemetry with service_name attribute
+  - ruleName: ext_service_service_name
+    identifier: service_name
+    name: service_name
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: service_name
+    - attribute: newrelic.entity.type
+      present: false
+    # Exclude data from INFRA-WIN_SERVICE telemetry sources. Typically, data from these sources
+    # includes entity info (guid, type, name) from the client side. But due to race conditions,
+    # data is occasionally emitted without entity info and is erroneously classified as EXT-SERVICE.
+    # Ideally, we would skip data where collector.name = infrastructure-agent, but it's not possible
+    # to express that condition. Excluding all data with attribute collector.name is probably fine.
+    - attribute: collector.name
+      present: false
+    tags:
+      telemetry.sdk.name:
+        entityTagName: instrumentation.provider
+      telemetry.sdk.language:
+        entityTagName: language
+      telemetry.sdk.version:
+
+    # telemetry with serviceName attribute
+  - ruleName: ext_service_serviceName
+    identifier: serviceName
+    name: serviceName
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: serviceName
+    - attribute: newrelic.entity.type
+      present: false
+    tags:
+      telemetry.sdk.name:
+        entityTagName: instrumentation.provider
+      telemetry.sdk.language:
+        entityTagName: language
+      telemetry.sdk.version:
+
+    # telemetry with user opt-in for otel collector internal telemetry
+  - ruleName: ext_service_otel_collector
+    identifier: service.name
+    name: service.name
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: newrelic.service.type # User Opt-In Tag
+      value: otel_collector
+    tags:
+       newrelic.service.type:
+        entityTagName: instrumentation.provider
+
+    # telemetry from opentelemetry provider without instrumentation.provider
+  - ruleName: ext_service_service_name_2
+    identifier: service.name
+    name: service.name
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: telemetry.sdk.name
+      value: opentelemetry
+    - attribute: instrumentation.provider
+      present: false
+    - attribute: newrelic.entity.type
+      present: false
+    tags:
+      k8s.cluster.name:
+        ttl: P1D
+      k8s.deployment.name:
+        ttl: P1D
+      k8s.namespace.name:
+        ttl: P1D
+      telemetry.sdk.name:
+        entityTagName: instrumentation.provider
+      telemetry.sdk.language:
+        entityTagName: language
+      telemetry.sdk.version:
+      service.namespace:
+
+    # telemetry from opentelemetry provider
+  - ruleName: ext_service_service_name_3
+    identifier: service.name
+    name: service.name
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: instrumentation.provider
+      value: opentelemetry
+    - attribute: newrelic.entity.type
+      present: false
+    - attribute: trace_role
+      present: false
+    tags:
+      k8s.cluster.name:
+        ttl: P1D
+      k8s.deployment.name:
+        ttl: P1D
+      k8s.namespace.name:
+        ttl: P1D
+      telemetry.sdk.language:
+        entityTagName: language
+      telemetry.sdk.version:
+      service.namespace:
+      faas.name:
+      faas.id:
+      newrelic.service.type:
+        ttl: P1D
+
+    # telemetry from kamon-agent provider
+  - ruleName: ext_service_service_name_4
+    identifier: service.name
+    name: service.name
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: instrumentation.provider
+      value: kamon-agent
+    tags:
+      telemetry.sdk.name:
+        entityTagName: instrumentation.provider
+      telemetry.sdk.language:
+        entityTagName: language
+      telemetry.sdk.version:
+
+    # telemetry from micrometer provider
+  - ruleName: ext_service_service_name_5
+    identifier: service.name
+    name: service.name
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: instrumentation.provider
+      value: micrometer
+    tags:
+      telemetry.sdk.name:
+        entityTagName: instrumentation.provider
+      telemetry.sdk.language:
+        entityTagName: language
+      telemetry.sdk.version:
+
+    # telemetry from JFR-Uploader provider
+  - ruleName: ext_service_service_name_6
+    identifier: service.name
+    name: service.name
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: instrumentation.provider
+      value: JFR-Uploader
+    tags:
+      telemetry.sdk.language:
+        entityTagName: language
+      telemetry.sdk.version:
+
+    # telemetry from pixie provider
+  - ruleName: ext_service_service_name_7
+    identifier: service.name
+    name: service.name
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: instrumentation.provider
+      value: pixie
+    tags:
+      k8s.cluster.name:
+        entityTagName: k8s.clusterName
+        ttl: P1D
+      k8s.namespace.name:
+        entityTagName: k8s.namespaceName
+        ttl: P1D
+      k8s.deployment.name:
+        entityTagName: k8s.deploymentName
+        ttl: P1D
+    
+    # telemetry from NR eBPF agent client
+  - ruleName: ext_service_service_name_8
+    identifier: service.name
+    name: service.name
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: instrumentation.name
+      value: nr_ebpf
+    - attribute: instrumentation.provider
+      value: opentelemetry
+    - attribute: trace_role
+      value: client
+    - attribute: service.name
+      present: true
+    tags:
+      k8s.cluster.name:
+        entityTagName: k8s.clusterName
+        ttl: P1D
+      k8s.namespace.name:
+        entityTagName: k8s.namespaceName
+        ttl: P1D
+      deployment.name:
+        entityTagName: k8s.deploymentName
+        ttl: P1D
+      telemetry.sdk.language:
+        entityTagName: language
+      host.name:
+      local_addr:
+
+    # telemetry from NR eBPF agent server
+  - ruleName: ext_service_service_name_9
+    identifier: service.name
+    name: service.name
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: instrumentation.name
+      value: nr_ebpf
+    - attribute: instrumentation.provider
+      value: opentelemetry
+    - attribute: trace_role
+      value: server
+    - attribute: service.name
+      present: true
+    tags:
+      k8s.cluster.name:
+        entityTagName: k8s.clusterName
+        ttl: P1D
+      k8s.namespace.name:
+        entityTagName: k8s.namespaceName
+        ttl: P1D
+      deployment.name:
+        entityTagName: k8s.deploymentName
+        ttl: P1D
+      telemetry.sdk.language:
+        entityTagName: language
+      host.name:
+      local_addr:
+      local_port:
+
+    # telemetry from NR eBPF agent with instrumentation.provider newrelic-ebpf
+  - ruleName: ext_service_composite
+    compositeIdentifier:
+        separator: ":"
+        attributes:
+          - service.name
+          - instrumentation.name
+    name: service.name
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: instrumentation.provider
+      value: newrelic-ebpf
+    - attribute: instrumentation.name
+      value: nr_ebpf
+    - attribute: service.name
+      present: true
+    tags:
+      k8s.cluster.name:
+        entityTagName: k8s.clusterName
+        ttl: P1D
+      k8s.namespace.name:
+        entityTagName: k8s.namespaceName
+        ttl: P1D
+      deployment.name:
+        entityTagName: k8s.deploymentName
+        ttl: P1D
+      telemetry.sdk.language:
+        entityTagName: language
+      host.name:
+      service.name:
+
+    # IMPORTANT:
+    # This rule matches on any telemetry with service.name
+    # which is too broad for some telemetry sources, resulting
+    # in matches that are not actually about services.  We're
+    # keeping it for backwards compatibility reasons but it
+    # is being ignored in some internal services while we add
+    # a configuration option to choose the relevant ingestion
+    # sources for each rule.
+  - ruleName: ext_service_service_name_10
+    identifier: service.name
+    name: service.name
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: service.name
+    - attribute: newrelic.entity.type
+      present: false
+    tags:
+      k8s.cluster.name:
+        ttl: P1D
+      k8s.deployment.name:
+        ttl: P1D
+      k8s.namespace.name:
+        ttl: P1D
+      telemetry.sdk.name:
+        entityTagName: instrumentation.provider
+      telemetry.sdk.language:
+        entityTagName: language
+      telemetry.sdk.version:
+      service.namespace:
+
+
+configuration:
+  entityExpirationTime: EIGHT_DAYS
+  alertable: true
+
+ownership:
+  primaryOwner:
+    teamName: "no owner"
+  secondaryOwners:
+    - teamName: "eBPF"

--- a/entity-types/ext-service/definition.stg.yml
+++ b/entity-types/ext-service/definition.stg.yml
@@ -52,7 +52,7 @@ synthesis:
     encodeIdentifierInGUID: true
     conditions:
     - attribute: newrelic.service.type # User Opt-In Tag
-      value: otel_collector
+      value: opentelemetry-collector
     tags:
        newrelic.service.type:
         entityTagName: instrumentation.provider


### PR DESCRIPTION
### Summary
This adds the `ext_service_otel_collector` rule to ext-service in staging. The goal is to set the instrumentation provider as the opentelemetry collector based on a user-provided attribute, for the purpose of sending collector-relevant golden metrics.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.