### PR TITLE
feat: Add AZURENATGATEWAY entity definition

### DIFF
--- a/entity-types/infra-azurenatgateway/definition.yml
+++ b/entity-types/infra-azurenatgateway/definition.yml
@@ -1,0 +1,28 @@
+domain: INFRA
+type: AZURENATGATEWAY
+goldenTags:
+  - azure.regionName
+  - azure.subscriptionId
+  - azure.type
+  - azure.resourceGroupName
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
+  rules:
+    - ruleName: infra_azurenatgateway_azure_resourceId
+      identifier: azure.resourceId
+      name: displayName
+      legacyFeatures:
+        overrideGuidType: true
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: azure.resourceType
+          value: microsoft.network/natgateways
+
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-azurenatgateway/golden_metrics.yml
+++ b/entity-types/infra-azurenatgateway/golden_metrics.yml
@@ -1,0 +1,36 @@
+datapathAvailability:
+  title: Datapath Availability
+  unit: PERCENTAGE
+  queries:
+    azure:
+      select: average(azure.network.natgateways.DatapathAvailability)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+bytesTransmitted:
+  title: Bytes transmitted
+  unit: BYTES
+  queries:
+    azure:
+      select: sum(azure.network.natgateways.ByteCount)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+packetsTransmitted:
+  title: Packets transmitted
+  unit: COUNT
+  queries:
+    azure:
+      select: sum(azure.network.natgateways.PacketCount)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+snatConnectionCount:
+  title: SNAT connection count
+  unit: COUNT
+  queries:
+    azure:
+      select: sum(azure.network.natgateways.SNATConnectionCount)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-azurenatgateway/summary_metrics.yml
+++ b/entity-types/infra-azurenatgateway/summary_metrics.yml
@@ -1,0 +1,21 @@
+providerAccountName:
+  tag:
+    key: newrelic.cloudIntegrations.providerAccountName
+  title: Azure account
+  unit: STRING
+datapathAvailability:
+  goldenMetric: datapathAvailability
+  unit: PERCENTAGE
+  title: Datapath Availability
+bytesTransmitted:
+  goldenMetric: bytesTransmitted
+  unit: BYTES
+  title: Bytes TX
+packetsTransmitted:
+  goldenMetric: packetsTransmitted
+  unit: COUNT
+  title: Packets TX
+snatConnectionCount:
+  goldenMetric: snatConnectionCount
+  unit: COUNT
+  title: SNAT Connections


### PR DESCRIPTION
## Summary
- Add Azure NAT Gateway (`Microsoft.Network/natGateways`) entity definition with synthesis rules
- Golden metrics: Datapath Availability, Bytes Transmitted, Packets Transmitted, SNAT Connection Count
- Summary metrics referencing golden metrics
- Standard golden tags: `azure.regionName`, `azure.subscriptionId`, `azure.type`, `azure.resourceGroupName`

## Files Added
- `entity-types/infra-azurenatgateway/definition.yml`
- `entity-types/infra-azurenatgateway/golden_metrics.yml`
- `entity-types/infra-azurenatgateway/summary_metrics.yml`

## Golden Metrics
| Metric | NRQL | Unit |
|--------|------|------|
| Datapath Availability | `average(azure.network.natgateways.DatapathAvailability)` | PERCENTAGE |
| Bytes Transmitted | `sum(azure.network.natgateways.ByteCount)` | BYTES |
| Packets Transmitted | `sum(azure.network.natgateways.PacketCount)` | COUNT |
| SNAT Connection Count | `sum(azure.network.natgateways.SNATConnectionCount)` | COUNT |

## Related PRs
- entity-type-ui-definitions-service: AZURENATGATEWAY UI definition
- beyond-workers: `microsoft.network/natgateways` already present
- beyond-api-v2: `microsoft.network/natgateways` already present in azure_monitor.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)