### PR TITLE
feat: Add GCPCLOUDRUNJOB entity definition

### DIFF
--- a/entity-types/infra-gcpcloudrunjob/dashboard.json
+++ b/entity-types/infra-gcpcloudrunjob/dashboard.json
@@ -1,0 +1,186 @@
+{
+  "name": "GCP Cloud Run Job",
+  "description": null,
+  "pages": [
+    {
+      "name": "Summary",
+      "description": null,
+      "widgets": [
+        {
+          "title": "Completed Execution Count",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.run.job.completed_execution_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Running Executions",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`gcp.run.job.running_executions`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "CPU Allocation Time",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.run.container.cpu.allocation_time`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Completed Executions by Result",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.run.job.completed_execution_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.result` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Running Task Attempts",
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`gcp.run.job.running_task_attempts`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Memory Allocation Time",
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.run.container.memory.allocation_time`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpcloudrunjob/definition.yml
+++ b/entity-types/infra-gcpcloudrunjob/definition.yml
@@ -1,0 +1,10 @@
+domain: INFRA
+type: GCPCLOUDRUNJOB
+goldenTags:
+- gcp.projectId
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-gcpcloudrunjob/golden_metrics.yml
+++ b/entity-types/infra-gcpcloudrunjob/golden_metrics.yml
@@ -1,0 +1,27 @@
+completedExecutionCount:
+  title: Completed Execution Count
+  unit: COUNT
+  queries:
+    gcp:
+      select: sum(gcp.run.job.completed_execution_count)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+runningExecutions:
+  title: Running Executions
+  unit: COUNT
+  queries:
+    gcp:
+      select: latest(gcp.run.job.running_executions)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+cpuAllocationTime:
+  title: CPU Allocation Time
+  unit: SECONDS
+  queries:
+    gcp:
+      select: sum(gcp.run.container.cpu.allocation_time)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-gcpcloudrunjob/summary_metrics.yml
+++ b/entity-types/infra-gcpcloudrunjob/summary_metrics.yml
@@ -1,0 +1,22 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: GCP account
+  unit: STRING
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
+completedExecutionCount:
+  goldenMetric: completedExecutionCount
+  unit: COUNT
+  title: Completed Execution Count
+runningExecutions:
+  goldenMetric: runningExecutions
+  unit: COUNT
+  title: Running Executions
+cpuAllocationTime:
+  goldenMetric: cpuAllocationTime
+  unit: SECONDS
+  title: CPU Allocation Time


### PR DESCRIPTION
### Relevant information

Adding GCPCLOUDRUNJOB entity definition for GCP Cloud Run Job.

Cloud Run Jobs are batch workloads in GCP that run containerized tasks to completion. This PR adds entity support for Cloud Run Jobs using the gcp-polling-v2 dimensional metrics (FROM Metric, NOT GcpXxxSample events).

This PR adds:
- `definition.yml` with synthesis rules and `alertable: true`
- `golden_metrics.yml` with key performance metrics (completedExecutionCount, runningExecutions, cpuAllocationTime)
- `summary_metrics.yml` with providerAccountName as GCP account, gcp project id and golden metrics
- `dashboard.json` for entity dashboard

Metrics sourced from official GCP documentation (run.googleapis.com, GA/BETA only):
- `gcp.run.job.completed_execution_count`
- `gcp.run.job.running_executions`
- `gcp.run.job.running_task_attempts`
- `gcp.run.container.cpu.allocation_time`
- `gcp.run.container.memory.allocation_time`

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid.
* [x] I've confirmed that my entity type wasn't already defined.