### PR TITLE
fix: site entity attribute changes

### DIFF
--- a/entity-types/infra-juniper_mist_site/definition.stg.yml
+++ b/entity-types/infra-juniper_mist_site/definition.stg.yml
@@ -4,7 +4,7 @@ type: JUNIPER_MIST_SITE
 synthesis:
   rules:
     - ruleName: infra_juniper_mist_site_id
-      name: name
+      name: site_name
       compositeIdentifier:
         separator: ":"
         attributes:
@@ -18,7 +18,7 @@ synthesis:
         - attribute: mist.site
           present: true
       tags:
-        id:
+        site_id:
           entityTagName: site_id
           multiValue: false
         org_id:

--- a/entity-types/infra-juniper_mist_site/definition.stg.yml
+++ b/entity-types/infra-juniper_mist_site/definition.stg.yml
@@ -21,6 +21,12 @@ synthesis:
         site_id:
           entityTagName: site_id
           multiValue: false
+        site_name:
+          entityTagName: site_name
+          multiValue: false
+        org_name:
+          entityTagName: org_name
+          multiValue: false
         org_id:
           entityTagName: org_id
           multiValue: false
@@ -45,7 +51,7 @@ synthesis:
       # Add a 4 hour ttl on all tags ingested in metric api using tags. prefix
       prefixedTags:
         tags.:
-          ttl: PT24H
+          ttl: PT4H
 
 ownership:
   primaryOwner:


### PR DESCRIPTION
### Relevant information

Update site_id and site_name attributes.


#### Api Review Board (ARB)

ARB Jira ticket:
https://new-relic.atlassian.net/browse/NR-548170

**Note**

According to the [documentation](https://newrelic.atlassian.net/wiki/spaces/NNM/pages/5383553317/Juniper+Mist+Entity+Definitions), the entity attributes are correct; however, we added incorrect attributes during the creation of the Juniper Mist site entity, I've updated the site_id and site_name attributes to match the spec.

### Checklist

* [X] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid.
* [X] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
* [X] I've linked an ARB ticket & received approval from API Review Board in order to make these changes
