### PR TITLE
feat(GCPMEMORYSTOREINSTANCENODE): add entity definitions for GCP Memorystore instance node

### DIFF
--- a/entity-types/infra-gcpmemorystoreinstancenode/dashboard.json
+++ b/entity-types/infra-gcpmemorystoreinstancenode/dashboard.json
@@ -1,0 +1,215 @@
+{
+  "name": "GCP Memorystore Instance Node",
+  "description": null,
+  "pages": [
+    {
+      "name": "Summary",
+      "description": null,
+      "widgets": [
+        {
+          "title": "CPU Utilization",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.memorystore.instance.node.cpu.utilization`) * 100 FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.role` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Memory Utilization",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.memorystore.instance.node.memory.utilization`) * 100 FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.role` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Connected Clients",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.memorystore.instance.node.clients.connected_clients`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.role` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Blocked Clients",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.memorystore.instance.node.clients.blocked_clients`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.role` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Commands Count",
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(sum(`gcp.memorystore.instance.node.commandstats.calls_count`), 1 minute) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.role`, `metric.command` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Total Keys",
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.memorystore.instance.node.keyspace.total_keys`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.role` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Memory Usage (bytes)",
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 12,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.memorystore.instance.node.memory.usage`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.role` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpmemorystoreinstancenode/definition.yml
+++ b/entity-types/infra-gcpmemorystoreinstancenode/definition.yml
@@ -1,0 +1,11 @@
+domain: INFRA
+type: GCPMEMORYSTOREINSTANCENODE
+goldenTags:
+- gcp.projectId
+- gcp.region
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-gcpmemorystoreinstancenode/golden_metrics.yml
+++ b/entity-types/infra-gcpmemorystoreinstancenode/golden_metrics.yml
@@ -1,0 +1,27 @@
+cpuUtilization:
+  title: CPU utilization (%)
+  unit: PERCENTAGE
+  queries:
+    gcp:
+      select: average(`gcp.memorystore.instance.node.cpu.utilization`) * 100
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+memoryUtilization:
+  title: Memory utilization (%)
+  unit: PERCENTAGE
+  queries:
+    gcp:
+      select: average(`gcp.memorystore.instance.node.memory.utilization`) * 100
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+connectedClients:
+  title: Connected clients
+  unit: COUNT
+  queries:
+    gcp:
+      select: average(`gcp.memorystore.instance.node.clients.connected_clients`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-gcpmemorystoreinstancenode/summary_metrics.yml
+++ b/entity-types/infra-gcpmemorystoreinstancenode/summary_metrics.yml
@@ -1,0 +1,12 @@
+cpuUtilization:
+  goldenMetric: cpuUtilization
+  title: CPU utilization (%)
+  unit: PERCENTAGE
+memoryUtilization:
+  goldenMetric: memoryUtilization
+  title: Memory utilization (%)
+  unit: PERCENTAGE
+connectedClients:
+  goldenMetric: connectedClients
+  title: Connected clients
+  unit: COUNT


### PR DESCRIPTION
## Summary

- Adds `GCPMEMORYSTOREINSTANCENODE` entity definition for GCP Memorystore for Valkey instance nodes (`memorystore.googleapis.com/InstanceNode`)
- Golden metrics: CPU utilization, Memory utilization, Connected clients (all from `FROM Metric` / GCP v2)
- Includes `definition.yml`, `golden_metrics.yml`, `summary_metrics.yml`, and `dashboard.json`

⚠️ Metric names sourced from [official GCP documentation](https://cloud.google.com/monitoring/api/metrics_gcp_i_o#gcp-memorystore). No live NR data available yet (datasource not yet polled in any account).

## Test plan
- [ ] Verify `infra-gcpmemorystoreinstancenode/definition.yml` schema validation passes
- [ ] Verify `golden_metrics.yml` queries return data once gcp_memorystore datasource is enabled
- [ ] Verify `dashboard.json` renders correctly in the entity view
- [ ] Confirm entity synthesises correctly from `memorystore.googleapis.com/InstanceNode` metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)