### PR TITLE
feat: Add AZURESTATICSITE entity definition

### DIFF
--- a/entity-types/infra-azurestaticsite/definition.yml
+++ b/entity-types/infra-azurestaticsite/definition.yml
@@ -1,0 +1,28 @@
+domain: INFRA
+type: AZURESTATICSITE
+goldenTags:
+  - azure.regionName
+  - azure.subscriptionId
+  - azure.type
+  - azure.resourceGroupName
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
+  rules:
+    - ruleName: infra_azurestaticsite_azure_resourceId
+      identifier: azure.resourceId
+      name: displayName
+      legacyFeatures:
+        overrideGuidType: true
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: azure.resourceType
+          value: microsoft.web/staticsites
+
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-azurestaticsite/golden_metrics.yml
+++ b/entity-types/infra-azurestaticsite/golden_metrics.yml
@@ -1,0 +1,36 @@
+siteHits:
+  title: Site Hits
+  unit: COUNT
+  queries:
+    azure:
+      select: sum(azure.web.staticsites.SiteHits)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+siteErrors:
+  title: Site Errors
+  unit: COUNT
+  queries:
+    azure:
+      select: sum(azure.web.staticsites.SiteErrors)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+cdnTotalLatency:
+  title: CDN Total Latency (ms)
+  unit: MS
+  queries:
+    azure:
+      select: sum(azure.web.staticsites.CdnTotalLatency)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+dataOut:
+  title: Data Out
+  unit: BYTES
+  queries:
+    azure:
+      select: sum(azure.web.staticsites.BytesSent)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-azurestaticsite/summary_metrics.yml
+++ b/entity-types/infra-azurestaticsite/summary_metrics.yml
@@ -1,0 +1,21 @@
+providerAccountName:
+  tag:
+    key: newrelic.cloudIntegrations.providerAccountName
+  title: Azure account
+  unit: STRING
+siteHits:
+  goldenMetric: siteHits
+  unit: COUNT
+  title: Hits
+siteErrors:
+  goldenMetric: siteErrors
+  unit: COUNT
+  title: Errors
+cdnTotalLatency:
+  goldenMetric: cdnTotalLatency
+  unit: MS
+  title: CDN Latency
+dataOut:
+  goldenMetric: dataOut
+  unit: BYTES
+  title: Data Out


### PR DESCRIPTION
## Summary                                                                                                                                                          
  - Add Azure Static Web Apps (`microsoft.web/staticsites`) as a new infra entity type.                                                                               
  - Golden metrics: Site Hits, Site Errors, CDN Total Latency, Data Out.                                                                                              
  - Synthesis rule matches `azure.resourceType = microsoft.web/staticsites`.                                                                                          
                                                                                                                                                                      
  ## Production data                                                                      
  **1,331 unique resources** reporting for `microsoft.web/staticsites` (BeyondAzureMonitorCall, last 7 days).                                                         
                                                                                                                                                                      
  ## Metric source                                                                                                                                                    
  https://learn.microsoft.com/en-us/azure/azure-monitor/reference/supported-metrics/microsoft-web-staticsites-metrics                                                 
                                                                                                                                                                      
  ARB - https://new-relic.atlassian.net/browse/NR-551510