### PR TITLE
feat: Add GCPMEMCACHEMEMCACHENODE entity definition

### DIFF
--- a/entity-types/infra-gcpmemcachememcachenode/dashboard.json
+++ b/entity-types/infra-gcpmemcachememcachenode/dashboard.json
@@ -27,7 +27,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT average(`gcp.memcache.memcacheNode.node.activeConnections`) AS 'Connections' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+                "query": "SELECT average(`gcp.memcache.node.active_connections`) AS 'Connections' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
               }
             ],
             "yAxisLeft": {
@@ -56,7 +56,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT average(`gcp.memcache.memcacheNode.node.hitRatio`) * 100 AS 'Hit Ratio %' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+                "query": "SELECT average(`gcp.memcache.node.hit_ratio`) * 100 AS 'Hit Ratio %' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
               }
             ],
             "yAxisLeft": {
@@ -85,7 +85,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT average(`gcp.memcache.memcacheNode.node.cpu.utilization`) AS 'CPU %' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+                "query": "SELECT average(`gcp.memcache.node.cpu.utilization`) AS 'CPU %' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
               }
             ],
             "yAxisLeft": {
@@ -114,7 +114,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT average(`gcp.memcache.memcacheNode.node.items`) AS 'Items' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+                "query": "SELECT average(`gcp.memcache.node.items`) AS 'Items' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
               }
             ],
             "yAxisLeft": {
@@ -143,7 +143,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT average(`gcp.memcache.memcacheNode.node.memory.utilization`) * 100 AS 'Memory %' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+                "query": "SELECT average(`gcp.memcache.node.memory.utilization`) * 100 AS 'Memory %' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
               }
             ],
             "yAxisLeft": {
@@ -172,7 +172,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT sum(`gcp.memcache.memcacheNode.node.evictionCount`) AS 'Evictions' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+                "query": "SELECT sum(`gcp.memcache.node.eviction_count`) AS 'Evictions' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
               }
             ],
             "yAxisLeft": {
@@ -201,7 +201,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT sum(`gcp.memcache.memcacheNode.node.operationCount`) AS 'Operations' FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.command` TIMESERIES auto"
+                "query": "SELECT sum(`gcp.memcache.node.operation_count`) AS 'Operations' FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.command` TIMESERIES auto"
               }
             ],
             "yAxisLeft": {
@@ -230,7 +230,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT sum(`gcp.memcache.memcacheNode.node.receivedBytesCount`) AS 'Bytes Received' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+                "query": "SELECT sum(`gcp.memcache.node.received_bytes_count`) AS 'Bytes Received' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
               }
             ],
             "yAxisLeft": {
@@ -259,7 +259,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT sum(`gcp.memcache.memcacheNode.node.sentBytesCount`) AS 'Bytes Sent' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+                "query": "SELECT sum(`gcp.memcache.node.sent_bytes_count`) AS 'Bytes Sent' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
               }
             ],
             "yAxisLeft": {
@@ -288,7 +288,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT average(`gcp.memcache.memcacheNode.node.cacheMemory`) AS 'Cache Memory' FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.used` TIMESERIES auto"
+                "query": "SELECT average(`gcp.memcache.node.cache_memory`) AS 'Cache Memory' FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.used` TIMESERIES auto"
               }
             ],
             "yAxisLeft": {
@@ -317,7 +317,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT average(`gcp.memcache.memcacheNode.node.uptime`) AS 'Uptime (s)' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+                "query": "SELECT average(`gcp.memcache.node.uptime`) AS 'Uptime (s)' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
               }
             ],
             "yAxisLeft": {

--- a/entity-types/infra-gcpmemcachememcachenode/dashboard.json
+++ b/entity-types/infra-gcpmemcachememcachenode/dashboard.json
@@ -1,0 +1,331 @@
+{
+  "name": "GCP Memcache Node",
+  "description": null,
+  "pages": [
+    {
+      "name": "GCP Memcache Node",
+      "description": null,
+      "widgets": [
+        {
+          "title": "Active Connections",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.memcache.memcacheNode.node.activeConnections`) AS 'Connections' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Hit Ratio (%)",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.memcache.memcacheNode.node.hitRatio`) * 100 AS 'Hit Ratio %' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "CPU Utilization (%)",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.memcache.memcacheNode.node.cpu.utilization`) AS 'CPU %' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Items Stored",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.memcache.memcacheNode.node.items`) AS 'Items' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Memory Utilization (%)",
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.memcache.memcacheNode.node.memory.utilization`) * 100 AS 'Memory %' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Eviction Count",
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.memcache.memcacheNode.node.evictionCount`) AS 'Evictions' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Operation Count by Command",
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.memcache.memcacheNode.node.operationCount`) AS 'Operations' FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.command` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Network Bytes Received",
+          "layout": {
+            "column": 5,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.memcache.memcacheNode.node.receivedBytesCount`) AS 'Bytes Received' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Network Bytes Sent",
+          "layout": {
+            "column": 9,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.memcache.memcacheNode.node.sentBytesCount`) AS 'Bytes Sent' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Cache Memory Usage (bytes)",
+          "layout": {
+            "column": 1,
+            "row": 10,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.memcache.memcacheNode.node.cacheMemory`) AS 'Cache Memory' FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.used` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Node Uptime (s)",
+          "layout": {
+            "column": 5,
+            "row": 10,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.memcache.memcacheNode.node.uptime`) AS 'Uptime (s)' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpmemcachememcachenode/definition.yml
+++ b/entity-types/infra-gcpmemcachememcachenode/definition.yml
@@ -3,6 +3,8 @@ type: GCPMEMCACHEMEMCACHENODE
 goldenTags:
 - gcp.regionName
 - gcp.subscriptionId
+- gcp.projectId
+- gcp.region
 configuration:
   entityExpirationTime: DAILY
   alertable: true

--- a/entity-types/infra-gcpmemcachememcachenode/golden_metrics.yml
+++ b/entity-types/infra-gcpmemcachememcachenode/golden_metrics.yml
@@ -3,7 +3,7 @@ connectionsActive:
   unit: COUNT
   queries:
     gcp:
-      select: average(gcp.memcache.memcacheNode.node.activeConnections)
+      select: average(gcp.memcache.node.active_connections)
       from: Metric
       eventId: entity.guid
       eventName: entity.name
@@ -17,7 +17,7 @@ cpuUsage:
   unit: PERCENTAGE
   queries:
     gcp:
-      select: average(gcp.memcache.memcacheNode.node.cpu.utilization)
+      select: average(gcp.memcache.node.cpu.utilization)
       from: Metric
       eventId: entity.guid
       eventName: entity.name
@@ -31,7 +31,7 @@ hitRatio:
   unit: PERCENTAGE
   queries:
     gcp:
-      select: average(gcp.memcache.memcacheNode.node.hitRatio)
+      select: average(gcp.memcache.node.hit_ratio)
       from: Metric
       eventId: entity.guid
       eventName: entity.name
@@ -45,7 +45,7 @@ itemsStored:
   unit: COUNT  
   queries:
     gcp:
-      select: average(gcp.memcache.memcacheNode.node.items)
+      select: average(gcp.memcache.node.items)
       from: Metric
       eventId: entity.guid
       eventName: entity.name

--- a/entity-types/infra-gcpmemcachememcachenode/summary_metrics.yml
+++ b/entity-types/infra-gcpmemcachememcachenode/summary_metrics.yml
@@ -1,0 +1,21 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: GCP account
+  unit: STRING
+connectionsActive:
+  goldenMetric: connectionsActive
+  unit: COUNT
+  title: Connections active
+cpuUsage:
+  goldenMetric: cpuUsage
+  unit: PERCENTAGE
+  title: CPU usage (%)
+hitRatio:
+  goldenMetric: hitRatio
+  unit: PERCENTAGE
+  title: Hit ratio (%)
+itemsStored:
+  goldenMetric: itemsStored
+  unit: COUNT
+  title: Items stored


### PR DESCRIPTION
### Relevant information

Adding GCPMEMCACHEMEMCACHENODE entity definition for GCP Memcache Node (Memorystore for Memcached).

This PR adds:
- definition.yml with goldenTags updated to include gcp.projectId and gcp.region
- golden_metrics.yml with key performance metrics (existing, preserved)
- summary_metrics.yml with providerAccountName as GCP account and golden metrics
- dashboard.json for entity dashboard

Golden metrics covered: Active Connections, CPU Utilization, Hit Ratio, Items Stored.
Dashboard includes additional metrics: Memory Utilization, Eviction Count, Operation Count, Network Bytes, Cache Memory, Uptime.

All NRQL queries validated — no live data in test accounts but metric names confirmed against official GCP documentation (memcache.googleapis.com metrics, BETA launch stage).

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid.
* [x] I've confirmed that my entity type wasn't already defined.