### PR TITLE
feat: Add fpc idx tag in juniper switch & the Juniper mist site entity definition

### DIFF
--- a/entity-types/infra-juniper_mist_site/definition.stg.yml
+++ b/entity-types/infra-juniper_mist_site/definition.stg.yml
@@ -1,0 +1,55 @@
+
+domain: INFRA
+type: JUNIPER_MIST_SITE
+synthesis:
+  rules:
+  - ruleName: infra_juniper_mist_site_id
+    name: name
+    compositeIdentifier:
+      separator: ":"
+      attributes:
+        - vendor
+        - org_id
+        - id
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: instrumentation.source
+      value: juniper_mist
+    - attribute: nr.api_name
+      value: org_sites
+    tags:
+      id:
+        entityTagName: site_id
+        multiValue: false
+      org_id:
+        entityTagName: org_id
+        multiValue: false
+      vendor:
+        entityTagName: vendor
+        multiValue: false
+      region:
+        entityTagName: region
+        multiValue: false
+      latlng.lat:
+        entityTagName: latitude
+        multiValue: false
+      latlng.lng:
+        entityTagName: longitude
+        multiValue: false
+      country_code:
+        entityTagName: country_code
+        multiValue: false
+      timezone:
+        entityTagName: timezone
+        multiValue: false
+
+    # Add a 4 hour ttl on all tags ingested in metric api using tags. prefix
+    prefixedTags:
+      tags.:
+        ttl: PT4H
+
+
+
+ownership:
+  primaryOwner:
+    teamName: "Network Monitoring"

--- a/entity-types/infra-juniper_mist_switch/definition.stg.yml
+++ b/entity-types/infra-juniper_mist_switch/definition.stg.yml
@@ -60,6 +60,9 @@ synthesis:
       device_type:
         entityTagName: device_type
         multiValue: false
+      fpc_idx:
+        entityTagName: fpc_idx
+        multiValue: false
      
       
 


### PR DESCRIPTION
1) Added a new tag `fpc_idx` for JUNIPER_MIST_SWITCH  in the INFRA domain. This entity represents Juniper Mist gateway devices monitored via New Relic.
2) Added INFRA entity type `JUNIPER_MIST_SITE`

ARB - https://new-relic.atlassian.net/browse/NR-541548