### PR TITLE
feat: Add GCPREDISCLUSTERNODE entity definition

### DIFF
--- a/entity-types/infra-gcpredisclusternode/dashboard.json
+++ b/entity-types/infra-gcpredisclusternode/dashboard.json
@@ -1,0 +1,246 @@
+{
+  "name": "GCP Redis Cluster Node",
+  "description": null,
+  "pages": [
+    {
+      "name": "GCP Redis Cluster Node",
+      "description": null,
+      "widgets": [
+        {
+          "title": "CPU Utilization",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.redis.cluster.node.cpu.utilization`) * 100 AS 'CPU %' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND collector.name = 'gcp-polling-v2' FACET `metric.state` TIMESERIES AUTO"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Memory Utilization",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.redis.cluster.node.memory.utilization`) * 100 AS 'Memory %' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND collector.name = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Memory Usage (Bytes)",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`gcp.redis.cluster.node.memory.usage`) AS 'Memory Bytes' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND collector.name = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Connected Clients",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`gcp.redis.cluster.node.clients.connected_clients`) AS 'Connected' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND collector.name = 'gcp-polling-v2' FACET `metric.role` TIMESERIES AUTO"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Total Keys",
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`gcp.redis.cluster.node.keyspace.total_keys`) AS 'Keys' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND collector.name = 'gcp-polling-v2' FACET `metric.role` TIMESERIES AUTO"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Keyspace Hits vs Misses",
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.redis.cluster.node.stats.keyspace_hits_count`) AS 'Hits', sum(`gcp.redis.cluster.node.stats.keyspace_misses_count`) AS 'Misses' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND collector.name = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Evicted Keys",
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.redis.cluster.node.stats.evicted_keys_count`) AS 'Evicted' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND collector.name = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Commands Executed",
+          "layout": {
+            "column": 5,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.redis.cluster.node.commandstats.calls_count`) AS 'Commands' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND collector.name = 'gcp-polling-v2' FACET `metric.command` TIMESERIES AUTO"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Network Throughput (Bytes)",
+          "layout": {
+            "column": 9,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.redis.cluster.node.stats.net_input_bytes_count`) AS 'Bytes In', sum(`gcp.redis.cluster.node.stats.net_output_bytes_count`) AS 'Bytes Out' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND collector.name = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpredisclusternode/definition.yml
+++ b/entity-types/infra-gcpredisclusternode/definition.yml
@@ -1,0 +1,11 @@
+domain: INFRA
+type: GCPREDISCLUSTERNODE
+goldenTags:
+- gcp.projectId
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-gcpredisclusternode/golden_metrics.yml
+++ b/entity-types/infra-gcpredisclusternode/golden_metrics.yml
@@ -1,0 +1,29 @@
+cpuUtilization:
+  title: CPU utilization
+  unit: PERCENTAGE
+  queries:
+    gcp:
+      select: average(`gcp.redis.cluster.node.cpu.utilization`) * 100
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+
+memoryUtilization:
+  title: Memory utilization
+  unit: PERCENTAGE
+  queries:
+    gcp:
+      select: average(`gcp.redis.cluster.node.memory.utilization`) * 100
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+
+connectedClients:
+  title: Connected clients
+  unit: COUNT
+  queries:
+    gcp:
+      select: latest(`gcp.redis.cluster.node.clients.connected_clients`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-gcpredisclusternode/summary_metrics.yml
+++ b/entity-types/infra-gcpredisclusternode/summary_metrics.yml
@@ -1,0 +1,26 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: GCP account
+  unit: STRING
+
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
+
+cpuUtilization:
+  goldenMetric: cpuUtilization
+  unit: PERCENTAGE
+  title: CPU utilization
+
+memoryUtilization:
+  goldenMetric: memoryUtilization
+  unit: PERCENTAGE
+  title: Memory utilization
+
+connectedClients:
+  goldenMetric: connectedClients
+  unit: COUNT
+  title: Connected clients


### PR DESCRIPTION
### Relevant information

Adding GCPREDISCLUSTERNODE entity definition for GCP Redis Cluster Node (Memorystore for Redis Cluster).

This PR adds:
- definition.yml with entity type, golden tags, and configuration
- golden_metrics.yml with key performance metrics (CPU utilization, memory utilization, connected clients)
- summary_metrics.yml with providerAccountName as GCP account, gcp project id, and golden metrics
- dashboard.json for entity dashboard with 9 widgets covering CPU, memory, keyspace, connections, and network metrics

All metrics sourced from official GCP Cloud Monitoring documentation (GA status only, no ALPHA metrics).

### GCP Resource Details
- Resource type: `redis.googleapis.com/ClusterNode`
- Monitored resource type: `redis.googleapis.com/ClusterNode`
- Metrics namespace: `gcp.redis.cluster.node.*`

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid.
* [x] I've confirmed that my entity type wasn't already defined.