### PR TITLE
feat: Add AZURESTORAGEACCOUNTBLOBSERVICE entity definition

### DIFF
--- a/entity-types/infra-azurestorageaccountblobservice/definition.yml
+++ b/entity-types/infra-azurestorageaccountblobservice/definition.yml
@@ -1,0 +1,28 @@
+domain: INFRA
+type: AZURESTORAGEACCOUNTBLOBSERVICE
+goldenTags:
+  - azure.regionName
+  - azure.subscriptionId
+  - azure.type
+  - azure.resourceGroupName
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
+  rules:
+    - ruleName: infra_azurestorageaccountblobservice_azure_resourceId
+      identifier: azure.resourceId
+      name: displayName
+      legacyFeatures:
+        overrideGuidType: true
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: azure.resourceType
+          value: microsoft.storage/storageaccounts/blobservices
+
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-azurestorageaccountblobservice/golden_metrics.yml
+++ b/entity-types/infra-azurestorageaccountblobservice/golden_metrics.yml
@@ -1,0 +1,36 @@
+blobCapacity:
+  title: Blob Capacity
+  unit: BYTES
+  queries:
+    azure:
+      select: average(azure.storage.storageaccounts.blobservices.BlobCapacity)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+transactions:
+  title: Transactions
+  unit: COUNT
+  queries:
+    azure:
+      select: sum(azure.storage.storageaccounts.blobservices.Transactions)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+availability:
+  title: Availability
+  unit: PERCENTAGE
+  queries:
+    azure:
+      select: average(azure.storage.storageaccounts.blobservices.Availability)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+successE2ELatency:
+  title: Success E2E Latency (ms)
+  unit: MS
+  queries:
+    azure:
+      select: average(azure.storage.storageaccounts.blobservices.SuccessE2ELatency)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-azurestorageaccountblobservice/summary_metrics.yml
+++ b/entity-types/infra-azurestorageaccountblobservice/summary_metrics.yml
@@ -1,0 +1,21 @@
+providerAccountName:
+  tag:
+    key: newrelic.cloudIntegrations.providerAccountName
+  title: Azure account
+  unit: STRING
+blobCapacity:
+  goldenMetric: blobCapacity
+  unit: BYTES
+  title: Blob Capacity
+transactions:
+  goldenMetric: transactions
+  unit: COUNT
+  title: Transactions
+availability:
+  goldenMetric: availability
+  unit: PERCENTAGE
+  title: Availability
+successE2ELatency:
+  goldenMetric: successE2ELatency
+  unit: MS
+  title: E2E Latency


### PR DESCRIPTION
## Summary                                                                                                                                                        
  - Add Azure Storage Account Blob Service (`microsoft.storage/storageaccounts/blobservices`) as a new infra entity type.                                             
  - Golden metrics: Blob Capacity, Transactions, Availability, Success E2E Latency.                                                                                   
  - Synthesis rule matches `azure.resourceType = microsoft.storage/storageaccounts/blobservices`.                                                                     
                                                                                                                                                                      
  ## Production data                                                                                                                                                  
  **37,524 unique resources** reporting for `microsoft.storage/storageaccounts/blobservices` (BeyondAzureMonitorCall, last 7 days).                                   
                                                                                                                                                                      
  ## Metric source                                                                                                                                                    
  https://learn.microsoft.com/en-us/azure/azure-monitor/reference/supported-metrics/microsoft-storage-storageaccounts-blobservices-metrics                            
                                                                                                                                                                      
  ARB - https://new-relic.atlassian.net/browse/NR-551510 