### PR TITLE
feat: add GCP AlloyDB Instance Node entity definitions

### DIFF
--- a/entity-types/infra-gcpalloydbinstancenode/dashboard.json
+++ b/entity-types/infra-gcpalloydbinstancenode/dashboard.json
@@ -1,0 +1,273 @@
+{
+  "name": "GCP AlloyDB Instance Node",
+  "description": null,
+  "pages": [
+    {
+      "name": "Summary",
+      "description": null,
+      "widgets": [
+        {
+          "title": "CPU Usage",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.alloydb.node.cpu.usage_time`) AS 'CPU Usage %' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Available Memory",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.area"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.alloydb.node.memory.available_memory`) AS 'Available Memory (bytes)' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Total Connections",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.alloydb.node.postgres.backends`) AS 'Total Connections' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Connections by State",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.alloydb.node.postgres.backends_by_state`) AS 'Connections' FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.state` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Transaction Count",
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(sum(`gcp.alloydb.node.postgres.transaction_count`), 1 minute) AS 'Transactions/min' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Replication Lag",
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT max(`gcp.alloydb.node.postgres.replay_lag`) AS 'Replication Lag (ms)' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Network Received Bytes",
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(sum(`gcp.alloydb.node.network.received_bytes_count`), 1 minute) AS 'Received (bytes/min)' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Network Sent Bytes",
+          "layout": {
+            "column": 5,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(sum(`gcp.alloydb.node.network.sent_bytes_count`), 1 minute) AS 'Sent (bytes/min)' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Ultra Fast Cache Hit Rate",
+          "layout": {
+            "column": 9,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.alloydb.node.postgres.ultrafastcache_hitrate`) AS 'Cache Hit Rate' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpalloydbinstancenode/definition.yml
+++ b/entity-types/infra-gcpalloydbinstancenode/definition.yml
@@ -6,6 +6,7 @@ configuration:
 
 goldenTags:
   - gcp.projectId
+  - gcp.region
 
 ownership:
   primaryOwner:

--- a/entity-types/infra-gcpalloydbinstancenode/definition.yml
+++ b/entity-types/infra-gcpalloydbinstancenode/definition.yml
@@ -1,0 +1,9 @@
+domain: INFRA
+type: GCPALLOYDBINSTANCENODE
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-gcpalloydbinstancenode/definition.yml
+++ b/entity-types/infra-gcpalloydbinstancenode/definition.yml
@@ -4,6 +4,9 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 
+goldenTags:
+  - gcp.projectId
+
 ownership:
   primaryOwner:
     teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-gcpalloydbinstancenode/golden_metrics.yml
+++ b/entity-types/infra-gcpalloydbinstancenode/golden_metrics.yml
@@ -1,0 +1,27 @@
+cpuUsageTime:
+  title: CPU Usage
+  unit: PERCENTAGE
+  queries:
+    gcp:
+      select: average(`gcp.alloydb.node.cpu.usage_time`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+backends:
+  title: Total Connections
+  unit: COUNT
+  queries:
+    gcp:
+      select: sum(`gcp.alloydb.node.postgres.backends`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+availableMemory:
+  title: Available Memory
+  unit: BYTES
+  queries:
+    gcp:
+      select: average(`gcp.alloydb.node.memory.available_memory`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-gcpalloydbinstancenode/summary_metrics.yml
+++ b/entity-types/infra-gcpalloydbinstancenode/summary_metrics.yml
@@ -1,0 +1,22 @@
+nrAccountId:
+  tag:
+    key: nrAccount.id
+  title: NR Account ID
+  unit: STRING
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
+cpuUsageTime:
+  goldenMetric: cpuUsageTime
+  unit: PERCENTAGE
+  title: CPU Usage
+backends:
+  goldenMetric: backends
+  unit: COUNT
+  title: Total Connections
+availableMemory:
+  goldenMetric: availableMemory
+  unit: BYTES
+  title: Available Memory

--- a/entity-types/infra-gcpalloydbinstancenode/summary_metrics.yml
+++ b/entity-types/infra-gcpalloydbinstancenode/summary_metrics.yml
@@ -1,7 +1,7 @@
-nrAccountId:
+providerAccountName:
   tag:
-    key: nrAccount.id
-  title: NR Account ID
+    key: providerAccountName
+  title: GCP account
   unit: STRING
 gcpProjectId:
   tag:


### PR DESCRIPTION
## Summary

ARB Ticket - [https://new-relic.atlassian.net/browse/NR-567584](url)

- Adds `definition.yml` with `alertable: true` for `GCPALLOYDBINSTANCENODE`
- Adds `golden_metrics.yml` with 3 golden metrics: CPU usage, total connections (backends), and available memory
- Adds `summary_metrics.yml` referencing golden metrics and GCP project ID tag
- Adds `dashboard.json` with 9 widgets: CPU usage, available memory, total connections, connections by state, transaction count, replication lag, network received/sent bytes, and Ultra Fast Cache hit rate

## Entity

- **Type:** `GCPALLOYDBINSTANCENODE`
- **Provider:** GCP
- **Metrics source:** `FROM Metric WHERE collector.name = 'gcp-polling-v2'`
- **Metric prefix:** `gcp.alloydb.node.*`

## Test plan
- [ ] Validators pass: `npm --prefix validator run validate-golden-metrics && validate-summary-metrics && validate-dashboard`
- [ ] Dashboard sanitizer reports no changes
- [ ] Metrics verified against official GCP AlloyDB documentation (`alloydb.googleapis.com/InstanceNode` resource type)

🤖 Generated with [Claude Code](https://claude.com/claude-code)