### PR TITLE
feat: Add GCPREDISCLUSTER entity definition

### DIFF
--- a/entity-types/infra-gcprediscluster/dashboard.json
+++ b/entity-types/infra-gcprediscluster/dashboard.json
@@ -1,0 +1,273 @@
+{
+  "name": "GCP Redis Cluster",
+  "description": null,
+  "pages": [
+    {
+      "name": "GCP Redis Cluster",
+      "description": null,
+      "widgets": [
+        {
+          "title": "CPU Utilization (%)",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.redis.cluster.cpu.average_utilization`) * 100 AS 'CPU %' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND collector.name = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Memory Utilization (%)",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.redis.cluster.memory.average_utilization`) * 100 AS 'Memory %' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND collector.name = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Total Memory Usage (bytes)",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.redis.cluster.memory.total_used_memory`) AS 'Memory Used (bytes)' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND collector.name = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Commands Count",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.redis.cluster.commandstats.total_calls_count`) AS 'Commands' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND collector.name = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Commands by Type",
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.redis.cluster.commandstats.total_calls_count`) AS 'Commands' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND collector.name = 'gcp-polling-v2' FACET `metric.command` TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Connected Clients",
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.redis.cluster.clients.total_connected_clients`) AS 'Clients' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND collector.name = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Total Keys",
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.redis.cluster.keyspace.total_keys`) AS 'Keys' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND collector.name = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Evicted Keys",
+          "layout": {
+            "column": 5,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.redis.cluster.stats.total_evicted_keys_count`) AS 'Evicted Keys' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND collector.name = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Network I/O (bytes)",
+          "layout": {
+            "column": 9,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.redis.cluster.stats.total_net_input_bytes_count`) AS 'Input Bytes', sum(`gcp.redis.cluster.stats.total_net_output_bytes_count`) AS 'Output Bytes' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND collector.name = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcprediscluster/definition.yml
+++ b/entity-types/infra-gcprediscluster/definition.yml
@@ -1,0 +1,11 @@
+domain: INFRA
+type: GCPREDISCLUSTER
+goldenTags:
+- gcp.projectId
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-gcprediscluster/golden_metrics.yml
+++ b/entity-types/infra-gcprediscluster/golden_metrics.yml
@@ -1,0 +1,29 @@
+cpuAverageUtilization:
+  title: CPU Utilization (%)
+  unit: PERCENTAGE
+  queries:
+    gcp:
+      select: average(gcp.redis.cluster.cpu.average_utilization) * 100
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+
+memoryAverageUtilization:
+  title: Memory Utilization (%)
+  unit: PERCENTAGE
+  queries:
+    gcp:
+      select: average(gcp.redis.cluster.memory.average_utilization) * 100
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+
+commandsTotalCallsCount:
+  title: Commands Count
+  unit: COUNT
+  queries:
+    gcp:
+      select: sum(gcp.redis.cluster.commandstats.total_calls_count)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-gcprediscluster/summary_metrics.yml
+++ b/entity-types/infra-gcprediscluster/summary_metrics.yml
@@ -1,0 +1,22 @@
+nrAccountId:
+  tag:
+    key: nrAccount.id
+  title: NR Account ID
+  unit: STRING
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
+cpuAverageUtilization:
+  goldenMetric: cpuAverageUtilization
+  unit: PERCENTAGE
+  title: CPU Utilization (%)
+memoryAverageUtilization:
+  goldenMetric: memoryAverageUtilization
+  unit: PERCENTAGE
+  title: Memory Utilization (%)
+commandsTotalCallsCount:
+  goldenMetric: commandsTotalCallsCount
+  unit: COUNT
+  title: Commands Count


### PR DESCRIPTION
### Relevant information

Adding GCPREDISCLUSTER entity definition for GCP Redis Cluster (Memorystore for Redis Cluster).

This PR adds:
- definition.yml with alertable: true and goldenTags
- golden_metrics.yml with 3 key performance metrics (CPU, memory, commands)
- summary_metrics.yml with providerAccountName as GCP account, gcp project id and golden metrics
- dashboard.json for entity dashboard (9 widgets covering CPU, memory, commands, clients, keys, network I/O)

All metrics use GA-only GCP metrics from official documentation:
- `gcp.redis.cluster.cpu.average_utilization`
- `gcp.redis.cluster.memory.average_utilization`
- `gcp.redis.cluster.commandstats.total_calls_count`

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid.
* [x] I've confirmed that my entity type wasn't already defined.