### PR TITLE
feat: Add Valkey entity types to REDIS relationship candidates

### DIFF
--- a/relationships/candidates/REDIS.yml
+++ b/relationships/candidates/REDIS.yml
@@ -9,6 +9,12 @@ lookups:
         type: AWSELASTICACHEREDISREPLICATIONGROUP
       - domain: INFRA
         type: AWSELASTICACHEREDISSHARD
+      - domain: INFRA
+        type: AWSELASTICACHEVALKEYCLUSTER
+      - domain: INFRA
+        type: AWSELASTICACHEVALKEYNODE
+      - domain: INFRA
+        type: AWSELASTICACHEVALKEYSERVERLESS
     tags:
       matchingMode: ALL
       predicates:


### PR DESCRIPTION
## Summary
- Add AWS ElastiCache Valkey entity types to REDIS.yml to enable autodiscovery relationships between APM applications and Valkey infrastructure

## Changes
Added the following entity types to `relationships/candidates/REDIS.yml`:
- `AWSELASTICACHEVALKEYCLUSTER`
- `AWSELASTICACHEVALKEYNODE`
- `AWSELASTICACHEVALKEYSERVERLESS`

## Why
Valkey is Redis-compatible and the APM agent reports Valkey connections as `db.system: "Redis"` with `Datastore/instance/Redis/{host}:{port}` metrics. Adding Valkey entity types to the existing REDIS relationship candidates enables autodiscovery without requiring a separate candidate file.

ARB Review ticket: [https://new-relic.atlassian.net/browse/NR-550276](https://new-relic.atlassian.net/browse/NR-550276)

Relevant information
Api Review Board (ARB)
Any pull request with changes to this repository has to be linked with an ARB ticket, which has to be approved before merging.

If you are an external contributor please contact New Relic Support.

If you don't know about the ARB process check [this](https://newrelic.enterprise.slack.com/docs/T02D34WJD/F08AW240NSV)

ARB Jira ticket:
https://new-relic.atlassian.net/browse/NR-550276

## Test plan
- [ ] Verify relationships are created between APM apps and Valkey infrastructure entities
- [ ] Validate endpoint/port tag matching works for Valkey entities
- [ ]  I've linked an ARB ticket & received approval from API Review Board in order to make these changes