### PR TITLE
feat: Add otel kafka broker to conatiner rels

### DIFF
--- a/relationships/synthesis/INFRA-CONTAINER-to-INFRA-KAFKABROKER.stg.yml
+++ b/relationships/synthesis/INFRA-CONTAINER-to-INFRA-KAFKABROKER.stg.yml
@@ -1,5 +1,5 @@
 relationships:
-  # Rule 1: NR OnHost Integration K8s container HOSTS Kafka broker (KafkaBrokerSample)
+  # Rule 1: NR OnHost Integration K8s container IS Kafka broker (KafkaBrokerSample)
   - name: ContainerContainsKafkaBrokerStg
     version: "1"
     origins:
@@ -19,7 +19,7 @@ relationships:
         present: true
     relationship:
       expires: PT75M
-      relationshipType: HOSTS
+      relationshipType: IS
       source:
         buildGuid:
           account:
@@ -47,7 +47,6 @@ relationships:
             value: KAFKABROKER
 
   # Rule 2: OTel Kafka broker (plain Docker) → OTel Container (dockerstats receiver)
-  # Matches infra_container_container_id synthesis: identifier = container.id
   - name: OtelKafkaBrokerToOtelDockerContainerStg
     version: "1"
     origins:
@@ -65,7 +64,7 @@ relationships:
         present: false
     relationship:
       expires: PT75M
-      relationshipType: HOSTS
+      relationshipType: IS
       source:
         buildGuid:
           account:
@@ -85,7 +84,6 @@ relationships:
             attribute: entity.type
 
   # Rule 3: OTel Kafka broker (plain Docker) → NR native Container (ContainerSample)
-  # Matches NR infra-agent docker container GUID: "docker:{container.id}" with valueInGuid: NA
   - name: OtelKafkaBrokerToNrDockerContainerStg
     version: "1"
     origins:
@@ -103,7 +101,7 @@ relationships:
         present: false
     relationship:
       expires: PT75M
-      relationshipType: HOSTS
+      relationshipType: IS
       source:
         buildGuid:
           account:
@@ -125,7 +123,6 @@ relationships:
             attribute: entity.type
 
   # Rule 4: OTel Kafka broker (K8s) → OTel K8s Container (kube-state-metrics / cAdvisor / kubeletstats)
-  # Matches infra_container_composite* synthesis: identifier = k8s.cluster.name:k8s.namespace.name:k8s.pod.name:k8s.container.name
   - name: OtelKafkaBrokerToOtelK8sContainerStg
     version: "1"
     origins:
@@ -147,7 +144,7 @@ relationships:
         present: true
     relationship:
       expires: PT75M
-      relationshipType: HOSTS
+      relationshipType: IS
       source:
         buildGuid:
           account:
@@ -173,7 +170,6 @@ relationships:
             attribute: entity.type
 
   # Rule 5: OTel Kafka broker (K8s) → NR native K8s Container (K8sContainerSample)
-  # Matches NR infra-agent k8s container GUID: "k8s:{cluster}:{namespace}:{pod}:container:{name}" with valueInGuid: NA
   - name: OtelKafkaBrokerToNrK8sContainerStg
     version: "1"
     origins:
@@ -195,7 +191,7 @@ relationships:
         present: true
     relationship:
       expires: PT75M
-      relationshipType: HOSTS
+      relationshipType: IS
       source:
         buildGuid:
           account:

--- a/relationships/synthesis/INFRA-CONTAINER-to-INFRA-KAFKABROKER.yml
+++ b/relationships/synthesis/INFRA-CONTAINER-to-INFRA-KAFKABROKER.yml
@@ -1,5 +1,5 @@
 relationships:
-  # From K8s container to Kafka broker
+  # Rule 1: NR OnHost Integration K8s container IS Kafka broker (KafkaBrokerSample)
   - name: ContainerContainsKafkaBroker
     version: "1"
     origins:
@@ -19,7 +19,7 @@ relationships:
         present: true
     relationship:
       expires: PT75M
-      relationshipType: HOSTS
+      relationshipType: IS
       source:
         buildGuid:
           account:
@@ -45,3 +45,175 @@ relationships:
           attribute: entityGuid
           entityType:
             value: KAFKABROKER
+
+  # Rule 2: OTel Container -> OTel Kafka broker (plain Docker)  (dockerstats receiver)
+  - name: OtelKafkaBrokerToOtelDockerContainer
+    version: "1"
+    origins:
+      - OpenTelemetry
+    conditions:
+      - attribute: eventType
+        anyOf: ["Metric", "Log"]
+      - attribute: instrumentation.provider
+        anyOf: ["opentelemetry"]
+      - attribute: entity.type
+        anyOf: ["KAFKABROKER"]
+      - attribute: container.id
+        present: true
+      - attribute: k8s.pod.name
+        present: false
+    relationship:
+      expires: PT75M
+      relationshipType: IS
+      source:
+        buildGuid:
+          account:
+            attribute: accountId
+          domain:
+            value: INFRA
+          type:
+            value: CONTAINER
+          identifier:
+            fragments:
+              - attribute: container.id
+            hashAlgorithm: FARM_HASH
+      target:
+        extractGuid:
+          attribute: entity.guid
+          entityType:
+            attribute: entity.type
+
+  # Rule 3: NR native Container (ContainerSample)  →  OTel Kafka broker (plain Docker)
+  - name: OtelKafkaBrokerToNrDockerContainer
+    version: "1"
+    origins:
+      - OpenTelemetry
+    conditions:
+      - attribute: eventType
+        anyOf: ["Metric", "Log"]
+      - attribute: instrumentation.provider
+        anyOf: ["opentelemetry"]
+      - attribute: entity.type
+        anyOf: ["KAFKABROKER"]
+      - attribute: container.id
+        present: true
+      - attribute: k8s.pod.name
+        present: false
+    relationship:
+      expires: PT75M
+      relationshipType: IS
+      source:
+        buildGuid:
+          account:
+            attribute: accountId
+          domain:
+            value: INFRA
+          type:
+            value: CONTAINER
+            valueInGuid: NA
+          identifier:
+            fragments:
+              - value: "docker:"
+              - attribute: container.id
+            hashAlgorithm: FARM_HASH
+      target:
+        extractGuid:
+          attribute: entity.guid
+          entityType:
+            attribute: entity.type
+
+  # Rule 4: OTel K8s Container (kube-state-metrics / cAdvisor / kubeletstats) -> OTel Kafka broker (K8s)
+  - name: OtelKafkaBrokerToOtelK8sContainer
+    version: "1"
+    origins:
+      - OpenTelemetry
+    conditions:
+      - attribute: eventType
+        anyOf: ["Metric", "Log"]
+      - attribute: instrumentation.provider
+        anyOf: ["opentelemetry"]
+      - attribute: entity.type
+        anyOf: ["KAFKABROKER"]
+      - attribute: k8s.cluster.name
+        present: true
+      - attribute: k8s.namespace.name
+        present: true
+      - attribute: k8s.pod.name
+        present: true
+      - attribute: k8s.container.name
+        present: true
+    relationship:
+      expires: PT75M
+      relationshipType: IS
+      source:
+        buildGuid:
+          account:
+            attribute: accountId
+          domain:
+            value: INFRA
+          type:
+            value: CONTAINER
+          identifier:
+            fragments:
+              - attribute: k8s.cluster.name
+              - value: ":"
+              - attribute: k8s.namespace.name
+              - value: ":"
+              - attribute: k8s.pod.name
+              - value: ":"
+              - attribute: k8s.container.name
+            hashAlgorithm: FARM_HASH
+      target:
+        extractGuid:
+          attribute: entity.guid
+          entityType:
+            attribute: entity.type
+
+  # Rule 5: NR native K8s Container (K8sContainerSample) -> OTel Kafka broker (K8s)
+  - name: OtelKafkaBrokerToNrK8sContainer
+    version: "1"
+    origins:
+      - OpenTelemetry
+    conditions:
+      - attribute: eventType
+        anyOf: ["Metric", "Log"]
+      - attribute: instrumentation.provider
+        anyOf: ["opentelemetry"]
+      - attribute: entity.type
+        anyOf: ["KAFKABROKER"]
+      - attribute: k8s.cluster.name
+        present: true
+      - attribute: k8s.namespace.name
+        present: true
+      - attribute: k8s.pod.name
+        present: true
+      - attribute: k8s.container.name
+        present: true
+    relationship:
+      expires: PT75M
+      relationshipType: IS
+      source:
+        buildGuid:
+          account:
+            attribute: accountId
+          domain:
+            value: INFRA
+          type:
+            value: CONTAINER
+            valueInGuid: NA
+          identifier:
+            fragments:
+              - value: "k8s:"
+              - attribute: k8s.cluster.name
+              - value: ":"
+              - attribute: k8s.namespace.name
+              - value: ":"
+              - attribute: k8s.pod.name
+              - value: ":container:"
+              - attribute: k8s.container.name
+            hashAlgorithm: FARM_HASH
+      target:
+        extractGuid:
+          attribute: entity.guid
+          entityType:
+            attribute: entity.type


### PR DESCRIPTION
Changes
Adds 4 new OTel relationship rules to INFRA-CONTAINER-to-INFRA-KAFKABROKER.stg.yml to link OTel-instrumented Kafka brokers to their host containers.
relationships/synthesis/INFRA-CONTAINER-to-INFRA-KAFKABROKER.yml
Why
Previously, the only container → broker relationship was for NR OnHost Integration (KafkaBrokerSample). OTel Kafka brokers had no container relationship, leaving a gap in the entity topology for OTel users.

Previous Staging changes PR: https://github.com/newrelic/entity-definitions/pull/2738

Rule	
### Relevant information

<!--
  Describe what you have done.
  Provide details that are relevant to the PR

  Always think that the person reviewing the PR doesn't have the context you have.

  Links to examples, documentation and similar resources make the process easier to review.
-->

<!--
  Contributions to this repository are reviewed at least twice a week

  There's no further action required once the PR has been created.
 -->

#### Api Review Board (ARB)

Any pull request with changes to this repository has to be linked with an ARB ticket, which has to be approved before merging.

If you are an external contributor please contact New Relic Support.

If you don't know about the ARB process check [this](https://newrelic.enterprise.slack.com/docs/T02D34WJD/F08AW240NSV)

ARB Jira ticket:
https://new-relic.atlassian.net/browse/NR-546406

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid.
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
* [ ] I've linked an ARB ticket & received approval from API Review Board in order to make these changes
