### PR TITLE
feat(nginx): add entity synthesis rules for NGINXSERVER instrumented using prometheus receiver

### DIFF
--- a/entity-types/infra-nginxserver/definition.stg.yml
+++ b/entity-types/infra-nginxserver/definition.stg.yml
@@ -1,0 +1,231 @@
+domain: INFRA
+type: NGINXSERVER
+
+goldenTags:
+- nginx.port
+- nginx.version
+- nginx.edition
+- nginx.hostname
+
+synthesis:
+  rules:
+  - ruleName: infra_nginxserver_composite
+    compositeIdentifier:
+      separator: ":"
+      attributes:
+        - nginx.deployment.name
+        - nginx.server.endpoint
+    name: nginx.display.name
+    encodeIdentifierInGUID: true
+    conditions:
+      - attribute: eventType
+        value: Metric
+      - attribute: nginx.deployment.name
+        present: true
+      - attribute: nginx.server.endpoint
+        present: true
+      - attribute: nginx.display.name
+        present: true
+      # All metrics from the receiver starts with the 'nginx.' prefix.
+      - attribute: metricName
+        prefix: nginx.
+      - attribute: instrumentation.provider
+        value: opentelemetry
+      # This filters only metrics coming from nginx receiver, given that metrics
+      # could differ between different runtime receivers.
+      - attribute: otel.library.name
+        value: "otelcol/nginxreceiver"
+    tags:
+      # Default resource attributes
+      nginx.server.endpoint:
+      # OTel attributes
+      # The library name contains the name of the receiver that is used to identify the source
+      # and select the dashboard.
+      otel.library.name:
+        entityTagName: instrumentation.name
+  - ruleName: infra_nginxserver_composite_2
+    compositeIdentifier:
+      separator: ":"
+      attributes:
+        - nginx.deployment.name
+        - nginx.server.endpoint
+    name: nginx.display.name
+    encodeIdentifierInGUID: true
+    conditions:
+      - attribute: eventType
+        value: Metric
+      - attribute: nginx.deployment.name
+        present: true
+      - attribute: nginx.server.endpoint
+        present: true
+      - attribute: nginx.display.name
+        present: true
+      # All metrics from the receiver starts with the 'nginx.' prefix.
+      - attribute: metricName
+        prefix: nginx.
+      - attribute: instrumentation.provider
+        value: opentelemetry
+      # This filters only metrics coming from nginx receiver, given that metrics
+      # could differ between different runtime receivers.
+      - attribute: otel.library.name
+        value: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiver"
+    tags:
+      # Default resource attributes
+      nginx.server.endpoint:
+      # OTel attributes
+      # The library name contains the name of the receiver that is used to identify the source
+      # and select the dashboard.
+      otel.library.name:
+        entityTagName: instrumentation.name
+  - ruleName: infra_nginxserver_composite_3
+    compositeIdentifier:
+      separator: ":"
+      attributes:
+        - nginx.deployment.name
+        - nginx.server.endpoint
+    name: nginx.display.name
+    encodeIdentifierInGUID: true
+    conditions:
+      - attribute: eventType
+        value: Metric
+      - attribute: nginx.deployment.name
+        present: true
+      - attribute: nginx.server.endpoint
+        present: true
+      - attribute: nginx.display.name
+        present: true
+      - attribute: metricName
+        prefix: nginxplus_
+      - attribute: instrumentation.provider
+        value: opentelemetry
+      - attribute: otel.library.name
+        value: "otelcol/prometheusreceiver"
+    tags:
+      nginx.server.endpoint:
+      otel.library.name:
+        entityTagName: instrumentation.name
+  - ruleName: infra_nginxserver_composite_4
+    compositeIdentifier:
+      separator: ":"
+      attributes:
+        - nginx.deployment.name
+        - nginx.server.endpoint
+    name: nginx.display.name
+    encodeIdentifierInGUID: true
+    conditions:
+      - attribute: eventType
+        value: Metric
+      - attribute: nginx.deployment.name
+        present: true
+      - attribute: nginx.server.endpoint
+        present: true
+      - attribute: nginx.display.name
+        present: true
+      - attribute: metricName
+        prefix: nginxplus_
+      - attribute: instrumentation.provider
+        value: opentelemetry
+      - attribute: otel.library.name
+        value: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver"
+    tags:
+      nginx.server.endpoint:
+      otel.library.name:
+        entityTagName: instrumentation.name
+  - ruleName: infra_nginxserver_composite_5
+    compositeIdentifier:
+      separator: ":"
+      attributes:
+        - nginx.deployment.name
+        - nginx.server.endpoint
+    name: nginx.display.name
+    encodeIdentifierInGUID: true
+    conditions:
+      - attribute: eventType
+        value: Log
+      - attribute: newrelic.source
+        value: 'api.logs.otlp'
+      - attribute: nginx.deployment.name
+        present: true
+      - attribute: nginx.server.endpoint
+        present: true
+      - attribute: nginx.display.name
+        present: true
+      - attribute: instrumentation.provider
+        value: opentelemetry
+    tags:
+      nginx.server.endpoint:
+  - ruleName: infra_nginxserver_composite_6
+    compositeIdentifier:
+      separator: ":"
+      attributes:
+        - nginx.deployment.name
+        - nginx.server.endpoint
+    name: nginx.display.name
+    encodeIdentifierInGUID: true
+    conditions:
+      - attribute: eventType
+        value: Metric
+      - attribute: nginx.deployment.name
+        present: true
+      - attribute: nginx.server.endpoint
+        present: true
+      - attribute: nginx.display.name
+        present: true
+      - attribute: metricName
+        prefix: nginx.
+      - attribute: instrumentation.provider
+        value: opentelemetry
+      - attribute: otel.library.name
+        value: "otelcol/prometheusreceiver"
+    tags:
+      nginx.server.endpoint:
+      otel.library.name:
+        entityTagName: instrumentation.name
+  - ruleName: infra_nginxserver_composite_7
+    compositeIdentifier:
+      separator: ":"
+      attributes:
+        - nginx.deployment.name
+        - nginx.server.endpoint
+    name: nginx.display.name
+    encodeIdentifierInGUID: true
+    conditions:
+      - attribute: eventType
+        value: Metric
+      - attribute: nginx.deployment.name
+        present: true
+      - attribute: nginx.server.endpoint
+        present: true
+      - attribute: nginx.display.name
+        present: true
+      - attribute: metricName
+        prefix: nginx.
+      - attribute: instrumentation.provider
+        value: opentelemetry
+      - attribute: otel.library.name
+        value: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver"
+    tags:
+      nginx.server.endpoint:
+      otel.library.name:
+        entityTagName: instrumentation.name
+
+  tags:
+    # For OpenTelemetry
+    telemetry.sdk.name:
+      entityTagName: instrumentation.provider
+
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+
+dashboardTemplates:
+  # This should match the entity created from the ohi in the infra pipeline
+  newRelic:
+    template: newrelic_dashboard.json
+  # otel receiver
+  opentelemetry:
+    template: opentelemetry_dashboard.json
+
+ownership:
+  primaryOwner:
+    teamName: "OnHost Agent and Integrations"

--- a/entity-types/infra-nginxserver/tests/Metric.stg.json
+++ b/entity-types/infra-nginxserver/tests/Metric.stg.json
@@ -1,0 +1,100 @@
+[
+    {
+        "description": "The current number of nginx connections by state",
+        "instrumentation.provider": "opentelemetry",
+        "metricName": "nginx.connections_current",
+        "newrelic.source": "api.metrics.otlp",
+        "nginx.connections_current": {
+            "type": "gauge",
+            "count": 1,
+            "sum": 1,
+            "min": 1,
+            "max": 1,
+            "latest": 1
+        },
+        "nginx.deployment.name": "nginx-3",
+        "nginx.display.name": "server:nginx-3",
+        "nginx.server.endpoint": "http://127.0.0.1:8081/basic_status",
+        "otel.library.name": "otelcol/nginxreceiver",
+        "otel.library.version": "0.82.0",
+        "state": "active",
+        "timestamp": 1757422823441,
+        "unit": "connections"
+    },
+    {
+        "description": "The current number of nginx connections by state",
+        "instrumentation.provider": "opentelemetry",
+        "metricName": "nginx.connections_current",
+        "newrelic.source": "api.metrics.otlp",
+        "nginx.connections_current": {
+            "type": "gauge",
+            "count": 1,
+            "sum": 1,
+            "min": 1,
+            "max": 1,
+            "latest": 1
+        },
+        "nginx.deployment.name": "nginx-1",
+        "nginx.display.name": "server:nginx-1",
+        "nginx.server.endpoint": "http://nginx:8080/basic_status",
+        "otel.library.name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiver",
+        "otel.library.version": "0.121.0",
+        "state": "active",
+        "timestamp": 1758198462460,
+        "unit": "connections"
+    },
+    {
+        "description": "Active client connections",
+        "http.scheme": "http",
+        "instrumentation.provider": "opentelemetry",
+        "metricName": "nginxplus_connections_active",
+        "net.host.port": "9113",
+        "newrelic.source": "api.metrics.otlp",
+        "nginx.deployment.name": "nginx-plus-1",
+        "nginx.display.name": "server:nginx-plus-1",
+        "nginx.server.endpoint": "http://127.0.0.1/api/9",
+        "nginxplus_connections_active": {
+            "type": "gauge",
+            "count": 1,
+            "sum": 1,
+            "min": 1,
+            "max": 1,
+            "latest": 1
+        },
+        "os.type": "linux",
+        "otel.library.name": "otelcol/prometheusreceiver",
+        "otel.library.version": "0.82.0",
+        "service.instance.id": "127.0.0.1:9113",
+        "service.name": "",
+        "timestamp": 1761287839186
+    },
+    {
+        "cloud.account.id": "1234567890",
+        "cloud.availability_zone": "us-east-2a",
+        "cloud.platform": "aws_ec2",
+        "cloud.provider": "aws",
+        "cloud.region": "us-east-2",
+        "host.id": "i-09b87d10fba55604e",
+        "host.image.id": "ami-0c2b8ca1dad447f8",
+        "host.type": "t2.large",
+        "instrumentation.provider": "opentelemetry",
+        "metricName": "nginx.connections_current",
+        "newrelic.source": "api.metrics.otlp",
+        "nginx.connections_current": {
+            "type": "gauge",
+            "count": 1,
+            "sum": 0,
+            "min": 0,
+            "max": 0,
+            "latest": 0
+        },
+        "nginx.deployment.name": "test-edge-02",
+        "nginx.display.name": "server:test-edge-02",
+        "nginx.server.endpoint": "http://127.0.0.1:8080/nginx_status",
+        "os.type": "linux",
+        "otel.library.name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel.library.version": "1.15.1",
+        "state": "reading",
+        "timestamp": 1779694506390
+    }
+]

--- a/relationships/synthesis/INFRA-HOST-to-INFRA-NGINXSERVER.stg.yml
+++ b/relationships/synthesis/INFRA-HOST-to-INFRA-NGINXSERVER.stg.yml
@@ -74,3 +74,73 @@ relationships:
           attribute: entityGuid
           entityType:
             value: NGINXServer
+
+  - name: oTelHostHostsNginxServerStg
+    version: "1"
+    origins:
+      - OpenTelemetry
+    conditions:
+      - attribute: eventType
+        anyOf: [ "Metric" ]
+      - attribute: metricName
+        startsWith: nginx.
+      - attribute: instrumentation.provider
+        anyOf: [ "opentelemetry" ]
+      - attribute: host.id
+        present: true
+    relationship:
+      expires: PT75M
+      relationshipType: HOSTS
+      source:
+        buildGuid:
+          account:
+            attribute: accountId
+          domain:
+            value: INFRA
+          type:
+            value: HOST
+            valueInGuid: NA
+          identifier:
+            fragments:
+              - attribute: host.id
+            hashAlgorithm: FARM_HASH
+      target:
+        extractGuid:
+          attribute: entity.guid
+          entityType:
+            value: NGINXSERVER
+
+  - name: oTelHostHostsNginxPlusServerStg
+    version: "1"
+    origins:
+      - OpenTelemetry
+    conditions:
+      - attribute: eventType
+        anyOf: [ "Metric" ]
+      - attribute: metricName
+        startsWith: nginxplus_
+      - attribute: instrumentation.provider
+        anyOf: [ "opentelemetry" ]
+      - attribute: host.id
+        present: true
+    relationship:
+      expires: PT75M
+      relationshipType: HOSTS
+      source:
+        buildGuid:
+          account:
+            attribute: accountId
+          domain:
+            value: INFRA
+          type:
+            value: HOST
+            valueInGuid: NA
+          identifier:
+            fragments:
+              - attribute: host.id
+            hashAlgorithm: FARM_HASH
+      target:
+        extractGuid:
+          attribute: entity.guid
+          entityType:
+            value: NGINXSERVER


### PR DESCRIPTION
### Relevant information

- Add entity synthesis rules for creating NGINXSERVER entity when instrumented using otel promtheusreceiver
- Add the same relationship synthesis rules from prod in staging to create INFRA-HOST -> INFRA-NGINXSERVER links

#### Api Review Board (ARB)

Any pull request with changes to this repository has to be linked with an ARB ticket, which has to be approved before merging.

If you are an external contributor please contact New Relic Support.

If you don't know about the ARB process check [this](https://newrelic.enterprise.slack.com/docs/T02D34WJD/F08AW240NSV)

ARB Jira ticket:
https://new-relic.atlassian.net/browse/NR-568582

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid.
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
* [x] I've linked an ARB ticket & received approval from API Review Board in order to make these changes
