### PR TITLE
chore(stg): clean up otel collector test rules from EXT-SERVICE staging

### DIFF
--- a/entity-types/ext-service/definition.stg.yml
+++ b/entity-types/ext-service/definition.stg.yml
@@ -45,30 +45,6 @@ synthesis:
         entityTagName: language
       telemetry.sdk.version:
 
-    # telemetry for collector with user opt-in tag
-  - ruleName: ext_service_otel_collector
-    identifier: service.name
-    name: service.name
-    encodeIdentifierInGUID: true
-    conditions:
-    - attribute: newrelic.service.type # User Opt-In Tag
-      value: otel-collector
-    tags:
-      newrelic.service.type:
-        entityTagName: instrumentation.name
-
-    # telemetry with collector metrics
-  - ruleName: ext_service_otel_collector_2
-    identifier: service.name
-    name: service.name
-    encodeIdentifierInGUID: true
-    conditions:
-    - attribute: metricName
-      prefix: otelcol_
-    tags:
-      service.name:
-        entityTagName: otelCollector
-
     # telemetry for gen_ai otel application with user opt-in tag
   - ruleName: ext_service_gen_ai_otel_app
     identifier: service.name


### PR DESCRIPTION
### Relevant information
Removes two experimental rules from EXT-Service staging. They were created only for test purposes, and this ticket is meant to clean them up.

#### Api Review Board (ARB)
These rules are experimental and staging-only.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid.
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
* [ ] I've linked an ARB ticket & received approval from API Review Board in order to make these changes
