### PR TITLE
feat: Add AZUREVIRTUALWAN entity definition

### DIFF
--- a/entity-types/infra-azurevirtualwan/definition.yml
+++ b/entity-types/infra-azurevirtualwan/definition.yml
@@ -1,0 +1,28 @@
+domain: INFRA
+type: AZUREVIRTUALWAN
+goldenTags:
+  - azure.regionName
+  - azure.subscriptionId
+  - azure.type
+  - azure.resourceGroupName
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
+  rules:
+    - ruleName: infra_azurevirtualwan_azure_resourceId
+      identifier: azure.resourceId
+      name: displayName
+      legacyFeatures:
+        overrideGuidType: true
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: azure.resourceType
+          value: microsoft.network/virtualwans
+
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"


### PR DESCRIPTION
Add Azure Virtual WAN (microsoft.network/virtualwans) entity definition for autodiscovery / Azure 360 inventory.

Virtual WAN is a logical container with no Azure Monitor metrics of its own. Metrics are emitted by child resources (virtualHubs, vpnGateways, expressRouteGateways, p2sVpnGateways) which are already modeled by existing entity types. This definition only enables entity synthesis for inventory and relationship mapping.

ARB: https://new-relic.atlassian.net/browse/NR-551510

### Relevant information

<!--
  Describe what you have done.
  Provide details that are relevant to the PR

  Always think that the person reviewing the PR doesn't have the context you have.

  Links to examples, documentation and similar resources make the process easier to review.
-->

<!--
  Contributions to this repository are reviewed at least twice a week

  There's no further action required once the PR has been created.
 -->

#### Api Review Board (ARB)

Any pull request with changes to this repository has to be linked with an ARB ticket, which has to be approved before merging.

If you are an external contributor please contact New Relic Support.

If you don't know about the ARB process check [this](https://newrelic.enterprise.slack.com/docs/T02D34WJD/F08AW240NSV)

ARB Jira ticket:
https://new-relic.atlassian.net/browse/NR-XXXX

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid.
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
* [ ] I've linked an ARB ticket & received approval from API Review Board in order to make these changes
