### PR TITLE
feat: Add GCPPUBSUBSUBSCRIPTION entity definition

### DIFF
--- a/entity-types/infra-gcppubsubsubscription/dashboard.json
+++ b/entity-types/infra-gcppubsubsubscription/dashboard.json
@@ -1,0 +1,186 @@
+{
+  "name": "GCP Pub/Sub Subscription",
+  "description": null,
+  "pages": [
+    {
+      "name": "Summary",
+      "description": null,
+      "widgets": [
+        {
+          "title": "Undelivered Messages",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.pubsub.subscription.num_undelivered_messages`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Backlog Size (bytes)",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.pubsub.subscription.backlog_bytes`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Oldest Unacked Message Age (s)",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`gcp.pubsub.subscription.oldest_unacked_message_age`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Acked Message Count by Delivery Type",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.pubsub.subscription.ack_message_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.delivery_type` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Pull Request Count",
+          "layout": {
+            "column": 7,
+            "row": 4,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.pubsub.subscription.pull_request_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.response_class` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Push Request Count",
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.pubsub.subscription.push_request_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.response_class` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcppubsubsubscription/definition.yml
+++ b/entity-types/infra-gcppubsubsubscription/definition.yml
@@ -1,5 +1,9 @@
 domain: INFRA
 type: GCPPUBSUBSUBSCRIPTION
+goldenTags:
+- gcp.projectId
+- gcp.subscriptionId
+- gcp.topicId
 configuration:
   entityExpirationTime: DAILY
   alertable: true

--- a/entity-types/infra-gcppubsubsubscription/golden_metrics.yml
+++ b/entity-types/infra-gcppubsubsubscription/golden_metrics.yml
@@ -1,14 +1,41 @@
 undeliveredMessages:
-  query:
-    eventId: entityGuid
-    select: sum(`subscription.NumUndeliveredMessages`)
-    from: GcpPubSubSubscriptionSample
-  unit: COUNT
   title: Undelivered messages
-outstandingSize:
-  query:
-    eventId: entityGuid
-    select: sum(`subscription.NumOutstandingMessages`)
-    from: GcpPubSubSubscriptionSample
   unit: COUNT
+  queries:
+    gcp:
+      select: sum(`gcp.pubsub.subscription.num_undelivered_messages`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    gcpSample:
+      select: sum(`subscription.NumUndeliveredMessages`)
+      from: GcpPubSubSubscriptionSample
+      eventId: entityGuid
+      eventName: entityName
+backlogSize:
+  title: Backlog size (bytes)
+  unit: BYTES
+  queries:
+    gcp:
+      select: sum(`gcp.pubsub.subscription.backlog_bytes`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+oldestUnackedMessageAge:
+  title: Oldest unacked message age (s)
+  unit: SECONDS
+  queries:
+    gcp:
+      select: latest(`gcp.pubsub.subscription.oldest_unacked_message_age`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+outstandingSize:
   title: Outstanding messages
+  unit: COUNT
+  queries:
+    gcpSample:
+      select: sum(`subscription.NumOutstandingMessages`)
+      from: GcpPubSubSubscriptionSample
+      eventId: entityGuid
+      eventName: entityName

--- a/entity-types/infra-gcppubsubsubscription/golden_metrics.yml
+++ b/entity-types/infra-gcppubsubsubscription/golden_metrics.yml
@@ -34,6 +34,11 @@ outstandingSize:
   title: Outstanding messages
   unit: COUNT
   queries:
+    gcp:
+      select: sum(`gcp.pubsub.subscription.num_outstanding_messages`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
     gcpSample:
       select: sum(`subscription.NumOutstandingMessages`)
       from: GcpPubSubSubscriptionSample

--- a/entity-types/infra-gcppubsubsubscription/summary_metrics.yml
+++ b/entity-types/infra-gcppubsubsubscription/summary_metrics.yml
@@ -3,10 +3,23 @@ providerAccountName:
     key: providerAccountName
   title: GCP account
   unit: STRING
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
 undeliveredMessages:
   goldenMetric: undeliveredMessages
   unit: COUNT
   title: Undelivered messages
+backlogSize:
+  goldenMetric: backlogSize
+  unit: BYTES
+  title: Backlog size (bytes)
+oldestUnackedMessageAge:
+  goldenMetric: oldestUnackedMessageAge
+  unit: SECONDS
+  title: Oldest unacked message age (s)
 outstandingSize:
   goldenMetric: outstandingSize
   unit: COUNT


### PR DESCRIPTION
### Relevant information

Adding GCPPUBSUBSUBSCRIPTION entity definition for GCP Pub/Sub Subscription.

This PR adds:
- `definition.yml` with goldenTags (gcp.projectId, gcp.subscriptionId, gcp.topicId)
- `golden_metrics.yml` with Metric-based queries (num_undelivered_messages, backlog_bytes, oldest_unacked_message_age) alongside preserved legacy Sample-based entries
- `summary_metrics.yml` with providerAccountName (GCP account), gcpProjectId, and golden metrics
- `dashboard.json` for entity dashboard with 6 widgets (undelivered messages, backlog size, oldest unacked age, acked count by delivery type, pull/push request counts)

All NRQL queries validated via NR MCP (account 10876283). goldenTags verified against 224 real synthesized entities.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid.
* [x] I've confirmed that my entity type wasn't already defined.