### PR TITLE
feat: Add ext-service rule for OTel gen_ai

### DIFF
--- a/entity-types/ext-service/definition.stg.yml
+++ b/entity-types/ext-service/definition.stg.yml
@@ -69,6 +69,18 @@ synthesis:
       service.name:
         entityTagName: otelCollector
 
+    # telemetry for gen_ai otel application with user opt-in tag
+  - ruleName: ext_service_gen_ai_otel_app
+    identifier: service.name
+    name: service.name
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: aiEnabledApp # User Opt-In Tag
+      value: "true"
+    tags:
+      aiEnabledApp:
+        entityTagName: aiEnabledApp
+
     # telemetry from opentelemetry provider without instrumentation.provider
   - ruleName: ext_service_service_name_2
     identifier: service.name


### PR DESCRIPTION
### Relevant information

Added a new synthesis rule ext_service_gen_ai_otel_app in entity-types/ext-service/definition.stg.yml that creates EXT-SERVICE entities for gen_ai OpenTelemetry applications when users opt in by setting the aiEnabledApp: true tag on their telemetry.

**Rule details:**

Rule name: ext_service_gen_ai_otel_app
Identifier/Name: service.name
Condition: aiEnabledApp attribute equals "true" (user opt-in tag)
Tags: aiEnabledApp persisted as an entity tag

**Why:**

This enables entity synthesis for gen_ai OTel applications. Users explicitly opt in by adding aiEnabledApp: true to their telemetry attributes,

<!--
  Describe what you have done.
  Provide details that are relevant to the PR

  Always think that the person reviewing the PR doesn't have the context you have.

  Links to examples, documentation and similar resources make the process easier to review.
-->

<!--
  Contributions to this repository are reviewed at least twice a week

  There's no further action required once the PR has been created.
 -->

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
