### PR TITLE
feat: Add GCPROUTERCLOUDROUTER entity definition

### DIFF
--- a/entity-types/infra-gcproutercloudrouter/dashboard.json
+++ b/entity-types/infra-gcproutercloudrouter/dashboard.json
@@ -1,0 +1,273 @@
+{
+  "name": "GCP Cloud Router",
+  "description": null,
+  "pages": [
+    {
+      "name": "Summary",
+      "description": null,
+      "widgets": [
+        {
+          "title": "BGP Sessions Up",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.router.bgp_sessions_up_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "BGP Sessions Down",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.router.bgp_sessions_down_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Sent Routes Count",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.router.sent_routes_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Best Routes Count",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.router.best_routes_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "BGP Received Routes by Peer",
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.router.bgp.received_routes_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.bgp_peer_name` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "BGP Session Up by Peer",
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`gcp.router.bgp.session_up`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.bgp_peer_name` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Router Up Tasks",
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`gcp.router.router_up`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "BFD Session Up by Peer",
+          "layout": {
+            "column": 5,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`gcp.router.bfd.session_up`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.peer_ip` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "BFD Control Packets (Received vs Transmitted)",
+          "layout": {
+            "column": 9,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.router.bfd.control.received_packets_count`) AS 'Received', sum(`gcp.router.bfd.control.transmitted_packets_count`) AS 'Transmitted' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcproutercloudrouter/definition.yml
+++ b/entity-types/infra-gcproutercloudrouter/definition.yml
@@ -1,9 +1,11 @@
 domain: INFRA
 type: GCPROUTERCLOUDROUTER
+goldenTags:
+- gcp.projectId
+- gcp.region
 configuration:
   entityExpirationTime: DAILY
   alertable: true
-
 ownership:
   primaryOwner:
     teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-gcproutercloudrouter/golden_metrics.yml
+++ b/entity-types/infra-gcproutercloudrouter/golden_metrics.yml
@@ -1,0 +1,27 @@
+bgpSessionsUp:
+  title: BGP Sessions Up
+  unit: COUNT
+  queries:
+    gcp:
+      select: sum(`gcp.router.bgp_sessions_up_count`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+bgpSessionsDown:
+  title: BGP Sessions Down
+  unit: COUNT
+  queries:
+    gcp:
+      select: sum(`gcp.router.bgp_sessions_down_count`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+sentRoutesCount:
+  title: Sent Routes Count
+  unit: COUNT
+  queries:
+    gcp:
+      select: sum(`gcp.router.sent_routes_count`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-gcproutercloudrouter/summary_metrics.yml
+++ b/entity-types/infra-gcproutercloudrouter/summary_metrics.yml
@@ -1,0 +1,22 @@
+nrAccountId:
+  tag:
+    key: nrAccount.id
+  title: NR Account ID
+  unit: STRING
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
+bgpSessionsUp:
+  goldenMetric: bgpSessionsUp
+  unit: COUNT
+  title: BGP Sessions Up
+bgpSessionsDown:
+  goldenMetric: bgpSessionsDown
+  unit: COUNT
+  title: BGP Sessions Down
+sentRoutesCount:
+  goldenMetric: sentRoutesCount
+  unit: COUNT
+  title: Sent Routes Count


### PR DESCRIPTION
### Relevant information

Adding GCPROUTERCLOUDROUTER entity definition for GCP Cloud Router (gce_router monitored resource type).

This PR adds:
- `definition.yml` — updated with `goldenTags: [gcp.projectId, gcp.region]` (confirmed present on synthesized GCE Router entities)
- `golden_metrics.yml` — three key metrics: bgpSessionsUp, bgpSessionsDown, sentRoutesCount
- `summary_metrics.yml` — NR account, GCP project ID, and golden metrics references
- `dashboard.json` — 9-widget dashboard covering BGP health, routing, BFD session status

All metrics sourced from official GCP Cloud Monitoring documentation (`router.googleapis.com`) — GA metrics only. Validated via NR MCP (returns 0, not null — data exists in account 10876283).

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid.
* [x] I've confirmed that my entity type wasn't already defined.