### PR TITLE
feat: Add AZUREWEBAPPSLOT entity definition

### DIFF
--- a/entity-types/infra-azurewebappslot/definition.yml
+++ b/entity-types/infra-azurewebappslot/definition.yml
@@ -1,0 +1,28 @@
+domain: INFRA
+type: AZUREWEBAPPSLOT
+goldenTags:
+  - azure.regionName
+  - azure.subscriptionId
+  - azure.type
+  - azure.resourceGroupName
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
+  rules:
+    - ruleName: infra_azurewebappslot_azure_resourceId
+      identifier: azure.resourceId
+      name: displayName
+      legacyFeatures:
+        overrideGuidType: true
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: azure.resourceType
+          value: microsoft.web/sites/slots
+
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-azurewebappslot/golden_metrics.yml
+++ b/entity-types/infra-azurewebappslot/golden_metrics.yml
@@ -1,0 +1,45 @@
+cpuTime:
+  title: CPU Time (s)
+  unit: SECONDS
+  queries:
+    azure:
+      select: sum(azure.web.sites.slots.CpuTime)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+memoryWorkingSet:
+  title: Memory Working Set
+  unit: BYTES
+  queries:
+    azure:
+      select: average(azure.web.sites.slots.AverageMemoryWorkingSet)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+dataIn:
+  title: Data In
+  unit: BYTES
+  queries:
+    azure:
+      select: sum(azure.web.sites.slots.BytesReceived)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+dataOut:
+  title: Data Out
+  unit: BYTES
+  queries:
+    azure:
+      select: sum(azure.web.sites.slots.BytesSent)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+connections:
+  title: Connections
+  unit: COUNT
+  queries:
+    azure:
+      select: average(azure.web.sites.slots.AppConnections)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-azurewebappslot/summary_metrics.yml
+++ b/entity-types/infra-azurewebappslot/summary_metrics.yml
@@ -1,0 +1,25 @@
+providerAccountName:
+  tag:
+    key: newrelic.cloudIntegrations.providerAccountName
+  title: Azure account
+  unit: STRING
+cpuTime:
+  goldenMetric: cpuTime
+  unit: SECONDS
+  title: CPU Time
+memoryWorkingSet:
+  goldenMetric: memoryWorkingSet
+  unit: BYTES
+  title: Memory
+dataIn:
+  goldenMetric: dataIn
+  unit: BYTES
+  title: Data In
+dataOut:
+  goldenMetric: dataOut
+  unit: BYTES
+  title: Data Out
+connections:
+  goldenMetric: connections
+  unit: COUNT
+  title: Connections


### PR DESCRIPTION
## Summary                                                                                                                                                          
  - Add Azure Web App Slot (deployment slots of App Service) (`microsoft.web/sites/slots`) as a new infra entity type.
  - Golden metrics: CPU Time, Memory Working Set, Data In, Data Out, Connections.                                                                                     
  - Synthesis rule matches `azure.resourceType = microsoft.web/sites/slots`.
                                                          
  ## Production data                                                                                                                                                  
  **6,512 unique resources** reporting for `microsoft.web/sites/slots` (BeyondAzureMonitorCall, last 7 days).
                                                                                                                                                                      
  ## Metric source                                                                                                                                                    
  https://learn.microsoft.com/en-us/azure/azure-monitor/reference/supported-metrics/microsoft-web-sites-slots-metrics                                                 
                                                                                                                                                                      
  ARB - https://new-relic.atlassian.net/browse/NR-551510 