### PR TITLE
feat: Add AZUREPOSTGRESQLSERVERGROUPSV2 entity definition

### DIFF
--- a/entity-types/infra-azurepostgresqlservergroupsv2/definition.yml
+++ b/entity-types/infra-azurepostgresqlservergroupsv2/definition.yml
@@ -1,0 +1,26 @@
+domain: INFRA
+type: AZUREPOSTGRESQLSERVERGROUPSV2
+goldenTags:
+- azure.regionName
+- azure.subscriptionId
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
+  rules:
+  - ruleName: infra_azurepostgresqlservergroupsv2_azure_resourceId
+    identifier: azure.resourceId
+    name: displayName
+    legacyFeatures:
+      overrideGuidType: true
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: azure.resourceType
+      value: microsoft.dbforpostgresql/servergroupsv2
+
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-azurepostgresqlservergroupsv2/golden_metrics.yml
+++ b/entity-types/infra-azurepostgresqlservergroupsv2/golden_metrics.yml
@@ -1,0 +1,42 @@
+cpu:
+  title: CPU (%)
+  unit: PERCENTAGE
+  queries:
+    azure:
+      select: average(azure.dbforpostgresql.servergroupsv2.cpu_percent)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    azureSample:
+      select: average(cpuPercent.Average)
+      from: AzurePostgreSqlServerGroupsv2Sample
+      eventId: entityGuid
+      eventName: entityName
+memory:
+  title: Memory (%)
+  unit: PERCENTAGE
+  queries:
+    azure:
+      select: average(azure.dbforpostgresql.servergroupsv2.memory_percent)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    azureSample:
+      select: average(memoryPercent.Average)
+      from: AzurePostgreSqlServerGroupsv2Sample
+      eventId: entityGuid
+      eventName: entityName
+storageUsed:
+  title: Storage used (%)
+  unit: PERCENTAGE
+  queries:
+    azure:
+      select: average(azure.dbforpostgresql.servergroupsv2.storage_percent)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    azureSample:
+      select: average(storagePercent.Average)
+      from: AzurePostgreSqlServerGroupsv2Sample
+      eventId: entityGuid
+      eventName: entityName

--- a/entity-types/infra-azurepostgresqlservergroupsv2/summary_metrics.yml
+++ b/entity-types/infra-azurepostgresqlservergroupsv2/summary_metrics.yml
@@ -1,0 +1,17 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: Azure account
+  unit: STRING
+cpu:
+  goldenMetric: cpu
+  unit: PERCENTAGE
+  title: CPU usage
+memory:
+  goldenMetric: memory
+  unit: PERCENTAGE
+  title: Memory usage
+storageUsed:
+  goldenMetric: storageUsed
+  unit: PERCENTAGE
+  title: Storage usage


### PR DESCRIPTION
## Summary

Add Azure Cosmos DB for PostgreSQL (`Microsoft.DBForPostgreSQL/serverGroupsv2`) entity definition.

### Changes
- **definition.yml**: Entity definition with synthesis rules mapping `azure.resourceType = microsoft.dbforpostgresql/servergroupsv2`
- **golden_metrics.yml**: CPU %, Memory %, Storage % (dimensional + sample queries)
- **summary_metrics.yml**: Summary metrics referencing golden metrics

### Entity Details
| Field | Value |
|-------|-------|
| Entity Type | `AZUREPOSTGRESQLSERVERGROUPSV2` |
| Resource Type | `microsoft.dbforpostgresql/servergroupsv2` |
| Domain | INFRA |
| Golden Tags | `azure.regionName`, `azure.subscriptionId` |
| Golden Metrics | CPU %, Memory %, Storage % |

### Metrics Source
Metrics verified from [Azure Monitor reference](https://learn.microsoft.com/en-us/azure/azure-monitor/reference/supported-metrics/microsoft-dbforpostgresql-servergroupsv2-metrics).

### Pattern
Follows the same structure as existing PostgreSQL entities:
- `infra-azurepostgresqlflexibleserver`
- `infra-azurepostgresqlserver`

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>