### PR TITLE
feat: Add GCPPUBSUBSNAPSHOT entity definition

### DIFF
--- a/entity-types/infra-gcppubsubsnapshot/dashboard.json
+++ b/entity-types/infra-gcppubsubsnapshot/dashboard.json
@@ -1,0 +1,244 @@
+{
+  "name": "GCP Pub/Sub Snapshot",
+  "description": null,
+  "pages": [
+    {
+      "name": "Summary",
+      "description": null,
+      "widgets": [
+        {
+          "title": "Backlog Bytes",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.pubsub.snapshot.backlog_bytes`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Number of Messages",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.pubsub.snapshot.num_messages`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Oldest Message Age (seconds)",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`gcp.pubsub.snapshot.oldest_message_age`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Backlog Bytes by Region",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.pubsub.snapshot.backlog_bytes_by_region`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.region` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Number of Messages by Region",
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.pubsub.snapshot.num_messages_by_region`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.region` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Oldest Message Age by Region (seconds)",
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`gcp.pubsub.snapshot.oldest_message_age_by_region`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.region` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Configuration Operations",
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.pubsub.snapshot.config_updates_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.operation_type` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Configuration Operations by Response Code",
+          "layout": {
+            "column": 7,
+            "row": 7,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.pubsub.snapshot.config_updates_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.response_code` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcppubsubsnapshot/definition.yml
+++ b/entity-types/infra-gcppubsubsnapshot/definition.yml
@@ -1,0 +1,11 @@
+domain: INFRA
+type: GCPPUBSUBSNAPSHOT
+goldenTags:
+- gcp.projectId
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-gcppubsubsnapshot/golden_metrics.yml
+++ b/entity-types/infra-gcppubsubsnapshot/golden_metrics.yml
@@ -1,0 +1,27 @@
+backlogBytes:
+  title: Backlog bytes
+  unit: BYTES
+  queries:
+    gcp:
+      select: sum(`gcp.pubsub.snapshot.backlog_bytes`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+numMessages:
+  title: Number of messages
+  unit: COUNT
+  queries:
+    gcp:
+      select: sum(`gcp.pubsub.snapshot.num_messages`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+oldestMessageAge:
+  title: Oldest message age
+  unit: SECONDS
+  queries:
+    gcp:
+      select: latest(`gcp.pubsub.snapshot.oldest_message_age`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-gcppubsubsnapshot/summary_metrics.yml
+++ b/entity-types/infra-gcppubsubsnapshot/summary_metrics.yml
@@ -1,0 +1,17 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: GCP account
+  unit: STRING
+backlogBytes:
+  goldenMetric: backlogBytes
+  unit: BYTES
+  title: Backlog bytes
+numMessages:
+  goldenMetric: numMessages
+  unit: COUNT
+  title: Number of messages
+oldestMessageAge:
+  goldenMetric: oldestMessageAge
+  unit: SECONDS
+  title: Oldest message age


### PR DESCRIPTION
### Relevant information

Adding GCPPUBSUBSNAPSHOT entity definition for GCP Pub/Sub Snapshot.

This PR adds:
- definition.yml with goldenTags (gcp.projectId) and alertable: true
- golden_metrics.yml with key performance metrics: backlogBytes, numMessages, oldestMessageAge
- summary_metrics.yml with providerAccountName as GCP account and golden metrics
- dashboard.json with widgets for all 7 Pub/Sub Snapshot metrics

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid.
* [x] I've confirmed that my entity type wasn't already defined.