### PR TITLE
NR-552017: Add a synthesis rule for INFRA Host Metric Events from eBPF Agent

### DIFF
--- a/entity-types/infra-host/definition.stg.yml
+++ b/entity-types/infra-host/definition.stg.yml
@@ -110,6 +110,50 @@ synthesis:
         tags.:
           ttl: P1D
 
+    # eBPF host data from New Relic eBPF infrastructure agent
+    - ruleName: ebpf_infra_host_host_id
+      identifier: host.id
+      name: host.name
+      legacyFeatures:
+        overrideGuidType: true
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: eventType
+          value: Metric
+        - attribute: instrumentation.provider
+          value: newrelic-ebpf
+        - attribute: instrumentation.name
+          value: nr_ebpf_infra
+        # if service.name is present, it's a service, not a host
+        - attribute: service.name
+          present: false
+        # if container.id is present, it's a container, not a host
+        - attribute: container.id
+          present: false
+      tags:
+        cloud.provider:
+        cloud.account.id:
+        cloud.region:
+        cloud.availability_zone:
+        cloud.platform:
+        host.id:
+        host.name:
+        host.type:
+        host.arch:
+        host.image.name:
+        host.image.id:
+        host.image.version:
+        instrumentation.provider:
+        instrumentation.name:
+        k8s.cluster.name:
+          ttl: P1D
+        k8s.namespace.name:
+          ttl: P1D
+        process.atp.enabled:
+      prefixedTags:
+        tags.:
+          ttl: P1D
+
     # opentelemetry host data from opentelemetry-collector
     - ruleName: infra_host_host_id_2
       identifier: host.id


### PR DESCRIPTION
### Relevant information
Add a new synthesis rule `ebpf_infra_host_host_id` to [entity-types/infra-host/definition.stg.yml](vscode-webview://0l66tsas2dtj370v3appuhruiav4pgojbv54fml8t7m92sk748p3/entity-types/infra-host/definition.stg.yml) that synthesizes INFRA:HOST entities from eBPF-sourced metrics. The rule:

#### Api Review Board (ARB)

Any pull request with changes to this repository has to be linked with an ARB ticket, which has to be approved before merging.


If you don't know about the ARB process check [this](https://newrelic.enterprise.slack.com/docs/T02D34WJD/F08AW240NSV)

ARB Jira ticket:
https://new-relic.atlassian.net/browse/NR-552401

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid.
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
* [ ] I've linked an ARB ticket & received approval from API Review Board in order to make these changes
