### PR TITLE
feat: Add GCPROUTERNATGATEWAY entity definition

### DIFF
--- a/entity-types/infra-gcprouternatgateway/dashboard.json
+++ b/entity-types/infra-gcprouternatgateway/dashboard.json
@@ -1,0 +1,273 @@
+{
+  "name": "GCP Router NAT Gateway",
+  "description": null,
+  "pages": [
+    {
+      "name": "Summary",
+      "description": null,
+      "widgets": [
+        {
+          "title": "Open Connections",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.router.nat.open_connections`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Sent Bytes Count",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.router.nat.sent_bytes_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Dropped Sent Packets Count",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.router.nat.dropped_sent_packets_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Allocated Ports by NAT IP",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.router.nat.allocated_ports`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.nat_ip` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Open Connections by Protocol",
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.router.nat.open_connections`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.ip_protocol` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Dropped Sent Packets by Reason",
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.router.nat.dropped_sent_packets_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.reason` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Received Bytes Count",
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.router.nat.received_bytes_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "New Connections Count by Protocol",
+          "layout": {
+            "column": 5,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.router.nat.new_connections_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.ip_protocol` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Port Usage",
+          "layout": {
+            "column": 9,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT max(`gcp.router.nat.port_usage`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.ip_protocol` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcprouternatgateway/definition.yml
+++ b/entity-types/infra-gcprouternatgateway/definition.yml
@@ -1,9 +1,11 @@
 domain: INFRA
 type: GCPROUTERNATGATEWAY
+goldenTags:
+- gcp.projectId
+- gcp.region
 configuration:
   entityExpirationTime: DAILY
   alertable: true
-
 ownership:
   primaryOwner:
     teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-gcprouternatgateway/golden_metrics.yml
+++ b/entity-types/infra-gcprouternatgateway/golden_metrics.yml
@@ -1,0 +1,27 @@
+openConnections:
+  title: Open Connections
+  unit: COUNT
+  queries:
+    gcp:
+      select: sum(`gcp.router.nat.open_connections`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+sentBytesCount:
+  title: Sent Bytes Count
+  unit: BYTES
+  queries:
+    gcp:
+      select: sum(`gcp.router.nat.sent_bytes_count`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+droppedSentPacketsCount:
+  title: Dropped Sent Packets Count
+  unit: COUNT
+  queries:
+    gcp:
+      select: sum(`gcp.router.nat.dropped_sent_packets_count`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-gcprouternatgateway/summary_metrics.yml
+++ b/entity-types/infra-gcprouternatgateway/summary_metrics.yml
@@ -1,0 +1,22 @@
+nrAccountId:
+  tag:
+    key: nrAccount.id
+  title: NR Account ID
+  unit: STRING
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
+openConnections:
+  goldenMetric: openConnections
+  unit: COUNT
+  title: Open Connections
+sentBytesCount:
+  goldenMetric: sentBytesCount
+  unit: BYTES
+  title: Sent Bytes Count
+droppedSentPacketsCount:
+  goldenMetric: droppedSentPacketsCount
+  unit: COUNT
+  title: Dropped Sent Packets Count


### PR DESCRIPTION
### Relevant information

Adding GCPROUTERNATGATEWAY entity definition for GCP Router NAT Gateway.

This PR adds:
- definition.yml with goldenTags (gcp.projectId, gcp.region)
- golden_metrics.yml with key performance metrics (openConnections, sentBytesCount, droppedSentPacketsCount)
- summary_metrics.yml with providerAccountName as GCP account, gcp project id and golden metrics
- dashboard.json for entity dashboard

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid.
* [x] I've confirmed that my entity type wasn't already defined.