### PR TITLE
feat: add GCPREDISCLUSTERNODE entity for GCP Memorystore Redis Cluster Node

### DIFF
--- a/entity-types/infra-gcpmemcachememcachenode/dashboard.json
+++ b/entity-types/infra-gcpmemcachememcachenode/dashboard.json
@@ -1,0 +1,273 @@
+{
+  "name": "GCP Memcache Node",
+  "description": null,
+  "pages": [
+    {
+      "name": "GCP Memcache Node",
+      "description": null,
+      "widgets": [
+        {
+          "title": "Active Connections",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT average(`gcp.memcache.memcacheNode.node.activeConnections`) AS 'Active Connections' WHERE `entity.guid` = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "CPU Utilization (%)",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT average(`gcp.memcache.memcacheNode.node.cpu.utilization`) AS 'CPU %' WHERE `entity.guid` = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Cache Hit Ratio (%)",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT average(`gcp.memcache.memcacheNode.node.hitRatio`) AS 'Hit Ratio %' WHERE `entity.guid` = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Items Stored",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT average(`gcp.memcache.memcacheNode.node.items`) AS 'Items' WHERE `entity.guid` = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Cache Memory (bytes)",
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT average(`gcp.memcache.memcacheNode.node.cacheMemory`) AS 'Cache Memory (bytes)' WHERE `entity.guid` = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Evictions",
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT sum(`gcp.memcache.memcacheNode.node.eviction`) AS 'Evictions' WHERE `entity.guid` = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Operations",
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT sum(`gcp.memcache.memcacheNode.node.operation`) AS 'Operations' WHERE `entity.guid` = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Received Bytes",
+          "layout": {
+            "column": 5,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT sum(`gcp.memcache.memcacheNode.node.receivedBytes`) AS 'Received Bytes' WHERE `entity.guid` = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Sent Bytes",
+          "layout": {
+            "column": 9,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT sum(`gcp.memcache.memcacheNode.node.sentBytes`) AS 'Sent Bytes' WHERE `entity.guid` = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpmemcachememcachenode/summary_metrics.yml
+++ b/entity-types/infra-gcpmemcachememcachenode/summary_metrics.yml
@@ -1,0 +1,21 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: GCP account
+  unit: STRING
+connectionsActive:
+  goldenMetric: connectionsActive
+  unit: COUNT
+  title: Connections active
+cpuUsage:
+  goldenMetric: cpuUsage
+  unit: PERCENTAGE
+  title: CPU usage (%)
+hitRatio:
+  goldenMetric: hitRatio
+  unit: PERCENTAGE
+  title: Hit ratio (%)
+itemsStored:
+  goldenMetric: itemsStored
+  unit: COUNT
+  title: Items stored

--- a/entity-types/infra-gcpredisclusternode/dashboard.json
+++ b/entity-types/infra-gcpredisclusternode/dashboard.json
@@ -1,0 +1,273 @@
+{
+  "name": "GCP Memorystore Redis Cluster Node",
+  "description": null,
+  "pages": [
+    {
+      "name": "GCP Memorystore Redis Cluster Node",
+      "description": null,
+      "widgets": [
+        {
+          "title": "CPU Utilization (%)",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT average(`gcp.redis.cluster.node.cpu.utilization`) * 100 AS 'CPU %' WHERE `entity.guid` = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Memory Utilization (%)",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT average(`gcp.redis.cluster.node.memory.utilization`) * 100 AS 'Memory %' WHERE `entity.guid` = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Connected Clients",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT average(`gcp.redis.cluster.node.clients.connected_clients`) AS 'Connected Clients' WHERE `entity.guid` = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Memory Usage (bytes)",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT average(`gcp.redis.cluster.node.memory.usage`) AS 'Memory Usage (bytes)' WHERE `entity.guid` = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Total Keys",
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT average(`gcp.redis.cluster.node.keyspace.total_keys`) AS 'Total Keys' WHERE `entity.guid` = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Evicted Keys",
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT sum(`gcp.redis.cluster.node.stats.evicted_keys_count`) AS 'Evicted Keys' WHERE `entity.guid` = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Keyspace Hits",
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT sum(`gcp.redis.cluster.node.stats.keyspace_hits_count`) AS 'Keyspace Hits' WHERE `entity.guid` = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Keyspace Misses",
+          "layout": {
+            "column": 5,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT sum(`gcp.redis.cluster.node.stats.keyspace_misses_count`) AS 'Keyspace Misses' WHERE `entity.guid` = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Blocked Clients",
+          "layout": {
+            "column": 9,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT average(`gcp.redis.cluster.node.clients.blocked_clients`) AS 'Blocked Clients' WHERE `entity.guid` = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpredisclusternode/definition.yml
+++ b/entity-types/infra-gcpredisclusternode/definition.yml
@@ -1,0 +1,11 @@
+domain: INFRA
+type: GCPREDISCLUSTERNODE
+goldenTags:
+- gcp.projectId
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-gcpredisclusternode/golden_metrics.yml
+++ b/entity-types/infra-gcpredisclusternode/golden_metrics.yml
@@ -1,0 +1,29 @@
+cpuUtilization:
+  title: CPU utilization (%)
+  unit: PERCENTAGE
+  queries:
+    gcp:
+      select: average(gcp.redis.cluster.node.cpu.utilization) * 100
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+
+memoryUtilization:
+  title: Memory utilization (%)
+  unit: PERCENTAGE
+  queries:
+    gcp:
+      select: average(gcp.redis.cluster.node.memory.utilization) * 100
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+
+connectedClients:
+  title: Connected clients
+  unit: COUNT
+  queries:
+    gcp:
+      select: average(gcp.redis.cluster.node.clients.connected_clients)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-gcpredisclusternode/summary_metrics.yml
+++ b/entity-types/infra-gcpredisclusternode/summary_metrics.yml
@@ -1,0 +1,20 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: GCP account
+  unit: STRING
+
+cpuUtilization:
+  goldenMetric: cpuUtilization
+  unit: PERCENTAGE
+  title: CPU utilization (%)
+
+memoryUtilization:
+  goldenMetric: memoryUtilization
+  unit: PERCENTAGE
+  title: Memory utilization (%)
+
+connectedClients:
+  goldenMetric: connectedClients
+  unit: COUNT
+  title: Connected clients


### PR DESCRIPTION
## Summary

- Adds entity definition for `GCPREDISCLUSTERNODE` (individual nodes within GCP Memorystore Redis Cluster instances)
- Resource type: `redis.googleapis.com/ClusterNode`
- Includes golden metrics: CPU utilization, memory utilization, connected clients
- Includes summary metrics, dashboard with 9 widgets covering CPU, memory, clients, keys, and cache hits/misses

## Metrics

Golden metrics sourced from official GCP documentation ([redis.googleapis.com/cluster/node/* metrics](https://docs.cloud.google.com/memorystore/docs/cluster/supported-monitoring-metrics)):
- `gcp.redis.cluster.node.cpu.utilization`
- `gcp.redis.cluster.node.memory.utilization`
- `gcp.redis.cluster.node.clients.connected_clients`

## Test plan

- [ ] Entity validator passes (`validate-definition`, `validate-golden-metrics`, `validate-summary-metrics`, `validate-dashboard`)
- [ ] Dashboard sanitizer runs without changes
- [ ] Metrics verified against GCP documentation (no live data available — doc-based confidence)
- [ ] GCPREDISCLUSTERNODE synthesized entities visible in NR UI once gcp-polling-v2 changes are deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)