### PR TITLE
feat: Add AZUREELASTICSAN entity definition

### DIFF
--- a/entity-types/infra-azureelasticsan/definition.yml
+++ b/entity-types/infra-azureelasticsan/definition.yml
@@ -1,0 +1,28 @@
+domain: INFRA
+type: AZUREELASTICSAN
+goldenTags:
+- azure.regionName
+- azure.subscriptionId
+- azure.type
+- azure.resourceGroupName
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
+  rules:
+  - ruleName: infra_azureelasticsan_azure_resourceId
+    identifier: azure.resourceId
+    name: displayName
+    legacyFeatures:
+      overrideGuidType: true
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: azure.resourceType
+      value: microsoft.elasticsan/elasticsans
+
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-azureelasticsan/golden_metrics.yml
+++ b/entity-types/infra-azureelasticsan/golden_metrics.yml
@@ -1,0 +1,27 @@
+transactions:
+  title: Transactions
+  unit: COUNT
+  queries:
+    azure:
+      select: sum(azure.elasticsan.elasticsans.Transactions)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+availability:
+  title: Availability
+  unit: PERCENTAGE
+  queries:
+    azure:
+      select: average(azure.elasticsan.elasticsans.Availability)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+usedCapacity:
+  title: Used Capacity
+  unit: BYTES
+  queries:
+    azure:
+      select: sum(azure.elasticsan.elasticsans.ElasticSanUsedCapacity)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-azureelasticsan/summary_metrics.yml
+++ b/entity-types/infra-azureelasticsan/summary_metrics.yml
@@ -1,0 +1,17 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: Azure account
+  unit: STRING
+transactions:
+  goldenMetric: transactions
+  unit: COUNT
+  title: Transactions
+availability:
+  goldenMetric: availability
+  unit: PERCENTAGE
+  title: Availability
+usedCapacity:
+  goldenMetric: usedCapacity
+  unit: BYTES
+  title: Used Capacity


### PR DESCRIPTION
## Summary
- Add Azure Elastic SAN (microsoft.elasticsan/elasticsans) entity definition with synthesis rules
- Add golden metrics: Transactions (count), Availability (%), Used Capacity (bytes)
- Add summary metrics referencing golden metrics

**Azure Monitor Metrics Reference:** https://learn.microsoft.com/en-us/azure/azure-monitor/reference/supported-metrics/microsoft-elasticsan-elasticsans-metrics

## Test plan
- [ ] Verify entity definition YAML passes validation
- [ ] Confirm golden metric NRQL queries return data for accounts with Azure Elastic SAN
- [ ] Validate synthesis rule matches microsoft.elasticsan/elasticsans resource type