### PR TITLE
feat: Add AZURELOGANALYTICSWORKSPACE entity definition

### DIFF
--- a/entity-types/infra-azureloganalyticsworkspace/definition.yml
+++ b/entity-types/infra-azureloganalyticsworkspace/definition.yml
@@ -1,0 +1,26 @@
+domain: INFRA
+type: AZURELOGANALYTICSWORKSPACE
+goldenTags:
+- azure.regionName
+- azure.subscriptionId
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
+  rules:
+  - ruleName: infra_azureloganalyticsworkspace_azure_resourceId
+    identifier: azure.resourceId
+    name: displayName
+    legacyFeatures:
+      overrideGuidType: true
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: azure.resourceType
+      value: microsoft.operationalinsights/workspaces
+
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-azureloganalyticsworkspace/golden_metrics.yml
+++ b/entity-types/infra-azureloganalyticsworkspace/golden_metrics.yml
@@ -1,0 +1,27 @@
+availabilityRateQuery:
+  title: Query availability rate
+  unit: PERCENTAGE
+  queries:
+    azure:
+      select: average(azure.operationalinsights.workspaces.AvailabilityRate_Query)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+ingestionTime:
+  title: Ingestion time
+  unit: SECONDS
+  queries:
+    azure:
+      select: average(azure.operationalinsights.workspaces.IngestionTime)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+queryCount:
+  title: Query count
+  unit: COUNT
+  queries:
+    azure:
+      select: sum(azure.operationalinsights.workspaces.QueryCount)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-azureloganalyticsworkspace/summary_metrics.yml
+++ b/entity-types/infra-azureloganalyticsworkspace/summary_metrics.yml
@@ -1,0 +1,17 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: Azure account
+  unit: STRING
+availabilityRateQuery:
+  goldenMetric: availabilityRateQuery
+  unit: PERCENTAGE
+  title: Query availability rate
+ingestionTime:
+  goldenMetric: ingestionTime
+  unit: SECONDS
+  title: Ingestion time
+queryCount:
+  goldenMetric: queryCount
+  unit: COUNT
+  title: Query count


### PR DESCRIPTION
## Summary

Add Azure Log Analytics Workspace (`Microsoft.OperationalInsights/workspaces`) entity definition.

- Entity definition with synthesis rules for `microsoft.operationalinsights/workspaces`
- Golden metrics: Query availability rate, Ingestion time, Query count
- Summary metrics referencing golden metrics
- Golden tags: `azure.regionName`, `azure.subscriptionId`

## Azure Monitor Metrics Used

| Metric | NR Metric Name | Unit | Aggregation |
|--------|---------------|------|-------------|
| AvailabilityRate_Query | `azure.operationalinsights.workspaces.AvailabilityRate_Query` | PERCENTAGE | average |
| Ingestion Time | `azure.operationalinsights.workspaces.IngestionTime` | SECONDS | average |
| Query Count | `azure.operationalinsights.workspaces.QueryCount` | COUNT | sum |

## Files Added

- `entity-types/infra-azureloganalyticsworkspace/definition.yml`
- `entity-types/infra-azureloganalyticsworkspace/golden_metrics.yml`
- `entity-types/infra-azureloganalyticsworkspace/summary_metrics.yml`

## Notes

- Resource type `microsoft.operationalinsights/workspaces` already exists in beyond-workers `supported_resource_types.yml`
- Resource type already exists in beyond-api-v2 `azure_monitor.yml` (both resource_types and exclude_resource_types)
- Metric names verified against Azure Monitor REST API docs and beyond-workers `AzureMetricAttributes.java` transformation rules

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>