### PR TITLE
feat(GCPMEMORYSTOREINSTANCE): add GCP Memorystore Instance entity definition

### DIFF
--- a/entity-types/infra-gcpmemorystoreinstance/dashboard.json
+++ b/entity-types/infra-gcpmemorystoreinstance/dashboard.json
@@ -1,0 +1,244 @@
+{
+  "name": "GCP Memorystore Instance",
+  "description": null,
+  "pages": [
+    {
+      "name": "Summary",
+      "description": null,
+      "widgets": [
+        {
+          "title": "CPU Average Utilization (%)",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.memorystore.instance.cpu.average_utilization`) * 100 AS 'CPU Utilization %' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Memory Average Utilization (%)",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.memorystore.instance.memory.average_utilization`) * 100 AS 'Memory Utilization %' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Commands (calls/min)",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(sum(`gcp.memorystore.instance.commandstats.total_calls_count`), 1 minute) AS 'Commands/min' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Total Memory Used (bytes)",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.memorystore.instance.memory.total_used_memory`) AS 'Memory Used (bytes)' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Connected Clients",
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.memorystore.instance.clients.total_connected_clients`) AS 'Connected Clients' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Keyspace Hits vs Misses",
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.memorystore.instance.stats.average_keyspace_hits`) AS 'Keyspace Hits', average(`gcp.memorystore.instance.stats.average_keyspace_misses`) AS 'Keyspace Misses' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Network Input/Output (bytes)",
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(sum(`gcp.memorystore.instance.stats.total_net_input_bytes_count`), 1 minute) AS 'Input bytes/min', rate(sum(`gcp.memorystore.instance.stats.total_net_output_bytes_count`), 1 minute) AS 'Output bytes/min' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Evicted Keys",
+          "layout": {
+            "column": 7,
+            "row": 7,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.memorystore.instance.stats.average_evicted_keys`) AS 'Avg Evicted Keys' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpmemorystoreinstance/definition.yml
+++ b/entity-types/infra-gcpmemorystoreinstance/definition.yml
@@ -1,0 +1,11 @@
+domain: INFRA
+type: GCPMEMORYSTOREINSTANCE
+goldenTags:
+- gcp.projectId
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-gcpmemorystoreinstance/golden_metrics.yml
+++ b/entity-types/infra-gcpmemorystoreinstance/golden_metrics.yml
@@ -1,0 +1,27 @@
+cpuAverageUtilization:
+  title: CPU average utilization (%)
+  unit: PERCENTAGE
+  queries:
+    gcp:
+      select: average(gcp.memorystore.instance.cpu.average_utilization) * 100
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+memoryAverageUtilization:
+  title: Memory average utilization (%)
+  unit: PERCENTAGE
+  queries:
+    gcp:
+      select: average(gcp.memorystore.instance.memory.average_utilization) * 100
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+commandsTotalCallsCount:
+  title: Commands (calls/min)
+  unit: COUNT
+  queries:
+    gcp:
+      select: rate(sum(gcp.memorystore.instance.commandstats.total_calls_count), 1 minute)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-gcpmemorystoreinstance/summary_metrics.yml
+++ b/entity-types/infra-gcpmemorystoreinstance/summary_metrics.yml
@@ -1,0 +1,22 @@
+nrAccountId:
+  tag:
+    key: nrAccount.id
+  title: NR Account ID
+  unit: STRING
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
+cpuAverageUtilization:
+  goldenMetric: cpuAverageUtilization
+  unit: PERCENTAGE
+  title: CPU average utilization (%)
+memoryAverageUtilization:
+  goldenMetric: memoryAverageUtilization
+  unit: PERCENTAGE
+  title: Memory average utilization (%)
+commandsTotalCallsCount:
+  goldenMetric: commandsTotalCallsCount
+  unit: COUNT
+  title: Commands (calls/min)


### PR DESCRIPTION
## Summary

- Adds `INFRA/GCPMEMORYSTOREINSTANCE` entity definition for GCP Memorystore for Valkey instances (`memorystore.googleapis.com/Instance`)
- **definition.yml**: domain INFRA, type GCPMEMORYSTOREINSTANCE, alertable, `gcp.projectId` golden tag
- **golden_metrics.yml**: 3 metrics — CPU average utilization (%), memory average utilization (%), commands/min
- **summary_metrics.yml**: NR account, GCP project, and all three golden metrics
- **dashboard.json**: 8-widget dashboard covering CPU, memory, commands, connected clients, keyspace hits/misses, network I/O, and evicted keys

## Metric source

All metrics sourced from [GCP Memorystore for Valkey supported-monitoring-metrics](https://docs.cloud.google.com/memorystore/docs/valkey/supported-monitoring-metrics) documentation.
Metric naming pattern: `memorystore.googleapis.com/instance/X/Y` → `gcp.memorystore.instance.X.Y`

## Validation

All queries validated against NR MCP (account 10876283, 686923, 12208939). No live Memorystore instances found in any account — metric names confirmed against official GCP documentation, query syntax validated without errors.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)