### PR TITLE
feat: mist prefix added for attributes and tags

### DIFF
--- a/entity-types/infra-juniper_mist_access_point/definition.stg.yml
+++ b/entity-types/infra-juniper_mist_access_point/definition.stg.yml
@@ -4,58 +4,58 @@ type: JUNIPER_MIST_ACCESS_POINT
 synthesis:
   rules:
   - ruleName: infra_juniper_mist_access_point_mac
-    name: name
+    name: mist.name
     compositeIdentifier:
       separator: ":"
       attributes:
         - vendor
-        - org_id
-        - mac
+        - mist.org_id
+        - mist.mac
     encodeIdentifierInGUID: true
     conditions:
-    - attribute: instrumentation.source
+    - attribute: instrumentation.name
       value: juniper_mist
-    - attribute: device_type
+    - attribute: mist.device_type
       value: ap
     tags:
-      mac:
-        entityTagName: mac
+      mist.mac:
+        entityTagName: mist.mac
         multiValue: false
-      model:
-        entityTagName: model
+      mist.model:
+        entityTagName: mist.model
         multiValue: false
-      ip:
-        entityTagName: ip
+      mist.ip:
+        entityTagName: mist.ip
         multiValue: false
-      device_id:
-        entityTagName: device_id
+      mist.device_id:
+        entityTagName: mist.device_id
         multiValue: false
-      serial:
-        entityTagName: serial
+      mist.serial:
+        entityTagName: mist.serial
         multiValue: false
-      site_id:
-        entityTagName: site_id
+      mist.site_id:
+        entityTagName: mist.site_id
         multiValue: false
-      org_id:
-        entityTagName: org_id
+      mist.org_id:
+        entityTagName: mist.org_id
         multiValue: false
-      org_name:
-        entityTagName: org_name
+      mist.org_name:
+        entityTagName: mist.org_name
         multiValue: false
-      site_name:
-        entityTagName: site_name
+      mist.site_name:
+        entityTagName: mist.site_name
         multiValue: false
       vendor:
         entityTagName: vendor
         multiValue: false
-      region:
-        entityTagName: region
+      mist.region:
+        entityTagName: mist.region
         multiValue: false
-      device_type:
-        entityTagName: device_type
+      mist.device_type:
+        entityTagName: mist.device_type
         multiValue: false
-      device_status:
-        entityTagName: device_status
+      mist.device_status:
+        entityTagName: mist.device_status
         multiValue: false
      
       

--- a/entity-types/infra-juniper_mist_gateway/definition.stg.yml
+++ b/entity-types/infra-juniper_mist_gateway/definition.stg.yml
@@ -4,61 +4,61 @@ type: JUNIPER_MIST_GATEWAY
 synthesis:
   rules:
   - ruleName: infra_juniper_mist_gateway_mac
-    name: name
+    name: mist.name
     compositeIdentifier:
       separator: ":"
       attributes:
         - vendor
-        - org_id
-        - mac
+        - mist.org_id
+        - mist.mac
     encodeIdentifierInGUID: true
     conditions:
-    - attribute: instrumentation.source
+    - attribute: instrumentation.name
       value: juniper_mist
-    - attribute: device_type
+    - attribute: mist.device_type
       value: gateway
     tags:
-      ip:
-        entityTagName: ip
+      mist.ip:
+        entityTagName: mist.ip
         multiValue: false
-      mac:
-        entityTagName: mac
+      mist.mac:
+        entityTagName: mist.mac
         multiValue: false
-      model:
-        entityTagName: model
+      mist.model:
+        entityTagName: mist.model
         multiValue: false
-      org_id:
-        entityTagName: org_id
+      mist.org_id:
+        entityTagName: mist.org_id
         multiValue: false
-      org_name:
-        entityTagName: org_name
+      mist.org_name:
+        entityTagName: mist.org_name
         multiValue: false
-      site_id:
-        entityTagName: site_id
+      mist.site_id:
+        entityTagName: mist.site_id
         multiValue: false
-      site_name:
-        entityTagName: site_name
+      mist.site_name:
+        entityTagName: mist.site_name
         multiValue: false
       vendor:
         entityTagName: vendor
         multiValue: false
-      region:
-        entityTagName: region
+      mist.region:
+        entityTagName: mist.region
         multiValue: false
-      serial:
-        entityTagName: serial
+      mist.serial:
+        entityTagName: mist.serial
         multiValue: false
-      device_id:
-        entityTagName: device_id
+      mist.device_id:
+        entityTagName: mist.device_id
         multiValue: false
-      device_type:
-        entityTagName: device_type
+      mist.device_type:
+        entityTagName: mist.device_type
         multiValue: false
-      device_status:
-        entityTagName: device_status
+      mist.device_status:
+        entityTagName: mist.device_status
         multiValue: false
-      node_name:
-        entityTagName: node_name
+      mist.node_name:
+        entityTagName: mist.node_name
         multiValue: false
 
     # Add a 4 hour ttl on all tags ingested in metric api using tags. prefix

--- a/entity-types/infra-juniper_mist_site/definition.stg.yml
+++ b/entity-types/infra-juniper_mist_site/definition.stg.yml
@@ -4,49 +4,49 @@ type: JUNIPER_MIST_SITE
 synthesis:
   rules:
     - ruleName: infra_juniper_mist_site_id
-      name: site_name
+      name: mist.site_name
       compositeIdentifier:
         separator: ":"
         attributes:
           - vendor
-          - org_id
-          - site_id
+          - mist.org_id
+          - mist.site_id
       encodeIdentifierInGUID: true
       conditions:
-        - attribute: instrumentation.source
+        - attribute: instrumentation.name
           value: juniper_mist
         - attribute: mist.site
           present: true
       tags:
-        site_id:
-          entityTagName: site_id
+        mist.site_id:
+          entityTagName: mist.site_id
           multiValue: false
-        site_name:
-          entityTagName: site_name
+        mist.site_name:
+          entityTagName: mist.site_name
           multiValue: false
-        org_name:
-          entityTagName: org_name
+        mist.org_name:
+          entityTagName: mist.org_name
           multiValue: false
-        org_id:
-          entityTagName: org_id
+        mist.org_id:
+          entityTagName: mist.org_id
           multiValue: false
         vendor:
           entityTagName: vendor
           multiValue: false
-        region:
-          entityTagName: region
+        mist.region:
+          entityTagName: mist.region
           multiValue: false
-        latlng.lat:
-          entityTagName: latitude
+        mist.latlng_lat:
+          entityTagName: mist.latitude
           multiValue: false
-        latlng.lng:
-          entityTagName: longitude
+        mist.latlng_lng:
+          entityTagName: mist.longitude
           multiValue: false
-        country_code:
-          entityTagName: country_code
+        mist.country_code:
+          entityTagName: mist.country_code
           multiValue: false
-        timezone:
-          entityTagName: timezone
+        mist.timezone:
+          entityTagName: mist.timezone
           multiValue: false
       # Add a 4 hour ttl on all tags ingested in metric api using tags. prefix
       prefixedTags:

--- a/entity-types/infra-juniper_mist_switch/definition.stg.yml
+++ b/entity-types/infra-juniper_mist_switch/definition.stg.yml
@@ -4,67 +4,67 @@ type: JUNIPER_MIST_SWITCH
 synthesis:
   rules:
   - ruleName: infra_juniper_mist_switch_mac
-    name: name
+    name: mist.name
     compositeIdentifier:
       separator: ":"
       attributes:
         - vendor
-        - org_id
-        - mac
+        - mist.org_id
+        - mist.mac
     encodeIdentifierInGUID: true
     conditions:
-    - attribute: instrumentation.source
+    - attribute: instrumentation.name
       value: juniper_mist
-    - attribute: device_type
+    - attribute: mist.device_type
       value: switch
     tags:
-      mac:
-        entityTagName: mac
+      mist.mac:
+        entityTagName: mist.mac
         multiValue: false
-      model:
-        entityTagName: model
+      mist.model:
+        entityTagName: mist.model
         multiValue: false
-      ip:
-        entityTagName: ip
+      mist.ip:
+        entityTagName: mist.ip
         multiValue: false
-      device_id:
-        entityTagName: device_id
+      mist.device_id:  
+        entityTagName: mist.device_id
         multiValue: false
-      vc_role:
-        entityTagName: vc_role
+      mist.vc_role:
+        entityTagName: mist.vc_role
         multiValue: false
-      vc_state:
-        entityTagName: vc_state
+      mist.vc_state:
+        entityTagName: mist.vc_state
         multiValue: false
-      serial:
-        entityTagName: serial
+      mist.serial:
+        entityTagName: mist.serial
         multiValue: false
-      site_id:
-        entityTagName: site_id
+      mist.site_id:
+        entityTagName: mist.site_id
         multiValue: false
-      org_id:
-        entityTagName: org_id
+      mist.org_id:
+        entityTagName: mist.org_id
         multiValue: false
-      org_name:
-        entityTagName: org_name
+      mist.org_name:
+        entityTagName: mist.org_name
         multiValue: false
-      site_name:
-        entityTagName: site_name
+      mist.site_name:
+        entityTagName: mist.site_name
         multiValue: false
       vendor:
         entityTagName: vendor
         multiValue: false
-      region:
-        entityTagName: region
+      mist.region:
+        entityTagName: mist.region
         multiValue: false
-      device_type:
-        entityTagName: device_type
+      mist.device_type:
+        entityTagName: mist.device_type
         multiValue: false
-      device_status:
-        entityTagName: device_status
+      mist.device_status:
+        entityTagName: mist.device_status
         multiValue: false
-      fpc_idx:
-        entityTagName: fpc_idx
+      mist.fpc_idx:
+        entityTagName: mist.fpc_idx
         multiValue: false
      
       


### PR DESCRIPTION
We have added a prefix `mist.`  for all the entity attribbutes, to differentiate from newrelic attributes.

Please find this [link](https://newrelic.atlassian.net/wiki/spaces/NNM/pages/5383553317/Juniper+Mist+Entity+Definitions) for detailed information.


ARB Jira ticket:
https://new-relic.atlassian.net/browse/NR-559202

### Checklist

* [X] I've read the guidelines and understand the acceptance criteria.
* [X] The value of the attribute marked as `identifier` will be unique and valid.
* [X] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
* [X] I've linked an ARB ticket & received approval from API Review Board in order to make these changes
