### PR TITLE
fix: correct DocumentDB APM relationship synthesis for CALLS relationships

### DIFF
--- a/relationships/candidates/AWSDOCDBINSTANCE.yml
+++ b/relationships/candidates/AWSDOCDBINSTANCE.yml
@@ -6,8 +6,17 @@ lookups:
     tags:
       matchingMode: ALL
       predicates:
-        - tagKeys: ["aws.endpoint"]
+        # Primary matching by instance identifier (always present)
+        - tagKeys: ["aws.rds.dbInstanceIdentifier"]
+          field: instanceId
+        # Optional port matching (when available and correct)
+        - tagKeys: ["aws.rds.dbInstancePort", "aws.rds.port"]
+          field: port
+          optional: true
+        # Optional endpoint matching (when available)
+        - tagKeys: ["aws.rds.endpoint", "aws.endpoint"]
           field: endpoint
+          optional: true
     onMatch:
       onMultipleMatches: RELATE_ALL
     onMiss:

--- a/relationships/synthesis/APM-APPLICATION-to-INFRA-AWSDOCDBINSTANCE.yml
+++ b/relationships/synthesis/APM-APPLICATION-to-INFRA-AWSDOCDBINSTANCE.yml
@@ -21,9 +21,9 @@ relationships:
           fields:
             # Extract instance identifier from hostname (e.g., rpaliwal-docdb-instance-1.coubraw8zuju.us-east-1.docdb.amazonaws.com -> rpaliwal-docdb-instance-1)
             - field: instanceId
-              attribute: metricName__4
-              regex: '^([^.]+)\..*\.docdb\.amazonaws\.com$'
-              regexCaptureGroup: 1
+              capture:
+                attribute: metricName__4
+                regex: '^([^.]+)\..*\.docdb\.amazonaws\.com$'
             # Extract port from metric name for additional matching when available
             - field: port
               attribute: metricName__5
@@ -50,9 +50,9 @@ relationships:
           fields:
             # Extract instance identifier from hostname (e.g., rpaliwal-docdb-instance-1.coubraw8zuju.us-east-1.docdb.amazonaws.com -> rpaliwal-docdb-instance-1)
             - field: instanceId
-              attribute: peer.hostname
-              regex: '^([^.]+)\..*\.docdb\.amazonaws\.com$'
-              regexCaptureGroup: 1
+              capture:
+                attribute: peer.hostname
+                regex: '^([^.]+)\..*\.docdb\.amazonaws\.com$'
             # Also pass port for additional matching when available
             - field: port
               attribute: server.port

--- a/relationships/synthesis/APM-APPLICATION-to-INFRA-AWSDOCDBINSTANCE.yml
+++ b/relationships/synthesis/APM-APPLICATION-to-INFRA-AWSDOCDBINSTANCE.yml
@@ -24,6 +24,9 @@ relationships:
               capture:
                 attribute: metricName__4
                 regex: '^([^.]+)\..*\.docdb\.amazonaws\.com$'
+            # Pass full hostname as endpoint for optional endpoint matching
+            - field: endpoint
+              attribute: metricName__4
             # Extract port from metric name for additional matching when available
             - field: port
               attribute: metricName__5
@@ -53,6 +56,9 @@ relationships:
               capture:
                 attribute: peer.hostname
                 regex: '^([^.]+)\..*\.docdb\.amazonaws\.com$'
+            # Pass full hostname as endpoint for optional endpoint matching
+            - field: endpoint
+              attribute: peer.hostname
             # Also pass port for additional matching when available
             - field: port
               attribute: server.port

--- a/relationships/synthesis/APM-APPLICATION-to-INFRA-AWSDOCDBINSTANCE.yml
+++ b/relationships/synthesis/APM-APPLICATION-to-INFRA-AWSDOCDBINSTANCE.yml
@@ -19,8 +19,14 @@ relationships:
         lookupGuid:
           candidateCategory: AWSDOCDBINSTANCE
           fields:
-            - field: endpoint
-              attribute: metricName__4 # hostname: <instance>.<cluster>.<region>.docdb.amazonaws.com
+            # Extract instance identifier from hostname (e.g., rpaliwal-docdb-instance-1.coubraw8zuju.us-east-1.docdb.amazonaws.com -> rpaliwal-docdb-instance-1)
+            - field: instanceId
+              attribute: metricName__4
+              regex: '^([^.]+)\..*\.docdb\.amazonaws\.com$'
+              regexCaptureGroup: 1
+            # Extract port from metric name for additional matching when available
+            - field: port
+              attribute: metricName__5
 
   # Pattern 2: Distributed Tracing - Span with peer.hostname pointing to DocumentDB
   - name: apmApplicationCallsAwsDocDbInstanceFromSpan
@@ -42,5 +48,11 @@ relationships:
         lookupGuid:
           candidateCategory: AWSDOCDBINSTANCE
           fields:
-            - field: endpoint
+            # Extract instance identifier from hostname (e.g., rpaliwal-docdb-instance-1.coubraw8zuju.us-east-1.docdb.amazonaws.com -> rpaliwal-docdb-instance-1)
+            - field: instanceId
               attribute: peer.hostname
+              regex: '^([^.]+)\..*\.docdb\.amazonaws\.com$'
+              regexCaptureGroup: 1
+            # Also pass port for additional matching when available
+            - field: port
+              attribute: server.port


### PR DESCRIPTION
Note:- These fixes are the part of previous changes done in https://new-relic.atlassian.net/browse/NR-555365 , here we updating few changes

- Fix AWSDOCDBINSTANCE candidate to match by aws.rds.dbInstanceIdentifier instead of missing aws.endpoint tag
- Add optional port and endpoint matching for enhanced lookup reliability
- Update synthesis rules to extract instanceId from hostnames using regex instead of passing full endpoints
- Add port fields (metricName__5, server.port) for additional matching validation

This resolves the issue where APM spans with peer.hostname like 'rpaliwal-docdb-instance-1.coubraw8zuju.us-east-1.docdb.amazonaws.com' failed to create CALLS relationships to DocumentDB instance entities.

The root cause was mismatch between synthesis rule output (endpoint field) and candidate lookup expectations (instanceId field with aws.rds.dbInstanceIdentifier tag).

### Relevant information

<!--
  Describe what you have done.
  Provide details that are relevant to the PR

  Always think that the person reviewing the PR doesn't have the context you have.

  Links to examples, documentation and similar resources make the process easier to review.
-->

<!--
  Contributions to this repository are reviewed at least twice a week

  There's no further action required once the PR has been created.
 -->

#### Api Review Board (ARB)

Any pull request with changes to this repository has to be linked with an ARB ticket, which has to be approved before merging.

If you are an external contributor please contact New Relic Support.

If you don't know about the ARB process check [this](https://newrelic.enterprise.slack.com/docs/T02D34WJD/F08AW240NSV)

ARB Jira ticket:
https://new-relic.atlassian.net/browse/NR-555365

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid.
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
* [ ] I've linked an ARB ticket & received approval from API Review Board in order to make these changes
