### PR TITLE
Add AWSELASTICACHEMEMCACHEDSERVERLESS to MEMCACHED relationship category

### DIFF
--- a/relationships/candidates/MEMCACHED.yml
+++ b/relationships/candidates/MEMCACHED.yml
@@ -5,6 +5,8 @@ lookups:
         type: AWSELASTICACHEMEMCACHEDCLUSTER
       - domain: INFRA
         type: AWSELASTICACHEMEMCACHEDNODE
+      - domain: INFRA
+        type: AWSELASTICACHEMEMCACHEDSERVERLESS
     tags:
       matchingMode: ALL
       predicates:


### PR DESCRIPTION
- Fixes UI display issue where Memcached serverless entities show raw entity type
- Enables proper categorization and human-readable display name
- Follows same pattern as Valkey serverless in REDIS category

### Relevant information

<!--
  Describe what you have done.
  Provide details that are relevant to the PR

  Always think that the person reviewing the PR doesn't have the context you have.

  Links to examples, documentation and similar resources make the process easier to review.
-->

<!--
  Contributions to this repository are reviewed at least twice a week

  There's no further action required once the PR has been created.
 -->

#### Api Review Board (ARB)

Any pull request with changes to this repository has to be linked with an ARB ticket, which has to be approved before merging.

If you are an external contributor please contact New Relic Support.

If you don't know about the ARB process check [this](https://newrelic.enterprise.slack.com/docs/T02D34WJD/F08AW240NSV)

ARB Jira ticket:
https://new-relic.atlassian.net/browse/NR-561974

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid.
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
* [ ] I've linked an ARB ticket & received approval from API Review Board in order to make these changes
