### PR TITLE
feat: add GCP Cloud Run Revision entity (GCPCLOUDRUNREVISION)

### DIFF
--- a/entity-types/infra-gcpcloudrunrevision/dashboard.json
+++ b/entity-types/infra-gcpcloudrunrevision/dashboard.json
@@ -1,0 +1,186 @@
+{
+  "name": "GCP Cloud Run Revision",
+  "description": null,
+  "pages": [
+    {
+      "name": "Summary",
+      "description": null,
+      "widgets": [
+        {
+          "title": "Request Count",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.run.request_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Error Rate",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT filter(sum(`gcp.run.request_count`), WHERE `metric.response_code_class` IN ('4xx','5xx')) * 100 / sum(`gcp.run.request_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Request Count by Response Code",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.run.request_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.response_code_class` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Request Latency (ms)",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.run.request_latencies`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Container Instance Count",
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.run.container.instance_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.state` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Container CPU Utilization",
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.run.container.cpu.utilizations`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpcloudrunrevision/definition.yml
+++ b/entity-types/infra-gcpcloudrunrevision/definition.yml
@@ -1,0 +1,10 @@
+domain: INFRA
+type: GCPCLOUDRUNREVISION
+goldenTags:
+- gcp.projectId
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-gcpcloudrunrevision/golden_metrics.yml
+++ b/entity-types/infra-gcpcloudrunrevision/golden_metrics.yml
@@ -1,0 +1,27 @@
+requestCount:
+  title: Request Count
+  unit: COUNT
+  queries:
+    gcp:
+      select: sum(`gcp.run.request_count`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+errorRate:
+  title: Error Rate
+  unit: PERCENTAGE
+  queries:
+    gcp:
+      select: filter(sum(`gcp.run.request_count`), WHERE `metric.response_code_class` IN ('4xx','5xx')) * 100 / sum(`gcp.run.request_count`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+requestLatency:
+  title: Request Latency
+  unit: MS
+  queries:
+    gcp:
+      select: average(`gcp.run.request_latencies`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-gcpcloudrunrevision/summary_metrics.yml
+++ b/entity-types/infra-gcpcloudrunrevision/summary_metrics.yml
@@ -1,8 +1,9 @@
-nrAccountId:
+providerAccountName:
   tag:
-    key: nrAccount.id
-  title: NR Account ID
+    key: providerAccountName
+  title: GCP account
   unit: STRING
+
 gcpProjectId:
   tag:
     key: gcp.projectId

--- a/entity-types/infra-gcpcloudrunrevision/summary_metrics.yml
+++ b/entity-types/infra-gcpcloudrunrevision/summary_metrics.yml
@@ -1,0 +1,22 @@
+nrAccountId:
+  tag:
+    key: nrAccount.id
+  title: NR Account ID
+  unit: STRING
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
+requestCount:
+  goldenMetric: requestCount
+  unit: COUNT
+  title: Request Count
+errorRate:
+  goldenMetric: errorRate
+  unit: PERCENTAGE
+  title: Error Rate
+requestLatency:
+  goldenMetric: requestLatency
+  unit: MS
+  title: Request Latency


### PR DESCRIPTION
## Summary

Adds entity definition for GCP Cloud Run Revision (`GCPCLOUDRUNREVISION`).

Cloud Run Revision is the immutable snapshot of Cloud Run service code and configuration. The synthesizer entry already exists in gcp-polling-v2. This PR adds the entity definition, golden metrics, summary metrics, and dashboard.

## Files Added

- `entity-types/infra-gcpcloudrunrevision/definition.yml` — domain INFRA, alertable, goldenTag: gcp.projectId
- `entity-types/infra-gcpcloudrunrevision/golden_metrics.yml` — requestCount, errorRate, requestLatency
- `entity-types/infra-gcpcloudrunrevision/summary_metrics.yml` — NR account, GCP project, golden metrics refs
- `entity-types/infra-gcpcloudrunrevision/dashboard.json` — 6 widgets: request count, error rate, request count by response code, latency, instance count, CPU utilization

## Metrics

All metrics sourced from `run.googleapis.com` via gcp-polling-v2 (FROM Metric only — no Sample events):

| Metric | NR Attribute | Description |
|--------|-------------|-------------|
| requestCount | `gcp.run.request_count` | Number of requests reaching the revision |
| errorRate | derived from request_count filtered 4xx/5xx | Percentage of error responses |
| requestLatency | `gcp.run.request_latencies` | Distribution of request latency in ms |

## Validation

- ✅ All schema validations pass (`npm run check` exit 0)
- ✅ Dashboard sanitizer: no modifications needed
- ⚠️ No live Cloud Run Revision metric data found in accounts 10876283, 686923, 12208939, 10018487
  - Metric names verified against official GCP documentation: https://cloud.google.com/monitoring/api/metrics_gcp_p_z?hl=en#gcp-run
  - Query syntax validated (no NRQL errors)

## Related PRs

- entity-type-ui-definitions-service: add GCPCLOUDRUNREVISION UI definition
- infra-summary: add GCPCLOUDRUNREVISION dashboard templates
- infrastructure: add gcp_run_dimensional_metrics.json