### PR TITLE
feat: Add GCPMEMORYSTOREINSTANCE entity definition

### DIFF
--- a/entity-types/infra-gcpmemorystoreinstance/dashboard.json
+++ b/entity-types/infra-gcpmemorystoreinstance/dashboard.json
@@ -1,0 +1,172 @@
+{
+  "name": "GCP Memorystore Instance",
+  "description": null,
+  "pages": [
+    {
+      "name": "GCP Memorystore Instance",
+      "description": null,
+      "widgets": [
+        {
+          "title": "CPU Utilization (%)",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT max(`gcp.memorystore.instance.cpu.maximum_utilization`) * 100 AS 'CPU %' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND `collector.name` = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Memory Utilization (%)",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT max(`gcp.memorystore.instance.memory.maximum_utilization`) * 100 AS 'Memory %' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND `collector.name` = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Connected Clients",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.memorystore.instance.clients.total_connected_clients`) AS 'Clients' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND `collector.name` = 'gcp-polling-v2' FACET `metric.role` TIMESERIES AUTO"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Total Keys",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`gcp.memorystore.instance.keyspace.total_keys`) AS 'Keys' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND `collector.name` = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Memory Used (Bytes)",
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`gcp.memorystore.instance.memory.total_used_memory`) AS 'Used Memory' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND `collector.name` = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Cache Hit Ratio (%)",
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.memorystore.instance.stats.average_keyspace_hits`) / (average(`gcp.memorystore.instance.stats.average_keyspace_hits`) + average(`gcp.memorystore.instance.stats.average_keyspace_misses`)) * 100 AS 'Cache Hit %' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND `collector.name` = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Evicted Keys",
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.memorystore.instance.stats.average_evicted_keys`) AS 'Evicted Keys' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND `collector.name` = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Network Input/Output (Bytes/s)",
+          "layout": {
+            "column": 5,
+            "row": 7,
+            "width": 8,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(sum(`gcp.memorystore.instance.stats.total_net_input_bytes_count`), 1 minute) AS 'Net In', rate(sum(`gcp.memorystore.instance.stats.total_net_output_bytes_count`), 1 minute) AS 'Net Out' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND `collector.name` = 'gcp-polling-v2' FACET `metric.role` TIMESERIES AUTO"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpmemorystoreinstance/definition.yml
+++ b/entity-types/infra-gcpmemorystoreinstance/definition.yml
@@ -1,0 +1,11 @@
+domain: INFRA
+type: GCPMEMORYSTOREINSTANCE
+goldenTags:
+- gcp.project_id
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-gcpmemorystoreinstance/golden_metrics.yml
+++ b/entity-types/infra-gcpmemorystoreinstance/golden_metrics.yml
@@ -1,0 +1,29 @@
+cpuUtilization:
+  title: CPU utilization (%)
+  unit: PERCENTAGE
+  queries:
+    gcp:
+      select: max(`gcp.memorystore.instance.cpu.maximum_utilization`) * 100
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+
+memoryUtilization:
+  title: Memory utilization (%)
+  unit: PERCENTAGE
+  queries:
+    gcp:
+      select: max(`gcp.memorystore.instance.memory.maximum_utilization`) * 100
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+
+connectedClients:
+  title: Connected clients
+  unit: COUNT
+  queries:
+    gcp:
+      select: average(`gcp.memorystore.instance.clients.total_connected_clients`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-gcpmemorystoreinstance/summary_metrics.yml
+++ b/entity-types/infra-gcpmemorystoreinstance/summary_metrics.yml
@@ -1,0 +1,20 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: GCP account
+  unit: STRING
+
+cpuUtilization:
+  goldenMetric: cpuUtilization
+  title: CPU utilization (%)
+  unit: PERCENTAGE
+
+memoryUtilization:
+  goldenMetric: memoryUtilization
+  title: Memory utilization (%)
+  unit: PERCENTAGE
+
+connectedClients:
+  goldenMetric: connectedClients
+  title: Connected clients
+  unit: COUNT


### PR DESCRIPTION
### Relevant information

Adding GCPMEMORYSTOREINSTANCE entity definition for GCP Memorystore instance (new unified API: `memorystore.googleapis.com`).

This PR adds:
- definition.yml with alertable: true and gcp.project_id goldenTag
- golden_metrics.yml with CPU utilization, memory utilization, and connected clients
- summary_metrics.yml with providerAccountName tag and goldenMetric references
- dashboard.json for entity dashboard (8 widgets covering CPU, memory, clients, keys, cache hit ratio, evictions, network)

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid.
* [x] I've confirmed that my entity type wasn't already defined.