### PR TITLE
feat: Add AZUREVIRTUALMACHINESCOMPUTE entity definition

### DIFF
--- a/entity-types/infra-azurevirtualmachinescompute/definition.yml
+++ b/entity-types/infra-azurevirtualmachinescompute/definition.yml
@@ -1,0 +1,28 @@
+domain: INFRA
+type: AZUREVIRTUALMACHINESCOMPUTE
+goldenTags:
+- azure.regionName
+- azure.subscriptionId
+- azure.type
+- azure.resourceGroupName
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
+  rules:
+  - ruleName: infra_azurevirtualmachinescompute_azure_resourceId
+    identifier: azure.resourceId
+    name: displayName
+    legacyFeatures:
+      overrideGuidType: true
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: azure.resourceType
+      value: microsoft.compute/virtualmachines
+
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-azurevirtualmachinescompute/golden_metrics.yml
+++ b/entity-types/infra-azurevirtualmachinescompute/golden_metrics.yml
@@ -1,0 +1,42 @@
+cpuPercent:
+  title: CPU
+  unit: PERCENTAGE
+  queries:
+    azure:
+      select: average(azure.compute.virtualmachines.PercentageCPU)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    azureSample:
+      select: average(cpuPercent.Average)
+      from: AzureVirtualMachineSample
+      eventId: entityGuid
+      eventName: entityName
+networkInTotal:
+  title: Incoming traffic (bytes)
+  unit: BYTES
+  queries:
+    azure:
+      select: average(azure.compute.virtualmachines.NetworkInTotal)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    azureSample:
+      select: average(networkInTotalBytes.Average)
+      from: AzureVirtualMachineSample
+      eventId: entityGuid
+      eventName: entityName
+networkOutTotal:
+  title: Outgoing traffic (bytes)
+  unit: BYTES
+  queries:
+    azure:
+      select: average(azure.compute.virtualmachines.NetworkOutTotal)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    azureSample:
+      select: average(networkOutTotalBytes.Average)
+      from: AzureVirtualMachineSample
+      eventId: entityGuid
+      eventName: entityName

--- a/entity-types/infra-azurevirtualmachinescompute/summary_metrics.yml
+++ b/entity-types/infra-azurevirtualmachinescompute/summary_metrics.yml
@@ -1,0 +1,17 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: Azure account
+  unit: STRING
+cpuPercent:
+  goldenMetric: cpuPercent
+  unit: PERCENTAGE
+  title: CPU
+networkInTotal:
+  goldenMetric: networkInTotal
+  unit: BYTES
+  title: Incoming
+networkOutTotal:
+  goldenMetric: networkOutTotal
+  unit: BYTES
+  title: Outgoing


### PR DESCRIPTION
## Summary

Add Azure Virtual Machines (`Microsoft.Compute/virtualMachines`) entity definition.

### Files Added
- `entity-types/infra-azurevirtualmachinescompute/definition.yml` - Entity definition with synthesis rules
- `entity-types/infra-azurevirtualmachinescompute/golden_metrics.yml` - Golden metrics (CPU, Network In/Out)
- `entity-types/infra-azurevirtualmachinescompute/summary_metrics.yml` - Summary metrics

### Golden Metrics
| Metric | Source (Dimensional) | Source (Sample) |
|--------|---------------------|-----------------|
| CPU % | `azure.compute.virtualmachines.PercentageCPU` | `cpuPercent.Average` |
| Network In | `azure.compute.virtualmachines.NetworkInTotal` | `networkInTotalBytes.Average` |
| Network Out | `azure.compute.virtualmachines.NetworkOutTotal` | `networkOutTotalBytes.Average` |

### Synthesis
- Identifier: `azure.resourceId`
- Condition: `azure.resourceType = microsoft.compute/virtualmachines`
- Based on existing `AZUREVIRTUALMACHINESCALESET` entity pattern

### Beyond Workers / Beyond API v2
No changes needed - `microsoft.compute/virtualmachines` resource type already exists in both repositories.

Generated with Claude Code