### PR TITLE
feat: Add AZUREDOCUMENTDBCASSANDRACLUSTERS entity definition

### DIFF
--- a/entity-types/infra-azuredocumentdbcassandraclusters/definition.yml
+++ b/entity-types/infra-azuredocumentdbcassandraclusters/definition.yml
@@ -1,0 +1,28 @@
+domain: INFRA
+type: AZUREDOCUMENTDBCASSANDRACLUSTERS
+goldenTags:
+- azure.regionName
+- azure.subscriptionId
+- azure.type
+- azure.resourceGroupName
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
+  rules:
+    - ruleName: infra_azuredocumentdbcassandraclusters_azure_resourceId
+      identifier: azure.resourceId
+      name: displayName
+      legacyFeatures:
+        overrideGuidType: true
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: azure.resourceType
+          value: microsoft.documentdb/cassandraclusters
+
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-azuredocumentdbcassandraclusters/golden_metrics.yml
+++ b/entity-types/infra-azuredocumentdbcassandraclusters/golden_metrics.yml
@@ -1,0 +1,27 @@
+connectedClients:
+  title: Connected native clients
+  unit: COUNT
+  queries:
+    azure:
+      select: average(azure.documentdb.cassandraclusters.cassandra_client_connected_native_clients)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+requestLatencyP99:
+  title: Request latency p99 (microseconds)
+  unit: COUNT
+  queries:
+    azure:
+      select: average(azure.documentdb.cassandraclusters.cassandra_client_request_latency_p99)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+cacheHitRate:
+  title: Cache hit rate (%)
+  unit: PERCENTAGE
+  queries:
+    azure:
+      select: average(azure.documentdb.cassandraclusters.cassandra_cache_hit_rate)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-azuredocumentdbcassandraclusters/summary_metrics.yml
+++ b/entity-types/infra-azuredocumentdbcassandraclusters/summary_metrics.yml
@@ -1,0 +1,17 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: Azure account
+  unit: STRING
+connectedClients:
+  goldenMetric: connectedClients
+  unit: COUNT
+  title: Connected native clients
+requestLatencyP99:
+  goldenMetric: requestLatencyP99
+  unit: COUNT
+  title: Request latency p99 (microseconds)
+cacheHitRate:
+  goldenMetric: cacheHitRate
+  unit: PERCENTAGE
+  title: Cache hit rate (%)


### PR DESCRIPTION
## Summary

Add Azure Managed Instance for Apache Cassandra (`Microsoft.DocumentDB/cassandraClusters`) entity definition.

### Changes
- **Entity definition** with synthesis rules for entity resolution via `azure.resourceId`
- **Golden metrics**: Connected native clients, Request latency P99, Cache hit rate
- **Summary metrics** referencing golden metrics
- **Golden tags**: `azure.regionName`, `azure.subscriptionId`, `azure.type`, `azure.resourceGroupName`

### Metrics Source
Metrics validated against [Azure Monitor supported metrics for Microsoft.DocumentDB/cassandraClusters](https://learn.microsoft.com/en-us/azure/azure-monitor/reference/supported-metrics/microsoft-documentdb-cassandraclusters-metrics).

### Golden Metrics

| Metric | NRQL | Unit |
|--------|------|------|
| Connected native clients | `average(azure.documentdb.cassandraclusters.cassandra_client_connected_native_clients)` | COUNT |
| Request latency P99 | `average(azure.documentdb.cassandraclusters.cassandra_client_request_latency_p99)` | COUNT |
| Cache hit rate | `average(azure.documentdb.cassandraclusters.cassandra_cache_hit_rate)` | PERCENTAGE |

### Related PRs
- entity-type-ui-definitions-service: (see companion PR)
- beyond-workers: `microsoft.documentdb/cassandraclusters` already exists — no changes needed
- beyond-api-v2: `microsoft.documentdb/cassandraclusters` already exists — no changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)