### PR TITLE
feat: Add GCPPUBSUBSNAPSHOT entity definition

### DIFF
--- a/entity-types/infra-gcppubsubsnapshot/dashboard.json
+++ b/entity-types/infra-gcppubsubsnapshot/dashboard.json
@@ -1,0 +1,215 @@
+{
+  "name": "GCP Pub/Sub Snapshot",
+  "description": null,
+  "pages": [
+    {
+      "name": "Summary",
+      "description": null,
+      "widgets": [
+        {
+          "title": "Snapshot Messages",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.pubsub.snapshot.num_messages`) AS 'Messages' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Snapshot Backlog Bytes",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.pubsub.snapshot.backlog_bytes`) AS 'Backlog Bytes' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Oldest Message Age (s)",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT max(`gcp.pubsub.snapshot.oldest_message_age`) AS 'Oldest Message Age (s)' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Messages by Region",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.pubsub.snapshot.num_messages_by_region`) AS 'Messages' FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.region` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Backlog Bytes by Region",
+          "layout": {
+            "column": 7,
+            "row": 4,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.pubsub.snapshot.backlog_bytes_by_region`) AS 'Backlog Bytes' FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.region` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Oldest Message Age by Region (s)",
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT max(`gcp.pubsub.snapshot.oldest_message_age_by_region`) AS 'Oldest Message Age (s)' FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.region` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Configuration Operations",
+          "layout": {
+            "column": 7,
+            "row": 7,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(sum(`gcp.pubsub.snapshot.config_updates_count`), 1 minute) AS 'Config Ops/min' FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.response_code` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcppubsubsnapshot/definition.yml
+++ b/entity-types/infra-gcppubsubsnapshot/definition.yml
@@ -1,0 +1,11 @@
+domain: INFRA
+type: GCPPUBSUBSNAPSHOT
+goldenTags:
+- gcp.projectId
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-gcppubsubsnapshot/golden_metrics.yml
+++ b/entity-types/infra-gcppubsubsnapshot/golden_metrics.yml
@@ -1,0 +1,27 @@
+numMessages:
+  title: Snapshot messages
+  unit: COUNT
+  queries:
+    gcp:
+      select: sum(`gcp.pubsub.snapshot.num_messages`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+backlogBytes:
+  title: Snapshot backlog bytes
+  unit: BYTES
+  queries:
+    gcp:
+      select: sum(`gcp.pubsub.snapshot.backlog_bytes`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+oldestMessageAge:
+  title: Oldest message age (s)
+  unit: SECONDS
+  queries:
+    gcp:
+      select: max(`gcp.pubsub.snapshot.oldest_message_age`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-gcppubsubsnapshot/summary_metrics.yml
+++ b/entity-types/infra-gcppubsubsnapshot/summary_metrics.yml
@@ -1,0 +1,22 @@
+nrAccountId:
+  tag:
+    key: nrAccount.id
+  title: NR Account ID
+  unit: STRING
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
+numMessages:
+  goldenMetric: numMessages
+  unit: COUNT
+  title: Snapshot messages
+backlogBytes:
+  goldenMetric: backlogBytes
+  unit: BYTES
+  title: Snapshot backlog bytes
+oldestMessageAge:
+  goldenMetric: oldestMessageAge
+  unit: SECONDS
+  title: Oldest message age (s)


### PR DESCRIPTION
### Relevant information

Adding GCPPUBSUBSNAPSHOT entity definition for GCP Pub/Sub Snapshot.

This PR adds:
- `definition.yml` with `alertable: true` and `gcp.projectId` golden tag
- `golden_metrics.yml` with 3 key metrics: numMessages, backlogBytes, oldestMessageAge
- `summary_metrics.yml` with NR account ID, GCP project ID, and golden metrics
- `dashboard.json` with 7 widgets covering all snapshot metrics (messages, backlog bytes, oldest message age, regional breakdowns, config operations)

**Metrics source:** Official GCP Cloud Monitoring documentation (`pubsub_snapshot` monitored resource type)
- `gcp.pubsub.snapshot.num_messages` (GAUGE)
- `gcp.pubsub.snapshot.backlog_bytes` (GAUGE)
- `gcp.pubsub.snapshot.oldest_message_age` (GAUGE)
- `gcp.pubsub.snapshot.num_messages_by_region` (GAUGE)
- `gcp.pubsub.snapshot.backlog_bytes_by_region` (GAUGE)
- `gcp.pubsub.snapshot.oldest_message_age_by_region` (GAUGE)
- `gcp.pubsub.snapshot.config_updates_count` (DELTA)

**Validation:** All NRQL queries validated via NR MCP against account 10876283. Core metrics (num_messages, backlog_bytes, config_updates_count) confirmed present. oldest_message_age returns null in the test environment as there are currently no active snapshots with retained messages — metric names verified against official GCP documentation.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid.
* [x] I've confirmed that my entity type wasn't already defined.