### PR TITLE
feat: Updated oracle rules for allowing Log events for query performance

### DIFF
--- a/entity-types/infra-oracledbinstance/definition.stg.yml
+++ b/entity-types/infra-oracledbinstance/definition.stg.yml
@@ -54,6 +54,8 @@ synthesis:
       conditions:
         - attribute: eventType
           value: Log
+        - attribute: event.name
+          value: db.server.
         - attribute: instrumentation.provider
           value: opentelemetry
         - attribute: otel.library.name

--- a/entity-types/infra-oracledbinstance/definition.stg.yml
+++ b/entity-types/infra-oracledbinstance/definition.stg.yml
@@ -46,6 +46,28 @@ synthesis:
           entityTagNames: [host.address, endpoint]
         host.port:
           entityTagName: host.port
+
+    - ruleName: infra_oracledbinstance_query_sample
+      identifier: host.name
+      name: host.name
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: eventType
+          value: Log
+        - attribute: instrumentation.provider
+          value: opentelemetry
+        - attribute: otel.library.name
+          value: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/oracledbreceiver
+      tags:
+        otel.library.name:
+          entityTagName: instrumentation.name
+        otel.library.version:
+          entityTagName: instrumentation.version
+        host.address:
+          entityTagNames: [host.address, endpoint]
+        host.port:
+          entityTagName: host.port
+
   #new rules
     - ruleName: infra_oracledbinstance_execution_plan_nrdot
       compositeIdentifier:


### PR DESCRIPTION
Description:
Added a new synthesis rule to support Log events from the OpenTelemetry Collector Contrib Oracle DB receiver, enabling entity synthesis from query sample and top query log data.

ARB Jira ticket:
https://new-relic.atlassian.net/browse/NR-555740
