### PR TITLE
feat:juniper mist entity definition files added for production

### DIFF
--- a/entity-types/infra-juniper_mist_access_point/definition.stg.yml
+++ b/entity-types/infra-juniper_mist_access_point/definition.stg.yml
@@ -63,7 +63,7 @@ synthesis:
     # Add a 4 hour ttl on all tags ingested in metric api using tags. prefix
     prefixedTags:
       tags.:
-        ttl: PT4H
+        ttl: P1D
 
 
 

--- a/entity-types/infra-juniper_mist_access_point/definition.stg.yml
+++ b/entity-types/infra-juniper_mist_access_point/definition.stg.yml
@@ -60,7 +60,7 @@ synthesis:
      
       
 
-    # Add a 4 hour ttl on all tags ingested in metric api using tags. prefix
+    # Add a 1 day ttl on all tags ingested in metric api using tags. prefix
     prefixedTags:
       tags.:
         ttl: P1D

--- a/entity-types/infra-juniper_mist_access_point/definition.yml
+++ b/entity-types/infra-juniper_mist_access_point/definition.yml
@@ -63,7 +63,7 @@ synthesis:
     # Add a 4 hour ttl on all tags ingested in metric api using tags. prefix
     prefixedTags:
       tags.:
-        ttl: PT4H
+        ttl: P1D
 
 
 

--- a/entity-types/infra-juniper_mist_access_point/definition.yml
+++ b/entity-types/infra-juniper_mist_access_point/definition.yml
@@ -60,7 +60,7 @@ synthesis:
      
       
 
-    # Add a 4 hour ttl on all tags ingested in metric api using tags. prefix
+    # Add a 1 day ttl on all tags ingested in metric api using tags. prefix
     prefixedTags:
       tags.:
         ttl: P1D

--- a/entity-types/infra-juniper_mist_access_point/definition.yml
+++ b/entity-types/infra-juniper_mist_access_point/definition.yml
@@ -1,0 +1,72 @@
+
+domain: INFRA
+type: JUNIPER_MIST_ACCESS_POINT
+synthesis:
+  rules:
+  - ruleName: infra_juniper_mist_access_point_mac
+    name: mist.name
+    compositeIdentifier:
+      separator: ":"
+      attributes:
+        - vendor
+        - mist.org_id
+        - mist.mac
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: instrumentation.name
+      value: juniper_mist
+    - attribute: mist.device_type
+      value: ap
+    tags:
+      mist.mac:
+        entityTagName: mist.mac
+        multiValue: false
+      mist.model:
+        entityTagName: mist.model
+        multiValue: false
+      mist.ip:
+        entityTagName: mist.ip
+        multiValue: false
+      mist.device_id:
+        entityTagName: mist.device_id
+        multiValue: false
+      mist.serial:
+        entityTagName: mist.serial
+        multiValue: false
+      mist.site_id:
+        entityTagName: mist.site_id
+        multiValue: false
+      mist.org_id:
+        entityTagName: mist.org_id
+        multiValue: false
+      mist.org_name:
+        entityTagName: mist.org_name
+        multiValue: false
+      mist.site_name:
+        entityTagName: mist.site_name
+        multiValue: false
+      vendor:
+        entityTagName: vendor
+        multiValue: false
+      mist.region:
+        entityTagName: mist.region
+        multiValue: false
+      mist.device_type:
+        entityTagName: mist.device_type
+        multiValue: false
+      mist.device_status:
+        entityTagName: mist.device_status
+        multiValue: false
+     
+      
+
+    # Add a 4 hour ttl on all tags ingested in metric api using tags. prefix
+    prefixedTags:
+      tags.:
+        ttl: PT4H
+
+
+
+ownership:
+  primaryOwner:
+    teamName: "Network Monitoring"

--- a/entity-types/infra-juniper_mist_gateway/definition.stg.yml
+++ b/entity-types/infra-juniper_mist_gateway/definition.stg.yml
@@ -61,7 +61,7 @@ synthesis:
         entityTagName: mist.node_name
         multiValue: false
 
-    # Add a 4 hour ttl on all tags ingested in metric api using tags. prefix
+    # Add a 1 day ttl on all tags ingested in metric api using tags. prefix
     prefixedTags:
       tags.:
         ttl: P1D

--- a/entity-types/infra-juniper_mist_gateway/definition.stg.yml
+++ b/entity-types/infra-juniper_mist_gateway/definition.stg.yml
@@ -64,7 +64,7 @@ synthesis:
     # Add a 4 hour ttl on all tags ingested in metric api using tags. prefix
     prefixedTags:
       tags.:
-        ttl: PT4H
+        ttl: P1D
 
 
 

--- a/entity-types/infra-juniper_mist_gateway/definition.yml
+++ b/entity-types/infra-juniper_mist_gateway/definition.yml
@@ -61,7 +61,7 @@ synthesis:
         entityTagName: mist.node_name
         multiValue: false
 
-    # Add a 4 hour ttl on all tags ingested in metric api using tags. prefix
+    # Add a 1 day ttl on all tags ingested in metric api using tags. prefix
     prefixedTags:
       tags.:
         ttl: P1D

--- a/entity-types/infra-juniper_mist_gateway/definition.yml
+++ b/entity-types/infra-juniper_mist_gateway/definition.yml
@@ -64,7 +64,7 @@ synthesis:
     # Add a 4 hour ttl on all tags ingested in metric api using tags. prefix
     prefixedTags:
       tags.:
-        ttl: PT4H
+        ttl: P1D
 
 
 

--- a/entity-types/infra-juniper_mist_gateway/definition.yml
+++ b/entity-types/infra-juniper_mist_gateway/definition.yml
@@ -1,0 +1,73 @@
+
+domain: INFRA
+type: JUNIPER_MIST_GATEWAY
+synthesis:
+  rules:
+  - ruleName: infra_juniper_mist_gateway_mac
+    name: mist.name
+    compositeIdentifier:
+      separator: ":"
+      attributes:
+        - vendor
+        - mist.org_id
+        - mist.mac
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: instrumentation.name
+      value: juniper_mist
+    - attribute: mist.device_type
+      value: gateway
+    tags:
+      mist.ip:
+        entityTagName: mist.ip
+        multiValue: false
+      mist.mac:
+        entityTagName: mist.mac
+        multiValue: false
+      mist.model:
+        entityTagName: mist.model
+        multiValue: false
+      mist.org_id:
+        entityTagName: mist.org_id
+        multiValue: false
+      mist.org_name:
+        entityTagName: mist.org_name
+        multiValue: false
+      mist.site_id:
+        entityTagName: mist.site_id
+        multiValue: false
+      mist.site_name:
+        entityTagName: mist.site_name
+        multiValue: false
+      vendor:
+        entityTagName: vendor
+        multiValue: false
+      mist.region:
+        entityTagName: mist.region
+        multiValue: false
+      mist.serial:
+        entityTagName: mist.serial
+        multiValue: false
+      mist.device_id:
+        entityTagName: mist.device_id
+        multiValue: false
+      mist.device_type:
+        entityTagName: mist.device_type
+        multiValue: false
+      mist.device_status:
+        entityTagName: mist.device_status
+        multiValue: false
+      mist.node_name:
+        entityTagName: mist.node_name
+        multiValue: false
+
+    # Add a 4 hour ttl on all tags ingested in metric api using tags. prefix
+    prefixedTags:
+      tags.:
+        ttl: PT4H
+
+
+
+ownership:
+  primaryOwner:
+    teamName: "Network Monitoring"

--- a/entity-types/infra-juniper_mist_site/definition.stg.yml
+++ b/entity-types/infra-juniper_mist_site/definition.stg.yml
@@ -48,7 +48,7 @@ synthesis:
         mist.timezone:
           entityTagName: mist.timezone
           multiValue: false
-      # Add a 4 hour ttl on all tags ingested in metric api using tags. prefix
+      # Add a 1 day ttl on all tags ingested in metric api using tags. prefix
       prefixedTags:
         tags.:
           ttl: P1D

--- a/entity-types/infra-juniper_mist_site/definition.stg.yml
+++ b/entity-types/infra-juniper_mist_site/definition.stg.yml
@@ -51,7 +51,7 @@ synthesis:
       # Add a 4 hour ttl on all tags ingested in metric api using tags. prefix
       prefixedTags:
         tags.:
-          ttl: PT4H
+          ttl: P1D
 
 ownership:
   primaryOwner:

--- a/entity-types/infra-juniper_mist_site/definition.yml
+++ b/entity-types/infra-juniper_mist_site/definition.yml
@@ -48,7 +48,7 @@ synthesis:
         mist.timezone:
           entityTagName: mist.timezone
           multiValue: false
-      # Add a 4 hour ttl on all tags ingested in metric api using tags. prefix
+      # Add a 1 day ttl on all tags ingested in metric api using tags. prefix
       prefixedTags:
         tags.:
           ttl: P1D

--- a/entity-types/infra-juniper_mist_site/definition.yml
+++ b/entity-types/infra-juniper_mist_site/definition.yml
@@ -51,7 +51,7 @@ synthesis:
       # Add a 4 hour ttl on all tags ingested in metric api using tags. prefix
       prefixedTags:
         tags.:
-          ttl: PT4H
+          ttl: P1D
 
 ownership:
   primaryOwner:

--- a/entity-types/infra-juniper_mist_site/definition.yml
+++ b/entity-types/infra-juniper_mist_site/definition.yml
@@ -1,0 +1,58 @@
+
+domain: INFRA
+type: JUNIPER_MIST_SITE
+synthesis:
+  rules:
+    - ruleName: infra_juniper_mist_site_id
+      name: mist.site_name
+      compositeIdentifier:
+        separator: ":"
+        attributes:
+          - vendor
+          - mist.org_id
+          - mist.site_id
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: instrumentation.name
+          value: juniper_mist
+        - attribute: mist.site
+          present: true
+      tags:
+        mist.site_id:
+          entityTagName: mist.site_id
+          multiValue: false
+        mist.site_name:
+          entityTagName: mist.site_name
+          multiValue: false
+        mist.org_name:
+          entityTagName: mist.org_name
+          multiValue: false
+        mist.org_id:
+          entityTagName: mist.org_id
+          multiValue: false
+        vendor:
+          entityTagName: vendor
+          multiValue: false
+        mist.region:
+          entityTagName: mist.region
+          multiValue: false
+        mist.latlng_lat:
+          entityTagName: mist.latitude
+          multiValue: false
+        mist.latlng_lng:
+          entityTagName: mist.longitude
+          multiValue: false
+        mist.country_code:
+          entityTagName: mist.country_code
+          multiValue: false
+        mist.timezone:
+          entityTagName: mist.timezone
+          multiValue: false
+      # Add a 4 hour ttl on all tags ingested in metric api using tags. prefix
+      prefixedTags:
+        tags.:
+          ttl: PT4H
+
+ownership:
+  primaryOwner:
+    teamName: "Network Monitoring"

--- a/entity-types/infra-juniper_mist_switch/definition.stg.yml
+++ b/entity-types/infra-juniper_mist_switch/definition.stg.yml
@@ -72,7 +72,7 @@ synthesis:
     # Add a 4 hour ttl on all tags ingested in metric api using tags. prefix
     prefixedTags:
       tags.:
-        ttl: PT4H
+        ttl: P1D
 
 
 

--- a/entity-types/infra-juniper_mist_switch/definition.stg.yml
+++ b/entity-types/infra-juniper_mist_switch/definition.stg.yml
@@ -69,7 +69,7 @@ synthesis:
      
       
 
-    # Add a 4 hour ttl on all tags ingested in metric api using tags. prefix
+    # Add a 1 day ttl on all tags ingested in metric api using tags. prefix
     prefixedTags:
       tags.:
         ttl: P1D

--- a/entity-types/infra-juniper_mist_switch/definition.yml
+++ b/entity-types/infra-juniper_mist_switch/definition.yml
@@ -72,7 +72,7 @@ synthesis:
     # Add a 4 hour ttl on all tags ingested in metric api using tags. prefix
     prefixedTags:
       tags.:
-        ttl: PT4H
+        ttl: P1D
 
 
 

--- a/entity-types/infra-juniper_mist_switch/definition.yml
+++ b/entity-types/infra-juniper_mist_switch/definition.yml
@@ -69,7 +69,7 @@ synthesis:
      
       
 
-    # Add a 4 hour ttl on all tags ingested in metric api using tags. prefix
+    # Add a 1 day ttl on all tags ingested in metric api using tags. prefix
     prefixedTags:
       tags.:
         ttl: P1D

--- a/entity-types/infra-juniper_mist_switch/definition.yml
+++ b/entity-types/infra-juniper_mist_switch/definition.yml
@@ -1,0 +1,81 @@
+
+domain: INFRA
+type: JUNIPER_MIST_SWITCH
+synthesis:
+  rules:
+  - ruleName: infra_juniper_mist_switch_mac
+    name: mist.name
+    compositeIdentifier:
+      separator: ":"
+      attributes:
+        - vendor
+        - mist.org_id
+        - mist.mac
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: instrumentation.name
+      value: juniper_mist
+    - attribute: mist.device_type
+      value: switch
+    tags:
+      mist.mac:
+        entityTagName: mist.mac
+        multiValue: false
+      mist.model:
+        entityTagName: mist.model
+        multiValue: false
+      mist.ip:
+        entityTagName: mist.ip
+        multiValue: false
+      mist.device_id:  
+        entityTagName: mist.device_id
+        multiValue: false
+      mist.vc_role:
+        entityTagName: mist.vc_role
+        multiValue: false
+      mist.vc_state:
+        entityTagName: mist.vc_state
+        multiValue: false
+      mist.serial:
+        entityTagName: mist.serial
+        multiValue: false
+      mist.site_id:
+        entityTagName: mist.site_id
+        multiValue: false
+      mist.org_id:
+        entityTagName: mist.org_id
+        multiValue: false
+      mist.org_name:
+        entityTagName: mist.org_name
+        multiValue: false
+      mist.site_name:
+        entityTagName: mist.site_name
+        multiValue: false
+      vendor:
+        entityTagName: vendor
+        multiValue: false
+      mist.region:
+        entityTagName: mist.region
+        multiValue: false
+      mist.device_type:
+        entityTagName: mist.device_type
+        multiValue: false
+      mist.device_status:
+        entityTagName: mist.device_status
+        multiValue: false
+      mist.fpc_idx:
+        entityTagName: mist.fpc_idx
+        multiValue: false
+     
+      
+
+    # Add a 4 hour ttl on all tags ingested in metric api using tags. prefix
+    prefixedTags:
+      tags.:
+        ttl: PT4H
+
+
+
+ownership:
+  primaryOwner:
+    teamName: "Network Monitoring"


### PR DESCRIPTION
Adding juniper mist (site, switch, gateway, access-point) entity definition files for production.

Please find this [link](https://newrelic.atlassian.net/wiki/spaces/NNM/pages/5383553317/Juniper+Mist+Entity+Definitions) for detailed information.

ARB Jira ticket:
https://new-relic.atlassian.net/browse/NR-559202

### Checklist

* [X] I've read the guidelines and understand the acceptance criteria.
* [X] The value of the attribute marked as `identifier` will be unique and valid.
* [X] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
* [X] I've linked an ARB ticket & received approval from API Review Board in order to make these changes
