### PR TITLE
feat: Add GCPPUBSUBTOPIC entity definition

### DIFF
--- a/entity-types/infra-gcppubsubtopic/dashboard.json
+++ b/entity-types/infra-gcppubsubtopic/dashboard.json
@@ -1,0 +1,186 @@
+{
+  "name": "GCP Pub/Sub Topic",
+  "description": null,
+  "pages": [
+    {
+      "name": "Summary",
+      "description": null,
+      "widgets": [
+        {
+          "title": "Publish Requests",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.pubsub.topic.send_request_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Publish Error Rate",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT filter(sum(`gcp.pubsub.topic.send_request_count`), WHERE `metric.response_class` = 'invalid' OR `metric.response_class` = 'internal') * 100 / sum(`gcp.pubsub.topic.send_request_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Publish Requests by Response Class",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.pubsub.topic.send_request_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.response_class` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Unacknowledged Messages by Region",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.pubsub.topic.num_unacked_messages_by_region`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.region` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Retained Messages",
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.pubsub.topic.num_retained_messages`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Retained Bytes",
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.pubsub.topic.retained_bytes`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcppubsubtopic/definition.yml
+++ b/entity-types/infra-gcppubsubtopic/definition.yml
@@ -1,5 +1,7 @@
 domain: INFRA
 type: GCPPUBSUBTOPIC
+goldenTags:
+- gcp.projectId
 configuration:
   entityExpirationTime: DAILY
   alertable: true

--- a/entity-types/infra-gcppubsubtopic/golden_metrics.yml
+++ b/entity-types/infra-gcppubsubtopic/golden_metrics.yml
@@ -2,23 +2,34 @@ sendMessageRequests:
   queries:
     gcp:
       eventId: entity.guid
-      select: (rate(sum(`gcp.pubsub.topic.send_message_operation_count`), 1 minute)) / 60
-      from: Metric 
-    gcpSample: 
+      eventName: entity.name
+      select: sum(`gcp.pubsub.topic.send_request_count`)
+      from: Metric
+    gcpSample:
       eventId: entityGuid
       select: (rate(sum(`topic.SendMessageOperation`), 1 minute)) / 60
       from: GcpPubSubTopicSample
-  unit: MESSAGES_PER_SECOND
-  title: Send rate
+  unit: COUNT
+  title: Publish requests
 unackedMessages:
   queries:
     gcp:
       eventId: entity.guid
-      select: sum(`gcp.pubsub.subscription.num_unacked_messages_by_region`)
-      from: Metric 
-    gcpSample: 
+      eventName: entity.name
+      select: sum(`gcp.pubsub.topic.num_unacked_messages_by_region`)
+      from: Metric
+    gcpSample:
       eventId: entityGuid
       select: sum(`topic.NumUnackedMessagesByRegion`)
       from: GcpPubSubTopicSample
   unit: COUNT
   title: Unacknowledged messages
+retainedMessages:
+  queries:
+    gcp:
+      eventId: entity.guid
+      eventName: entity.name
+      select: sum(`gcp.pubsub.topic.num_retained_messages`)
+      from: Metric
+  unit: COUNT
+  title: Retained messages

--- a/entity-types/infra-gcppubsubtopic/summary_metrics.yml
+++ b/entity-types/infra-gcppubsubtopic/summary_metrics.yml
@@ -3,11 +3,20 @@ providerAccountName:
     key: providerAccountName
   title: GCP account
   unit: STRING
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
 sendMessageRequests:
   goldenMetric: sendMessageRequests
-  unit: MESSAGES_PER_SECOND
-  title: Send rate
+  unit: COUNT
+  title: Publish requests
 unackedMessages:
   goldenMetric: unackedMessages
   unit: COUNT
   title: Unacknowledged messages
+retainedMessages:
+  goldenMetric: retainedMessages
+  unit: COUNT
+  title: Retained messages


### PR DESCRIPTION
### Relevant information

Adding GCPPUBSUBTOPIC entity definition for GCP Pub/Sub Topic.

This PR adds/updates:
- `definition.yml` — adds `goldenTags: [gcp.projectId]` (confirmed present on real entities)
- `golden_metrics.yml` — replaces deprecated `send_message_operation_count` with `send_request_count`; fixes `unackedMessages` to use topic metric (was incorrectly referencing a subscription metric); adds `retainedMessages` metric; preserves existing Sample-based entries for backward compatibility
- `summary_metrics.yml` — adds `gcpProjectId` tag and `retainedMessages` golden metric reference
- `dashboard.json` — new entity dashboard with 6 widgets: Publish Requests, Publish Error Rate, Requests by Response Class, Unacked Messages by Region, Retained Messages, Retained Bytes

All NRQL queries validated via NR MCP (account 10876283). Metric names sourced from official GCP documentation (GA metrics only).

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid.
* [x] I've confirmed that my entity type wasn't already defined.