### PR TITLE
feat: Add AZUREAUTOSCALESETTING entity definition

### DIFF
--- a/entity-types/infra-azureautoscalesetting/definition.yml
+++ b/entity-types/infra-azureautoscalesetting/definition.yml
@@ -1,0 +1,28 @@
+domain: INFRA
+type: AZUREAUTOSCALESETTING
+goldenTags:
+  - azure.regionName
+  - azure.subscriptionId
+  - azure.type
+  - azure.resourceGroupName
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
+  rules:
+    - ruleName: infra_azureautoscalesetting_azure_resourceId
+      identifier: azure.resourceId
+      name: displayName
+      legacyFeatures:
+        overrideGuidType: true
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: azure.resourceType
+          value: microsoft.insights/autoscalesettings
+
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-azureautoscalesetting/golden_metrics.yml
+++ b/entity-types/infra-azureautoscalesetting/golden_metrics.yml
@@ -1,0 +1,27 @@
+observedCapacity:
+  title: Observed Capacity
+  unit: COUNT
+  queries:
+    azure:
+      select: average(azure.insights.autoscalesettings.ObservedCapacity)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+scaleActionsInitiated:
+  title: Scale Actions Initiated
+  unit: COUNT
+  queries:
+    azure:
+      select: sum(azure.insights.autoscalesettings.ScaleActionsInitiated)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+observedMetricValue:
+  title: Observed Metric Value
+  unit: COUNT
+  queries:
+    azure:
+      select: average(azure.insights.autoscalesettings.ObservedMetricValue)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-azureautoscalesetting/summary_metrics.yml
+++ b/entity-types/infra-azureautoscalesetting/summary_metrics.yml
@@ -1,0 +1,17 @@
+providerAccountName:
+  tag:
+    key: newrelic.cloudIntegrations.providerAccountName
+  title: Azure account
+  unit: STRING
+observedCapacity:
+  goldenMetric: observedCapacity
+  unit: COUNT
+  title: Observed Capacity
+scaleActionsInitiated:
+  goldenMetric: scaleActionsInitiated
+  unit: COUNT
+  title: Scale Actions
+observedMetricValue:
+  goldenMetric: observedMetricValue
+  unit: COUNT
+  title: Observed Value


### PR DESCRIPTION
## Summary                                                                                                                                                          
  - Add Azure Autoscale Setting (`microsoft.insights/autoscalesettings`) as a new infra entity type.                                                                  
  - Golden metrics: Observed Capacity, Scale Actions Initiated, Observed Metric Value.                                                                                
  - Synthesis rule matches `azure.resourceType = microsoft.insights/autoscalesettings`.   
                                                                                          
  ## Production data                                            
  **3,062 unique resources** reporting for `microsoft.insights/autoscalesettings` (BeyondAzureMonitorCall, last 7 days).                                              
                                                               
  ## Metric source                                                                                                                                                    
  https://learn.microsoft.com/en-us/azure/azure-monitor/reference/supported-metrics/microsoft-insights-autoscalesettings-metrics                                      
                                                                                                                                                                      
  ARB - https://new-relic.atlassian.net/browse/NR-551510