### PR TITLE
NR-565682: Add golden metrics for AWS WAFv2 WebACL and RuleGroup

### DIFF
--- a/entity-types/infra-awswafv2rulegroup/definition.yml
+++ b/entity-types/infra-awswafv2rulegroup/definition.yml
@@ -5,6 +5,12 @@ goldenTags:
 - aws.awsRegion
 - aws.region
 - aws.wafv2.RuleGroup
+- aws.wafv2.Scope
+- account
+- label.Team
+- label.team
+- label.env
+- label.environment
 configuration:
   entityExpirationTime: DAILY
   alertable: true

--- a/entity-types/infra-awswafv2rulegroup/definition.yml
+++ b/entity-types/infra-awswafv2rulegroup/definition.yml
@@ -1,5 +1,10 @@
 domain: INFRA
 type: AWSWAFV2RULEGROUP
+goldenTags:
+- aws.accountId
+- aws.awsRegion
+- aws.region
+- aws.wafv2.RuleGroup
 configuration:
   entityExpirationTime: DAILY
   alertable: true

--- a/entity-types/infra-awswafv2rulegroup/golden_metrics.yml
+++ b/entity-types/infra-awswafv2rulegroup/golden_metrics.yml
@@ -1,0 +1,36 @@
+allowedRequests:
+  title: Allowed requests
+  unit: COUNT
+  queries:
+    aws:
+      select: sum(aws.wafv2.AllowedRequests)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+blockedRequests:
+  title: Blocked requests
+  unit: COUNT
+  queries:
+    aws:
+      select: sum(aws.wafv2.BlockedRequests)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+countedRequests:
+  title: Counted requests
+  unit: COUNT
+  queries:
+    aws:
+      select: sum(aws.wafv2.CountedRequests)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+passedRequests:
+  title: Passed requests
+  unit: COUNT
+  queries:
+    aws:
+      select: sum(aws.wafv2.PassedRequests)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-awswafv2rulegroup/summary_metrics.yml
+++ b/entity-types/infra-awswafv2rulegroup/summary_metrics.yml
@@ -1,0 +1,13 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: AWS account
+  unit: STRING
+allowedRequests:
+  goldenMetric: allowedRequests
+  unit: COUNT
+  title: Allowed
+blockedRequests:
+  goldenMetric: blockedRequests
+  unit: COUNT
+  title: Blocked

--- a/entity-types/infra-awswafv2webacl/definition.yml
+++ b/entity-types/infra-awswafv2webacl/definition.yml
@@ -1,5 +1,11 @@
 domain: INFRA
 type: AWSWAFV2WEBACL
+goldenTags:
+- aws.accountId
+- aws.awsRegion
+- aws.region
+- aws.wafv2.WebACL
+- aws.wafv2.Scope
 configuration:
   entityExpirationTime: DAILY
   alertable: true

--- a/entity-types/infra-awswafv2webacl/definition.yml
+++ b/entity-types/infra-awswafv2webacl/definition.yml
@@ -6,6 +6,11 @@ goldenTags:
 - aws.region
 - aws.wafv2.WebACL
 - aws.wafv2.Scope
+- account
+- label.Team
+- label.team
+- label.env
+- label.environment
 configuration:
   entityExpirationTime: DAILY
   alertable: true

--- a/entity-types/infra-awswafv2webacl/golden_metrics.yml
+++ b/entity-types/infra-awswafv2webacl/golden_metrics.yml
@@ -1,0 +1,36 @@
+allowedRequests:
+  title: Allowed requests
+  unit: COUNT
+  queries:
+    aws:
+      select: sum(aws.wafv2.AllowedRequests)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+blockedRequests:
+  title: Blocked requests
+  unit: COUNT
+  queries:
+    aws:
+      select: sum(aws.wafv2.BlockedRequests)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+countedRequests:
+  title: Counted requests
+  unit: COUNT
+  queries:
+    aws:
+      select: sum(aws.wafv2.CountedRequests)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+passedRequests:
+  title: Passed requests
+  unit: COUNT
+  queries:
+    aws:
+      select: sum(aws.wafv2.PassedRequests)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-awswafv2webacl/summary_metrics.yml
+++ b/entity-types/infra-awswafv2webacl/summary_metrics.yml
@@ -1,0 +1,13 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: AWS account
+  unit: STRING
+allowedRequests:
+  goldenMetric: allowedRequests
+  unit: COUNT
+  title: Allowed
+blockedRequests:
+  goldenMetric: blockedRequests
+  unit: COUNT
+  title: Blocked


### PR DESCRIPTION
## Summary

Completes the entity-type definitions for AWS WAFv2 WebACL (`AWSWAFV2WEBACL`) and RuleGroup (`AWSWAFV2RULEGROUP`). Both entity types existed only as stubs (`definition.yml` with domain/type/expiration); no golden metrics, summary metrics, or golden tags were defined, so the UI was blank for these entities.

CloudWatch Metric Streams currently emits ~2.8M `AWS/WAFV2` metric points/day to New Relic with **zero** `entity.guid` attached because no synthesizer rules existed. Companion PRs in `beyond-common` and `beyond-cloudwatch-metrics-stream-processor` add the synthesis rules; this PR makes the resulting entities renderable.

## Changes

- **`entity-types/infra-awswafv2webacl/`**
  - `definition.yml` — added `goldenTags` (account, region, WebACL, Scope, plus `account` and `label.*` for parity with ALB/Lambda)
  - `golden_metrics.yml` (new) — 4 metrics: `allowedRequests`, `blockedRequests`, `countedRequests`, `passedRequests`
  - `summary_metrics.yml` (new) — provider account + Allowed/Blocked summary
- **`entity-types/infra-awswafv2rulegroup/`** — same shape, with `aws.wafv2.RuleGroup` substituted

## Notes

- **CWMS-only**: `golden_metrics.yml` contains only the `aws:` (Metric) query block. AWS WAFv2 polling is not currently supported (`SimpleAwsJob.java:439-449` returns `null` because CloudWatch dimensions don't carry the WAFv2 ARN id), so there is no `awsSample` block.
- **No `synthesis:` rules added**: Entity creation is driven by `BeyondEntitySynthesis` events emitted by the CWMS processor, matching the pattern used by other recent CWMS-only entity types like `AWSELASTICACHEVALKEYSERVERLESS` and `AWSELASTICACHEMEMCACHEDSERVERLESS`.
- **Metric attribute names** verified against `beyond-worker/src/dist/config/integrations/aws/aws_wafv2.yml`: `AllowedRequests`, `BlockedRequests`, `CountedRequests`, `PassedRequests` — all `Sum` / `Count`.

## Test plan

- [x] `npx ajv validate` against `entity-schema-v1.json`, `golden-metrics-schema-v1.json`, `summary-metrics-schema-v1.json` — all 6 files valid
- [x] `node tools/validate_folders.js` — passes
- [x] `node tools/validate_rules.js` — passes
- [ ] CI validation in this PR
- [ ] After companion PRs merge: verify entities synthesize in production with golden metrics rendering in the UI
- [ ] Verify `aws.wafv2.Scope` is actually populated on synthesized entities; drop from `goldenTags` if absent

## Companion PRs

- `beyond-common`: adds `AWS/WAFV2` block to `aws-entity-definitions.yml` covering all observed dimension permutations
- `beyond-cloudwatch-metrics-stream-processor`: bumps `beyond-common`, adds test rows in `AwsEntityDefinitionSpec`

JIRA: https://new-relic.atlassian.net/browse/NR-565682


Relevant information
Api Review Board (ARB)
Any pull request with changes to this repository has to be linked with an ARB ticket, which has to be approved before merging.

If you are an external contributor please contact New Relic Support.

If you don't know about the ARB process check [this](https://newrelic.enterprise.slack.com/docs/T02D34WJD/F08AW240NSV)

ARB Jira ticket:
https://new-relic.atlassian.net/browse/NR-567400