### PR TITLE
add missing uninstrumented aws doc db instance entity

### DIFF
--- a/entity-types/uninstrumented-awsdocdbinstance/definition.yml
+++ b/entity-types/uninstrumented-awsdocdbinstance/definition.yml
@@ -1,0 +1,14 @@
+domain: UNINSTRUMENTED
+type: AWSDOCDBINSTANCE
+
+configuration:
+  entityExpirationTime: DAILY
+  alertable: false
+
+synthesis:
+  # Uninstrumented can't use synthesis
+  disabled: true
+
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"


### PR DESCRIPTION
### Relevant information

Add missing uninstrumented `AWSDOCDBINSTANCE` entity as it's failing on entity definition validation.

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid.
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
* [ ] I've linked an ARB ticket & received approval from API Review Board in order to make these changes
