### PR TITLE
feat: Add AZURESTORAGEACCOUNTTABLESERVICE entity definition

### DIFF
--- a/entity-types/infra-azurestorageaccounttableservice/definition.yml
+++ b/entity-types/infra-azurestorageaccounttableservice/definition.yml
@@ -1,0 +1,28 @@
+domain: INFRA
+type: AZURESTORAGEACCOUNTTABLESERVICE
+goldenTags:
+  - azure.regionName
+  - azure.subscriptionId
+  - azure.type
+  - azure.resourceGroupName
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
+  rules:
+    - ruleName: infra_azurestorageaccounttableservice_azure_resourceId
+      identifier: azure.resourceId
+      name: displayName
+      legacyFeatures:
+        overrideGuidType: true
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: azure.resourceType
+          value: microsoft.storage/storageaccounts/tableservices
+
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-azurestorageaccounttableservice/golden_metrics.yml
+++ b/entity-types/infra-azurestorageaccounttableservice/golden_metrics.yml
@@ -1,0 +1,36 @@
+transactions:
+  title: Transactions
+  unit: COUNT
+  queries:
+    azure:
+      select: sum(azure.storage.storageaccounts.tableservices.Transactions)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+availability:
+  title: Availability
+  unit: PERCENTAGE
+  queries:
+    azure:
+      select: average(azure.storage.storageaccounts.tableservices.Availability)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+tableEntityCount:
+  title: Table Entity Count
+  unit: COUNT
+  queries:
+    azure:
+      select: average(azure.storage.storageaccounts.tableservices.TableEntityCount)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+successE2ELatency:
+  title: Success E2E Latency (ms)
+  unit: MS
+  queries:
+    azure:
+      select: average(azure.storage.storageaccounts.tableservices.SuccessE2ELatency)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-azurestorageaccounttableservice/summary_metrics.yml
+++ b/entity-types/infra-azurestorageaccounttableservice/summary_metrics.yml
@@ -1,0 +1,21 @@
+providerAccountName:
+  tag:
+    key: newrelic.cloudIntegrations.providerAccountName
+  title: Azure account
+  unit: STRING
+transactions:
+  goldenMetric: transactions
+  unit: COUNT
+  title: Transactions
+availability:
+  goldenMetric: availability
+  unit: PERCENTAGE
+  title: Availability
+tableEntityCount:
+  goldenMetric: tableEntityCount
+  unit: COUNT
+  title: Entities
+successE2ELatency:
+  goldenMetric: successE2ELatency
+  unit: MS
+  title: E2E Latency


### PR DESCRIPTION
## Summary                                                                                                                                                          
  - Add Azure Storage Account Table Service (`microsoft.storage/storageaccounts/tableservices`) as a new infra entity type.
  - Golden metrics: Transactions, Availability, Table Entity Count, Success E2E Latency.                                                                              
  - Synthesis rule matches `azure.resourceType = microsoft.storage/storageaccounts/tableservices`.
                                                          
  ## Production data                                                                                                                                                  
  **35,886 unique resources** reporting for `microsoft.storage/storageaccounts/tableservices` (BeyondAzureMonitorCall, last 7 days).
                                                                                                                                                                      
  ## Metric source                                                                                                                                                    
  https://learn.microsoft.com/en-us/azure/azure-monitor/reference/supported-metrics/microsoft-storage-storageaccounts-tableservices-metrics                           
                                                                                                                                                                      
  ARB - https://new-relic.atlassian.net/browse/NR-551510