### PR TITLE
feat: add GCP Redis instance entity definition (gcp-polling-v2)

### DIFF
--- a/entity-types/infra-gcpredisinstance/dashboard.json
+++ b/entity-types/infra-gcpredisinstance/dashboard.json
@@ -1,0 +1,273 @@
+{
+  "name": "GCP Redis Instance",
+  "description": null,
+  "pages": [
+    {
+      "name": "Summary",
+      "description": null,
+      "widgets": [
+        {
+          "title": "Cache Hit Ratio (%)",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(gcp.redis.stats.cache_hit_ratio) * 100 AS 'Cache Hit Ratio (%)' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Memory Usage Ratio (%)",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(gcp.redis.stats.memory.usage_ratio) * 100 AS 'Memory Usage Ratio (%)' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Connected Clients",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(gcp.redis.clients.connected) AS 'Connected Clients' FROM Metric WHERE entity.guid = '{{entity.id}}' FACET metric.role TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "CPU Utilization (seconds)",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(gcp.redis.stats.cpu_utilization) AS 'CPU Utilization (s)' FROM Metric WHERE entity.guid = '{{entity.id}}' FACET metric.role TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Network Traffic (bytes)",
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(gcp.redis.stats.network_traffic) AS 'Network Traffic (bytes)' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Keyspace Hits vs Misses",
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(gcp.redis.stats.keyspace_hits) AS 'Hits', sum(gcp.redis.stats.keyspace_misses) AS 'Misses' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Memory Usage (bytes)",
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(gcp.redis.stats.memory.usage) AS 'Used Memory (bytes)', average(gcp.redis.stats.memory.maxmemory) AS 'Max Memory (bytes)' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Evicted & Expired Keys",
+          "layout": {
+            "column": 5,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(gcp.redis.stats.evicted_keys) AS 'Evicted Keys', sum(gcp.redis.stats.expired_keys) AS 'Expired Keys' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Blocked Clients",
+          "layout": {
+            "column": 9,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(gcp.redis.clients.blocked) AS 'Blocked Clients' FROM Metric WHERE entity.guid = '{{entity.id}}' FACET metric.role TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpredisinstance/definition.yml
+++ b/entity-types/infra-gcpredisinstance/definition.yml
@@ -1,6 +1,7 @@
 domain: INFRA
 type: GCPREDISINSTANCE
 goldenTags:
+- gcp.projectId
 - gcp.regionName
 - gcp.subscriptionId
 configuration:

--- a/entity-types/infra-gcpredisinstance/golden_metrics.yml
+++ b/entity-types/infra-gcpredisinstance/golden_metrics.yml
@@ -3,7 +3,7 @@ cacheHitRatio:
   unit: PERCENTAGE
   queries:
     gcp:
-      select: average(gcp.redis.instance.stats.cacheHitRatio)
+      select: average(gcp.redis.stats.cache_hit_ratio) * 100
       from: Metric
       eventId: entity.guid
       eventName: entity.name
@@ -17,7 +17,7 @@ cpuSecondsConsumedS:
   unit: SECONDS
   queries:
     gcp:
-      select: average(gcp.redis.instance.stats.cpuUtilization)
+      select: sum(gcp.redis.stats.cpu_utilization)
       from: Metric
       eventId: entity.guid
       eventName: entity.name
@@ -31,7 +31,7 @@ memoryUsageRatio:
   unit: PERCENTAGE
   queries:
     gcp:
-      select: average(gcp.redis.instance.stats.memory.usageRatio)
+      select: average(gcp.redis.stats.memory.usage_ratio) * 100
       from: Metric
       eventId: entity.guid
       eventName: entity.name
@@ -45,7 +45,7 @@ totalNetworkTrafficBytes:
   unit: BYTES        
   queries:
     gcp:
-      select: average(gcp.redis.instance.stats.networkTraffic)
+      select: sum(gcp.redis.stats.network_traffic)
       from: Metric
       eventId: entity.guid
       eventName: entity.name

--- a/entity-types/infra-gcpredisinstance/summary_metrics.yml
+++ b/entity-types/infra-gcpredisinstance/summary_metrics.yml
@@ -1,0 +1,21 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: GCP account
+  unit: STRING
+cacheHitRatio:
+  goldenMetric: cacheHitRatio
+  unit: PERCENTAGE
+  title: Cache hit ratio
+memoryUsageRatio:
+  goldenMetric: memoryUsageRatio
+  unit: PERCENTAGE
+  title: Memory usage ratio
+cpuSecondsConsumedS:
+  goldenMetric: cpuSecondsConsumedS
+  unit: SECONDS
+  title: CPU utilization
+totalNetworkTrafficBytes:
+  goldenMetric: totalNetworkTrafficBytes
+  unit: BYTES
+  title: Network traffic


### PR DESCRIPTION
## Summary

- Adds `gcp.projectId` to `goldenTags` alongside existing `gcp.regionName` and `gcp.subscriptionId`
- Updates `golden_metrics.yml` with correct gcp-polling-v2 metric names (`gcp.redis.stats.cache_hit_ratio`, `gcp.redis.stats.cpu_utilization`, `gcp.redis.stats.memory.usage_ratio`, `gcp.redis.stats.network_traffic`) replacing legacy camelCase names
- Creates `summary_metrics.yml` referencing the four golden metrics
- Creates `dashboard.json` with 9 widgets covering cache hit ratio, memory usage, connected clients, CPU utilization, network traffic, keyspace hits/misses, evictions, and blocked clients

## Metric naming

Metric names sourced from [GCP Cloud Monitoring API docs](https://cloud.google.com/monitoring/api/metrics_gcp_p_z#gcp-redis) following the gcp-polling-v2 convention: `redis.googleapis.com/stats/cache_hit_ratio` → `gcp.redis.stats.cache_hit_ratio`

## Validation

- All 4 entity-definitions validators pass (`validate-definition`, `validate-golden-metrics`, `validate-summary-metrics`, `validate-dashboard`)
- NRQL queries are syntactically valid; metric names confirmed from official GCP docs (no live Redis data in test accounts)

## Related PRs

- gcp-polling-v2: entity synthesis wiring
- entity-type-ui-definitions-service: UI definition update
- infra-summary: dashboard templates
- infrastructure: dimensional metrics dashboard

🤖 Generated with [Claude Code](https://claude.ai/claude-code)