### PR TITLE
feat(infra-awsecstask): reduce entity TTL from 24h to 4h

### DIFF
--- a/entity-types/infra-awsecstask/definition.yml
+++ b/entity-types/infra-awsecstask/definition.yml
@@ -4,7 +4,7 @@ goldenTags:
   - aws.accountId
   - aws.region
 configuration:
-  entityExpirationTime: DAILY
+  entityExpirationTime: FOUR_HOURS
   alertable: false
 
 ownership:


### PR DESCRIPTION
## Summary
- Change `entityExpirationTime` for `INFRA-AWSECSTASK` from `DAILY` (24h) to `FOUR_HOURS`.
- ECS tasks are short-lived workloads; a 4-hour TTL better reflects their lifecycle and reduces stale entity noise.


Relevant information
Api Review Board (ARB)
Any pull request with changes to this repository has to be linked with an ARB ticket, which has to be approved before merging.

If you are an external contributor please contact New Relic Support.

If you don't know about the ARB process check [this](https://newrelic.enterprise.slack.com/docs/T02D34WJD/F08AW240NSV)

ARB Jira ticket:
https://new-relic.atlassian.net/browse/NR-562062