### PR TITLE
feat(gcp-memcache): add summary_metrics and dashboard for GCPMEMCACHEMEMCACHENODE

### DIFF
--- a/entity-types/infra-gcpmemcachememcachenode/dashboard.json
+++ b/entity-types/infra-gcpmemcachememcachenode/dashboard.json
@@ -1,0 +1,273 @@
+{
+  "name": "GCP Memcache Node",
+  "description": null,
+  "pages": [
+    {
+      "name": "GCP Memcache Node",
+      "description": null,
+      "widgets": [
+        {
+          "title": "Active Connections",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT average(`gcp.memcache.memcacheNode.node.activeConnections`) AS 'Active Connections' WHERE `entity.guid` = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "CPU Utilization (%)",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT average(`gcp.memcache.memcacheNode.node.cpu.utilization`) AS 'CPU %' WHERE `entity.guid` = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Cache Hit Ratio (%)",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT average(`gcp.memcache.memcacheNode.node.hitRatio`) AS 'Hit Ratio %' WHERE `entity.guid` = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Items Stored",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT average(`gcp.memcache.memcacheNode.node.items`) AS 'Items' WHERE `entity.guid` = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Cache Memory (bytes)",
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT average(`gcp.memcache.memcacheNode.node.cacheMemory`) AS 'Cache Memory (bytes)' WHERE `entity.guid` = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Evictions",
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT sum(`gcp.memcache.memcacheNode.node.eviction`) AS 'Evictions' WHERE `entity.guid` = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Operations",
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT sum(`gcp.memcache.memcacheNode.node.operation`) AS 'Operations' WHERE `entity.guid` = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Received Bytes",
+          "layout": {
+            "column": 5,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT sum(`gcp.memcache.memcacheNode.node.receivedBytes`) AS 'Received Bytes' WHERE `entity.guid` = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Sent Bytes",
+          "layout": {
+            "column": 9,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT sum(`gcp.memcache.memcacheNode.node.sentBytes`) AS 'Sent Bytes' WHERE `entity.guid` = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpmemcachememcachenode/summary_metrics.yml
+++ b/entity-types/infra-gcpmemcachememcachenode/summary_metrics.yml
@@ -1,0 +1,21 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: GCP account
+  unit: STRING
+connectionsActive:
+  goldenMetric: connectionsActive
+  unit: COUNT
+  title: Connections active
+cpuUsage:
+  goldenMetric: cpuUsage
+  unit: PERCENTAGE
+  title: CPU usage (%)
+hitRatio:
+  goldenMetric: hitRatio
+  unit: PERCENTAGE
+  title: Hit ratio (%)
+itemsStored:
+  goldenMetric: itemsStored
+  unit: COUNT
+  title: Items stored


### PR DESCRIPTION
## Summary

- Add `summary_metrics.yml` for `infra-gcpmemcachememcachenode` entity with golden metric references and tag entry for GCP account
- Add `dashboard.json` with 9 widgets covering the key Memcache node metrics using `FROM Metric` (gcp-polling-v2): active connections, CPU utilization, hit ratio, items stored, cache memory, evictions, operations, received bytes, sent bytes

## Test plan

- [ ] Dashboard JSON sanitizer ran clean (`npm --prefix validator run sanitize-dashboards`)
- [ ] All schema validators pass (`validate-definition`, `validate-summary-metrics`, `validate-golden-metrics`, `validate-dashboard`)
- [ ] Metric names consistent with existing `golden_metrics.yml` entries already in repo
- [ ] ⚠️ No live `GCPMEMCACHEMEMCACHENODE` entities found in validation accounts (10876283, 686923, 10018487) — metric names verified against official GCP documentation and query syntax validated (no NRQL errors)

## Related PRs (merge together)

- entity-type-ui-definitions-service: `feat/gcp-memcache-ui`
- infra-summary: `feat/gcp-memcache-dashboard`
- infrastructure: `feat/gcp-memcache-infra-metrics`

🤖 Generated with [Claude Code](https://claude.com/claude-code)