### PR TITLE
feat: add GCP AlloyDB and AI Platform entity definitions

### DIFF
--- a/entity-types/infra-gcpaiplatformendpoint/dashboard.json
+++ b/entity-types/infra-gcpaiplatformendpoint/dashboard.json
@@ -1,0 +1,200 @@
+{
+  "name": "GCP AI Platform Endpoint",
+  "pages": [
+    {
+      "name": "GCP AI Platform Endpoint",
+      "widgets": [
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "height": 3,
+            "width": 4
+          },
+          "title": "Prediction Count",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT sum(`gcp.aiplatform.prediction.online.prediction_count`) WHERE entity.guid = '{{entity.id}}' TIMESERIES AUTO",
+                "accountId": 0}
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "height": 3,
+            "width": 4
+          },
+          "title": "Error Count",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT sum(`gcp.aiplatform.prediction.online.error_count`) WHERE entity.guid = '{{entity.id}}' TIMESERIES AUTO",
+                "accountId": 0}
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "height": 3,
+            "width": 4
+          },
+          "title": "Prediction Latency (ms)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT average(`gcp.aiplatform.prediction.online.prediction_latencies`) AS 'Latency (ms)' WHERE entity.guid = '{{entity.id}}' TIMESERIES AUTO",
+                "accountId": 0}
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "height": 3,
+            "width": 4
+          },
+          "title": "CPU Utilization",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT average(`gcp.aiplatform.prediction.online.cpu.utilization`) AS 'CPU %' WHERE entity.guid = '{{entity.id}}' TIMESERIES AUTO",
+                "accountId": 0}
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "height": 3,
+            "width": 4
+          },
+          "title": "Memory Usage (bytes)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT average(`gcp.aiplatform.prediction.online.memory.bytes_used`) AS 'Memory (bytes)' WHERE entity.guid = '{{entity.id}}' TIMESERIES AUTO",
+                "accountId": 0}
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "height": 3,
+            "width": 4
+          },
+          "title": "Replicas",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT latest(`gcp.aiplatform.prediction.online.replicas`) AS 'Replicas', latest(`gcp.aiplatform.prediction.online.target_replicas`) AS 'Target Replicas' WHERE entity.guid = '{{entity.id}}' TIMESERIES AUTO",
+                "accountId": 0}
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "height": 3,
+            "width": 6
+          },
+          "title": "Network Bytes Sent",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT sum(`gcp.aiplatform.prediction.online.network.sent_bytes_count`) AS 'Bytes Sent' WHERE entity.guid = '{{entity.id}}' TIMESERIES AUTO",
+                "accountId": 0}
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 7,
+            "row": 7,
+            "height": 3,
+            "width": 6
+          },
+          "title": "Network Bytes Received",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT sum(`gcp.aiplatform.prediction.online.network.received_bytes_count`) AS 'Bytes Received' WHERE entity.guid = '{{entity.id}}' TIMESERIES AUTO",
+                "accountId": 0}
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.bar"
+          },
+          "layout": {
+            "column": 1,
+            "row": 10,
+            "height": 3,
+            "width": 6
+          },
+          "title": "Errors by Deployed Model",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT sum(`gcp.aiplatform.prediction.online.error_count`) FACET metric.deployed_model_id WHERE entity.guid = '{{entity.id}}' SINCE 1 hour ago",
+                "accountId": 0}
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.bar"
+          },
+          "layout": {
+            "column": 7,
+            "row": 10,
+            "height": 3,
+            "width": 6
+          },
+          "title": "Prediction Count by Deployed Model",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT sum(`gcp.aiplatform.prediction.online.prediction_count`) FACET metric.deployed_model_id WHERE entity.guid = '{{entity.id}}' SINCE 1 hour ago",
+                "accountId": 0}
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpaiplatformendpoint/definition.yml
+++ b/entity-types/infra-gcpaiplatformendpoint/definition.yml
@@ -4,6 +4,10 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 
+goldenTags:
+  - gcp.projectId
+  - gcp.region
+
 ownership:
   primaryOwner:
     teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-gcpaiplatformendpoint/golden_metrics.yml
+++ b/entity-types/infra-gcpaiplatformendpoint/golden_metrics.yml
@@ -3,12 +3,12 @@ cpuUtilization:
   unit: PERCENTAGE
   queries:
     gcp:
-      select: average(gcp.vertexAiEndpoint.prediction.online.cpu.Utilization)
+      select: average(gcp.aiplatform.prediction.online.cpu.utilization)
       from: Metric
       eventId: entity.guid
       eventName: entity.name
     gcpSample:
-      select: average(`prediction.online.cpu.Utilization`)
+      select: average(prediction.online.cpu.Utilization)
       from: GcpVertexAiEndpointSample
       eventId: entityGuid
       eventName: entityName
@@ -17,12 +17,12 @@ memoryUsage:
   unit: BYTES
   queries:
     gcp:
-      select: average(gcp.vertexAiEndpoint.prediction.online.memory.BytesUsed)
+      select: average(gcp.aiplatform.prediction.online.memory.bytes_used)
       from: Metric
       eventId: entity.guid
       eventName: entity.name
     gcpSample:
-      select: average(`prediction.online.cpu.memory.BytesUsed`)
+      select: average(prediction.online.memory.BytesUsed)
       from: GcpVertexAiEndpointSample
       eventId: entityGuid
       eventName: entityName
@@ -31,12 +31,12 @@ bytesSent:
   unit: BYTES
   queries:
     gcp:
-      select: average(gcp.vertexAiEndpoint.prediction.online.network.SentBytes)
+      select: average(gcp.aiplatform.prediction.online.network.sent_bytes_count)
       from: Metric
       eventId: entity.guid
       eventName: entity.name
     gcpSample:
-      select: average(`prediction.online.cpu.network.SentBytes`)
+      select: average(prediction.online.network.SentBytes)
       from: GcpVertexAiEndpointSample
       eventId: entityGuid
       eventName: entityName
@@ -45,12 +45,40 @@ bytesReceived:
   unit: BYTES
   queries:
     gcp:
-      select: average(gcp.vertexAiEndpoint.prediction.online.network.ReceivedBytes)
+      select: average(gcp.aiplatform.prediction.online.network.received_bytes_count)
       from: Metric
       eventId: entity.guid
       eventName: entity.name
     gcpSample:
-      select: average(`prediction.online.cpu.network.ReceivedBytes`)
+      select: average(prediction.online.network.ReceivedBytes)
+      from: GcpVertexAiEndpointSample
+      eventId: entityGuid
+      eventName: entityName
+predictionCount:
+  title: Prediction count
+  unit: COUNT
+  queries:
+    gcp:
+      select: sum(gcp.aiplatform.prediction.online.prediction_count)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    gcpSample:
+      select: sum(prediction.online.ResponseCount)
+      from: GcpVertexAiEndpointSample
+      eventId: entityGuid
+      eventName: entityName
+errorCount:
+  title: Error count
+  unit: COUNT
+  queries:
+    gcp:
+      select: sum(gcp.aiplatform.prediction.online.error_count)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    gcpSample:
+      select: sum(prediction.online.Error)
       from: GcpVertexAiEndpointSample
       eventId: entityGuid
       eventName: entityName

--- a/entity-types/infra-gcpaiplatformendpoint/summary_metrics.yml
+++ b/entity-types/infra-gcpaiplatformendpoint/summary_metrics.yml
@@ -3,6 +3,15 @@ providerAccountName:
     key: providerAccountName
   title: GCP account
   unit: STRING
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
+cpuUtilization:
+  goldenMetric: cpuUtilization
+  unit: PERCENTAGE
+  title: CPU Utilization
 bytesReceived:
   goldenMetric: bytesReceived
   unit: BYTES

--- a/entity-types/infra-gcpaiplatformfeatureonlinestore/dashboard.json
+++ b/entity-types/infra-gcpaiplatformfeatureonlinestore/dashboard.json
@@ -1,0 +1,186 @@
+{
+  "name": "GCP AI Platform Feature Online Store",
+  "description": null,
+  "pages": [
+    {
+      "name": "GCP AI Platform Feature Online Store",
+      "description": null,
+      "widgets": [
+        {
+          "title": "Request Count by Feature View",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT sum(`gcp.aiplatform.featureonlinestore.online_serving.request_count`) WHERE `entity.guid` = '{{entity.id}}' FACET `metric.feature_view_id` TIMESERIES"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Serving Latency by Feature View (ms)",
+          "layout": {
+            "column": 7,
+            "row": 1,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT average(`gcp.aiplatform.featureonlinestore.online_serving.serving_latencies`) WHERE `entity.guid` = '{{entity.id}}' FACET `metric.feature_view_id` TIMESERIES"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Stored Bytes",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT sum(`gcp.aiplatform.featureonlinestore.storage.stored_bytes`) WHERE `entity.guid` = '{{entity.id}}' TIMESERIES"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Serving Bytes Count by Feature View",
+          "layout": {
+            "column": 7,
+            "row": 4,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT sum(`gcp.aiplatform.featureonlinestore.online_serving.serving_bytes_count`) WHERE `entity.guid` = '{{entity.id}}' FACET `metric.feature_view_id` TIMESERIES"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Bigtable CPU Load (%)",
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT average(`gcp.aiplatform.featureonlinestore.storage.bigtable_cpu_load`) WHERE `entity.guid` = '{{entity.id}}' TIMESERIES"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Bigtable Nodes",
+          "layout": {
+            "column": 7,
+            "row": 7,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT sum(`gcp.aiplatform.featureonlinestore.storage.bigtable_nodes`) WHERE `entity.guid` = '{{entity.id}}' TIMESERIES"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpaiplatformfeatureonlinestore/golden_metrics.yml
+++ b/entity-types/infra-gcpaiplatformfeatureonlinestore/golden_metrics.yml
@@ -7,6 +7,11 @@ request:
       from: GcpVertexAiFeatureOnlineStoreSample
       eventId: entityGuid
       eventName: entityName
+    gcp:
+      select: sum(gcp.aiplatform.featureonlinestore.online_serving.request_count)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
 latencies:
   title: Latency
   unit: MS
@@ -16,6 +21,11 @@ latencies:
       from: GcpVertexAiFeatureOnlineStoreSample
       eventId: entityGuid
       eventName: entityName
+    gcp:
+      select: average(gcp.aiplatform.featureonlinestore.online_serving.serving_latencies)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
 storedBytes:
   title: Stored Bytes
   unit: BYTES
@@ -25,3 +35,35 @@ storedBytes:
       from: GcpVertexAiFeatureOnlineStoreSample
       eventId: entityGuid
       eventName: entityName
+    gcp:
+      select: sum(gcp.aiplatform.featureonlinestore.storage.stored_bytes)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+servingBytesCount:
+  title: Serving Bytes
+  unit: BYTES
+  queries:
+    gcp:
+      select: sum(gcp.aiplatform.featureonlinestore.online_serving.serving_bytes_count)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+bigtableCpuLoad:
+  title: Bigtable CPU Load
+  unit: PERCENTAGE
+  queries:
+    gcp:
+      select: average(gcp.aiplatform.featureonlinestore.storage.bigtable_cpu_load)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+bigtableNodes:
+  title: Bigtable Nodes
+  unit: COUNT
+  queries:
+    gcp:
+      select: sum(gcp.aiplatform.featureonlinestore.storage.bigtable_nodes)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-gcpaiplatformfeatureonlinestore/golden_metrics.yml
+++ b/entity-types/infra-gcpaiplatformfeatureonlinestore/golden_metrics.yml
@@ -36,7 +36,7 @@ storedBytes:
       eventId: entityGuid
       eventName: entityName
     gcp:
-      select: sum(gcp.aiplatform.featureonlinestore.storage.stored_bytes)
+      select: average(gcp.aiplatform.featureonlinestore.storage.stored_bytes)
       from: Metric
       eventId: entity.guid
       eventName: entity.name

--- a/entity-types/infra-gcpaiplatformfeatureonlinestore/summary_metrics.yml
+++ b/entity-types/infra-gcpaiplatformfeatureonlinestore/summary_metrics.yml
@@ -3,6 +3,11 @@ providerAccountName:
     key: providerAccountName
   title: GCP account
   unit: STRING
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
 request:
   goldenMetric: request
   unit: COUNT

--- a/entity-types/infra-gcpaiplatformfeatureonlinestore/summary_metrics.yml
+++ b/entity-types/infra-gcpaiplatformfeatureonlinestore/summary_metrics.yml
@@ -20,3 +20,15 @@ storedBytes:
   goldenMetric: storedBytes
   unit: BYTES
   title: Stored Bytes
+servingBytesCount:
+  goldenMetric: servingBytesCount
+  unit: BYTES
+  title: Serving Bytes
+bigtableCpuLoad:
+  goldenMetric: bigtableCpuLoad
+  unit: PERCENTAGE
+  title: Bigtable CPU Load
+bigtableNodes:
+  goldenMetric: bigtableNodes
+  unit: COUNT
+  title: Bigtable Nodes

--- a/entity-types/infra-gcpaiplatformfeaturestore/dashboard.json
+++ b/entity-types/infra-gcpaiplatformfeaturestore/dashboard.json
@@ -1,0 +1,240 @@
+{
+  "name": "GCP AI Platform Featurestore",
+  "description": null,
+  "pages": [
+    {
+      "name": "Overview",
+      "description": null,
+      "widgets": [
+        {
+          "title": "CPU Load",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.aiplatform.featurestore.cpu_load`) AS 'CPU Load (%)' FROM Metric WHERE entity.guid IN ({{entity.id}}) TIMESERIES AUTO"
+              }
+            ]
+          }
+        },
+        {
+          "title": "CPU Load (Hottest Node)",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.aiplatform.featurestore.cpu_load_hottest_node`) AS 'CPU Load Hottest Node (%)' FROM Metric WHERE entity.guid IN ({{entity.id}}) TIMESERIES AUTO"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Node Count",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`gcp.aiplatform.featurestore.node_count`) AS 'Node Count' FROM Metric WHERE entity.guid IN ({{entity.id}})"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Online Serving Request Count",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.aiplatform.featurestore.online_serving.request_count`) AS 'Request Count' FROM Metric WHERE entity.guid IN ({{entity.id}}) TIMESERIES AUTO"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Online Serving Latency",
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.aiplatform.featurestore.online_serving.latencies`) AS 'Latency (ms)' FROM Metric WHERE entity.guid IN ({{entity.id}}) TIMESERIES AUTO"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Request Count by Entity Type",
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.aiplatform.featurestore.online_serving.request_count`) AS 'Requests' FROM Metric WHERE entity.guid IN ({{entity.id}}) FACET `metric.entity_type_id` TIMESERIES AUTO"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Stored Bytes by Storage Type",
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.aiplatform.featurestore.storage.stored_bytes`) AS 'Stored Bytes' FROM Metric WHERE entity.guid IN ({{entity.id}}) FACET `metric.storage_type` TIMESERIES AUTO"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Online Serving Request Bytes",
+          "layout": {
+            "column": 5,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.aiplatform.featurestore.online_serving.request_bytes_count`) AS 'Request Bytes' FROM Metric WHERE entity.guid IN ({{entity.id}}) TIMESERIES AUTO"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Entities Updated (Online Storage)",
+          "layout": {
+            "column": 9,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.aiplatform.featurestore.online_entities_updated`) AS 'Entities Updated' FROM Metric WHERE entity.guid IN ({{entity.id}}) FACET `metric.type` TIMESERIES AUTO"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpaiplatformfeaturestore/definition.yml
+++ b/entity-types/infra-gcpaiplatformfeaturestore/definition.yml
@@ -1,5 +1,8 @@
 domain: INFRA
 type: GCPAIPLATFORMFEATURESTORE
+goldenTags:
+  - gcp.projectId
+  - gcp.region
 configuration:
   entityExpirationTime: DAILY
   alertable: true

--- a/entity-types/infra-gcpaiplatformfeaturestore/golden_metrics.yml
+++ b/entity-types/infra-gcpaiplatformfeaturestore/golden_metrics.yml
@@ -3,7 +3,7 @@ storedBytes:
   unit: BYTES
   queries:
     gcp:
-      select: average(gcp.featurestore.online_serving.RequestBytes)
+      select: average(gcp.aiplatform.featurestore.storage.stored_bytes)
       from: Metric
       eventId: entity.guid
       eventName: entity.name
@@ -17,7 +17,7 @@ cpuLoad:
   unit: PERCENTAGE
   queries:
     gcp:
-      select: average(gcp.featurestore.CpuLoad)
+      select: average(gcp.aiplatform.featurestore.cpu_load)
       from: Metric
       eventId: entity.guid
       eventName: entity.name
@@ -31,7 +31,7 @@ latency:
   unit: MS
   queries:
     gcp:
-      select: average(gcp.featurestore.online_serving.Latencies)
+      select: average(gcp.aiplatform.featurestore.online_serving.latencies)
       from: Metric
       eventId: entity.guid
       eventName: entity.name

--- a/entity-types/infra-gcpaiplatformfeaturestore/summary_metrics.yml
+++ b/entity-types/infra-gcpaiplatformfeaturestore/summary_metrics.yml
@@ -3,6 +3,11 @@ providerAccountName:
     key: providerAccountName
   title: GCP account
   unit: STRING
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
 storedBytes:
   goldenMetric: storedBytes
   unit: BYTES

--- a/entity-types/infra-gcpaiplatformindex/dashboard.json
+++ b/entity-types/infra-gcpaiplatformindex/dashboard.json
@@ -1,0 +1,83 @@
+{
+  "name": "GCP AI Platform Index",
+  "description": null,
+  "pages": [
+    {
+      "name": "GCP AI Platform Index",
+      "description": null,
+      "widgets": [
+        {
+          "title": "Stream Update Requests",
+          "layout": {"column": 1, "row": 1, "width": 4, "height": 3},
+          "visualization": {"id": "viz.line"},
+          "rawConfiguration": {
+            "legend": {"enabled": true},
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT sum(`gcp.aiplatform.matching_engine.stream_update.request_count`) AS 'Requests' WHERE entity.guid IN ({{entity.guid}}) FACET `metric.request_type` TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {"zero": true}
+          }
+        },
+        {
+          "title": "Stream Update Latency (ms)",
+          "layout": {"column": 5, "row": 1, "width": 4, "height": 3},
+          "visualization": {"id": "viz.line"},
+          "rawConfiguration": {
+            "legend": {"enabled": true},
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT average(`gcp.aiplatform.matching_engine.stream_update.latencies`) AS 'Latency (ms)' WHERE entity.guid IN ({{entity.guid}}) FACET `metric.request_type` TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {"zero": true}
+          }
+        },
+        {
+          "title": "Stream Update Datapoint Count",
+          "layout": {"column": 9, "row": 1, "width": 4, "height": 3},
+          "visualization": {"id": "viz.line"},
+          "rawConfiguration": {
+            "legend": {"enabled": true},
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT sum(`gcp.aiplatform.matching_engine.stream_update.datapoint_count`) AS 'Datapoints' WHERE entity.guid IN ({{entity.guid}}) FACET `metric.request_type` TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {"zero": true}
+          }
+        },
+        {
+          "title": "Requests by Deployed Index",
+          "layout": {"column": 1, "row": 4, "width": 6, "height": 3},
+          "visualization": {"id": "viz.bar"},
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT sum(`gcp.aiplatform.matching_engine.stream_update.request_count`) AS 'Requests' WHERE entity.guid IN ({{entity.guid}}) FACET `metric.deployed_index_id` SINCE 1 hour ago"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Datapoints by Request Type",
+          "layout": {"column": 7, "row": 4, "width": 6, "height": 3},
+          "visualization": {"id": "viz.bar"},
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT sum(`gcp.aiplatform.matching_engine.stream_update.datapoint_count`) AS 'Datapoints' WHERE entity.guid IN ({{entity.guid}}) FACET `metric.request_type` SINCE 1 hour ago"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpaiplatformindex/definition.yml
+++ b/entity-types/infra-gcpaiplatformindex/definition.yml
@@ -4,6 +4,10 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 
+goldenTags:
+  - gcp.projectId
+  - gcp.region
+
 ownership:
   primaryOwner:
     teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-gcpaiplatformindex/golden_metrics.yml
+++ b/entity-types/infra-gcpaiplatformindex/golden_metrics.yml
@@ -2,6 +2,11 @@ request:
   title: Total Requests
   unit: COUNT
   queries:
+    gcp:
+      select: sum(gcp.aiplatform.matching_engine.stream_update.request_count)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
     gcpSample:
       select: sum(matchingEngine.streamUpdate.Request)
       from: GcpVertexAiIndexSample
@@ -11,6 +16,11 @@ latencies:
   title: Latency
   unit: MS
   queries:
+    gcp:
+      select: average(gcp.aiplatform.matching_engine.stream_update.latencies)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
     gcpSample:
       select: average(matchingEngine.streamUpdate.Latencies)
       from: GcpVertexAiIndexSample
@@ -20,6 +30,11 @@ datapointCount:
   title: Datapoint Count
   unit: COUNT
   queries:
+    gcp:
+      select: sum(gcp.aiplatform.matching_engine.stream_update.datapoint_count)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
     gcpSample:
       select: average(matchingEngine.streamUpdate.Datapoint)
       from: GcpVertexAiIndexSample

--- a/entity-types/infra-gcpaiplatformindex/golden_metrics.yml
+++ b/entity-types/infra-gcpaiplatformindex/golden_metrics.yml
@@ -31,7 +31,7 @@ datapointCount:
   unit: COUNT
   queries:
     gcp:
-      select: sum(gcp.aiplatform.matching_engine.stream_update.datapoint_count)
+      select: average(gcp.aiplatform.matching_engine.stream_update.datapoint_count)
       from: Metric
       eventId: entity.guid
       eventName: entity.name

--- a/entity-types/infra-gcpaiplatformindex/summary_metrics.yml
+++ b/entity-types/infra-gcpaiplatformindex/summary_metrics.yml
@@ -3,6 +3,11 @@ providerAccountName:
     key: providerAccountName
   title: GCP account
   unit: STRING
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
 request:
   goldenMetric: request
   unit: COUNT

--- a/entity-types/infra-gcpaiplatformlocation/dashboard.json
+++ b/entity-types/infra-gcpaiplatformlocation/dashboard.json
@@ -1,0 +1,162 @@
+{
+  "name": "GCP AI Platform Location",
+  "description": null,
+  "pages": [
+    {
+      "name": "GCP AI Platform Location",
+      "description": null,
+      "widgets": [
+        {
+          "title": "Executing Pipeline Jobs",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.aiplatform.executing_vertexai_pipeline_jobs`) AS 'Pipeline Jobs' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES AUTO",
+                "offset": 300000
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Executing Pipeline Tasks",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.aiplatform.executing_vertexai_pipeline_tasks`) AS 'Pipeline Tasks' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES AUTO",
+                "offset": 300000
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Online Prediction Requests by Base Model",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.aiplatform.online_prediction_requests_per_base_model`) AS 'Requests' FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.base_model` TIMESERIES AUTO",
+                "offset": 300000
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Online Prediction Input Tokens",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.aiplatform.online_prediction_input_tokens_per_minute_per_base_model`) AS 'Input Tokens' FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.base_model` TIMESERIES AUTO",
+                "offset": 300000
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Online Prediction Output Tokens",
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.aiplatform.online_prediction_output_tokens_per_minute_per_base_model`) AS 'Output Tokens' FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.base_model` TIMESERIES AUTO",
+                "offset": 300000
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpaiplatformlocation/definition.yml
+++ b/entity-types/infra-gcpaiplatformlocation/definition.yml
@@ -4,6 +4,10 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 
+goldenTags:
+  - gcp.projectId
+  - gcp.region
+
 ownership:
   primaryOwner:
     teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-gcpaiplatformlocation/golden_metrics.yml
+++ b/entity-types/infra-gcpaiplatformlocation/golden_metrics.yml
@@ -1,3 +1,13 @@
+executingPipelineJobs:
+  title: Executing Pipeline Jobs
+  unit: COUNT
+  queries:
+    gcp:
+      select: sum(gcp.aiplatform.executing_vertexai_pipeline_jobs)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+
 pipelineTasks:
   title: Pipeline Tasks
   unit: COUNT
@@ -7,6 +17,12 @@ pipelineTasks:
       from: GcpVertexAiLocationSample
       eventId: entityGuid
       eventName: entityName
+    gcp:
+      select: sum(gcp.aiplatform.executing_vertexai_pipeline_tasks)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+
 onlinePredictionRequestsPerBaseModel:
   title: Online Prediction Requests Per Base Model
   unit: COUNT
@@ -16,3 +32,28 @@ onlinePredictionRequestsPerBaseModel:
       from: GcpVertexAiLocationSample
       eventId: entityGuid
       eventName: entityName
+    gcp:
+      select: sum(gcp.aiplatform.online_prediction_requests_per_base_model)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+
+onlinePredictionInputTokens:
+  title: Online Prediction Input Tokens Per Minute
+  unit: COUNT
+  queries:
+    gcp:
+      select: sum(gcp.aiplatform.online_prediction_input_tokens_per_minute_per_base_model)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+
+onlinePredictionOutputTokens:
+  title: Online Prediction Output Tokens Per Minute
+  unit: COUNT
+  queries:
+    gcp:
+      select: sum(gcp.aiplatform.online_prediction_output_tokens_per_minute_per_base_model)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-gcpaiplatformlocation/golden_metrics.yml
+++ b/entity-types/infra-gcpaiplatformlocation/golden_metrics.yml
@@ -33,7 +33,7 @@ onlinePredictionRequestsPerBaseModel:
       eventId: entityGuid
       eventName: entityName
     gcp:
-      select: sum(gcp.aiplatform.online_prediction_requests_per_base_model)
+      select: average(gcp.aiplatform.online_prediction_requests_per_base_model)
       from: Metric
       eventId: entity.guid
       eventName: entity.name

--- a/entity-types/infra-gcpaiplatformlocation/summary_metrics.yml
+++ b/entity-types/infra-gcpaiplatformlocation/summary_metrics.yml
@@ -8,6 +8,10 @@ gcpProjectId:
     key: gcp.projectId
   title: GCP Project ID
   unit: STRING
+executingPipelineJobs:
+  goldenMetric: executingPipelineJobs
+  unit: COUNT
+  title: Executing Pipeline Jobs
 pipelineTasks:
   goldenMetric: pipelineTasks
   unit: COUNT
@@ -16,3 +20,11 @@ onlinePredictionRequestsPerBaseModel:
   goldenMetric: onlinePredictionRequestsPerBaseModel
   unit: COUNT
   title: Online Prediction Requests Per Base Model
+onlinePredictionInputTokens:
+  goldenMetric: onlinePredictionInputTokens
+  unit: COUNT
+  title: Online Prediction Input Tokens Per Minute
+onlinePredictionOutputTokens:
+  goldenMetric: onlinePredictionOutputTokens
+  unit: COUNT
+  title: Online Prediction Output Tokens Per Minute

--- a/entity-types/infra-gcpaiplatformlocation/summary_metrics.yml
+++ b/entity-types/infra-gcpaiplatformlocation/summary_metrics.yml
@@ -3,6 +3,11 @@ providerAccountName:
     key: providerAccountName
   title: GCP account
   unit: STRING
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
 pipelineTasks:
   goldenMetric: pipelineTasks
   unit: COUNT

--- a/entity-types/infra-gcpaiplatformpipelinejob/summary_metrics.yml
+++ b/entity-types/infra-gcpaiplatformpipelinejob/summary_metrics.yml
@@ -3,6 +3,11 @@ providerAccountName:
     key: providerAccountName
   title: GCP account
   unit: STRING
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
 jobDuration:
   goldenMetric: jobDuration
   unit: SECONDS

--- a/entity-types/infra-gcpalloydbcluster/dashboard.json
+++ b/entity-types/infra-gcpalloydbcluster/dashboard.json
@@ -1,0 +1,65 @@
+{
+  "name": "GCP AlloyDB Cluster",
+  "description": null,
+  "pages": [
+    {
+      "name": "GCP AlloyDB Cluster",
+      "description": null,
+      "widgets": [
+        {
+          "title": "Storage Usage (bytes)",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT sum(`gcp.alloydb.cluster.storage.usage`) AS 'Storage Usage' WHERE entity.guid IN ({{entity.guid}}) TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Last Backup Time",
+          "layout": {
+            "column": 7,
+            "row": 1,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "dataFormatters": [
+              {
+                "name": "Last Backup Time",
+                "type": "date"
+              }
+            ],
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT latest(`gcp.alloydb.cluster.last_backup_timestamp`) AS 'Last Backup Time' WHERE entity.guid IN ({{entity.guid}}) FACET `metric.backup_type`"
+              }
+            ],
+            "thresholds": []
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpalloydbcluster/definition.yml
+++ b/entity-types/infra-gcpalloydbcluster/definition.yml
@@ -4,6 +4,10 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 
+goldenTags:
+  - gcp.projectId
+  - gcp.region
+
 ownership:
   primaryOwner:
     teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-gcpalloydbcluster/golden_metrics.yml
+++ b/entity-types/infra-gcpalloydbcluster/golden_metrics.yml
@@ -1,0 +1,18 @@
+storageUsage:
+  title: Storage Usage
+  unit: BYTES
+  queries:
+    gcp:
+      select: sum(gcp.alloydb.cluster.storage.usage)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+backupLastBackupTime:
+  title: Last Backup Time
+  unit: TIMESTAMP
+  queries:
+    gcp:
+      select: latest(gcp.alloydb.cluster.last_backup_timestamp)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-gcpalloydbcluster/summary_metrics.yml
+++ b/entity-types/infra-gcpalloydbcluster/summary_metrics.yml
@@ -1,0 +1,18 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: GCP account
+  unit: STRING
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
+storageUsage:
+  goldenMetric: storageUsage
+  unit: BYTES
+  title: Storage Usage
+backupLastBackupTime:
+  goldenMetric: backupLastBackupTime
+  unit: TIMESTAMP
+  title: Last Backup Time

--- a/entity-types/infra-gcpalloydbdatabase/dashboard.json
+++ b/entity-types/infra-gcpalloydbdatabase/dashboard.json
@@ -1,0 +1,302 @@
+{
+  "name": "GCP AlloyDB Database",
+  "description": null,
+  "pages": [
+    {
+      "name": "GCP AlloyDB Database",
+      "description": null,
+      "widgets": [
+        {
+          "title": "Client Connections",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT sum(`gcp.alloydb.database.conn_pool.client_connections`) AS 'Client Connections' WHERE entity.guid = '{{entity.guid}}' TIMESERIES AUTO FACET `metric.status`, `metric.pooler`"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Server Connections",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT sum(`gcp.alloydb.database.conn_pool.server_connections`) AS 'Server Connections' WHERE entity.guid = '{{entity.guid}}' TIMESERIES AUTO FACET `metric.status`, `metric.pooler`"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Client Connection Wait Time",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT average(`gcp.alloydb.database.conn_pool.client_connection_wait_time`) AS 'Wait Time (ms)' WHERE entity.guid = '{{entity.guid}}' TIMESERIES AUTO FACET `metric.pooler`"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Committed Transactions",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT sum(`gcp.alloydb.database.postgresql.committed_transactions_for_top_databases`) AS 'Committed Transactions' WHERE entity.guid = '{{entity.guid}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Rolled Back Transactions",
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT sum(`gcp.alloydb.database.postgresql.rolledback_transactions_for_top_databases`) AS 'Rolled Back Transactions' WHERE entity.guid = '{{entity.guid}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Query Execution Time",
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT sum(`gcp.alloydb.database.postgresql.insights.aggregate.execution_time`) / 1000000 AS 'Execution Time (s)' WHERE entity.guid = '{{entity.guid}}' TIMESERIES AUTO FACET `metric.user`, `metric.client_addr`"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Query Latency",
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT sum(`gcp.alloydb.database.postgresql.insights.aggregate.latencies`) / 1000000 AS 'Query Latency (s)' WHERE entity.guid = '{{entity.guid}}' TIMESERIES AUTO FACET `metric.user`, `metric.client_addr`"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Buffer Cache Hits",
+          "layout": {
+            "column": 5,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT sum(`gcp.alloydb.database.postgresql.blks_hit_for_top_databases`) AS 'Blocks Hit' WHERE entity.guid = '{{entity.guid}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Disk Blocks Read",
+          "layout": {
+            "column": 9,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT sum(`gcp.alloydb.database.postgresql.blks_read_for_top_databases`) AS 'Blocks Read' WHERE entity.guid = '{{entity.guid}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Deadlocks",
+          "layout": {
+            "column": 1,
+            "row": 10,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT sum(`gcp.alloydb.database.postgresql.deadlock_count_for_top_databases`) AS 'Deadlocks' WHERE entity.guid = '{{entity.guid}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpalloydbdatabase/definition.yml
+++ b/entity-types/infra-gcpalloydbdatabase/definition.yml
@@ -4,6 +4,10 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 
+goldenTags:
+  - gcp.projectId
+  - gcp.region
+
 ownership:
   primaryOwner:
     teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-gcpalloydbdatabase/golden_metrics.yml
+++ b/entity-types/infra-gcpalloydbdatabase/golden_metrics.yml
@@ -1,0 +1,27 @@
+clientConnections:
+  title: Client Connections
+  unit: COUNT
+  queries:
+    gcp:
+      select: sum(`gcp.alloydb.database.conn_pool.client_connections`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+committedTransactions:
+  title: Committed Transactions
+  unit: COUNT
+  queries:
+    gcp:
+      select: sum(`gcp.alloydb.database.postgresql.committed_transactions_for_top_databases`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+executionTime:
+  title: Execution Time
+  unit: SECONDS
+  queries:
+    gcp:
+      select: sum(`gcp.alloydb.database.postgresql.insights.aggregate.execution_time`) / 1000000
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-gcpalloydbdatabase/summary_metrics.yml
+++ b/entity-types/infra-gcpalloydbdatabase/summary_metrics.yml
@@ -1,0 +1,22 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: GCP account
+  unit: STRING
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
+clientConnections:
+  goldenMetric: clientConnections
+  unit: COUNT
+  title: Client Connections
+committedTransactions:
+  goldenMetric: committedTransactions
+  unit: COUNT
+  title: Committed Transactions
+executionTime:
+  goldenMetric: executionTime
+  unit: SECONDS
+  title: Execution Time

--- a/entity-types/infra-gcpalloydbinstance/dashboard.json
+++ b/entity-types/infra-gcpalloydbinstance/dashboard.json
@@ -1,0 +1,273 @@
+{
+  "name": "GCP AlloyDB Instance",
+  "description": null,
+  "pages": [
+    {
+      "name": "Summary",
+      "description": null,
+      "widgets": [
+        {
+          "title": "CPU Average Utilization",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.alloydb.instance.cpu.average_utilization`) AS 'Avg CPU %' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "CPU Maximum Utilization",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT max(`gcp.alloydb.instance.cpu.maximum_utilization`) AS 'Max CPU %' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Minimum Available Memory",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.area"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.alloydb.instance.memory.min_available_memory`) AS 'Min Available Memory (bytes)' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Total Connections",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.alloydb.instance.postgres.total_connections`) AS 'Total Connections' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Average Connections per Node",
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.alloydb.instance.postgres.average_connections`) AS 'Avg Connections/Node' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Connections Limit per Node",
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.alloydb.instance.postgres.connections_limit`) AS 'Connection Limit/Node' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Committed Transactions",
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(sum(`gcp.alloydb.instance.postgres.commit_count`), 1 minute) AS 'Commits/min' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Rolled Back Transactions",
+          "layout": {
+            "column": 5,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(sum(`gcp.alloydb.instance.postgres.abort_count`), 1 minute) AS 'Rollbacks/min' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Replication Lag",
+          "layout": {
+            "column": 9,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT max(`gcp.alloydb.instance.postgres.replication.maximum_lag`) AS 'Max Replication Lag (ms)' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpalloydbinstance/definition.yml
+++ b/entity-types/infra-gcpalloydbinstance/definition.yml
@@ -4,6 +4,10 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 
+goldenTags:
+  - gcp.projectId
+  - gcp.region
+
 ownership:
   primaryOwner:
     teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-gcpalloydbinstance/golden_metrics.yml
+++ b/entity-types/infra-gcpalloydbinstance/golden_metrics.yml
@@ -1,0 +1,27 @@
+cpuAverageUtilization:
+  title: CPU Average Utilization
+  unit: PERCENTAGE
+  queries:
+    gcp:
+      select: average(`gcp.alloydb.instance.cpu.average_utilization`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+totalConnections:
+  title: Total Connections
+  unit: COUNT
+  queries:
+    gcp:
+      select: sum(`gcp.alloydb.instance.postgres.total_connections`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+minAvailableMemory:
+  title: Minimum Available Memory
+  unit: BYTES
+  queries:
+    gcp:
+      select: average(`gcp.alloydb.instance.memory.min_available_memory`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-gcpalloydbinstance/summary_metrics.yml
+++ b/entity-types/infra-gcpalloydbinstance/summary_metrics.yml
@@ -1,0 +1,22 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: GCP account
+  unit: STRING
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
+cpuAverageUtilization:
+  goldenMetric: cpuAverageUtilization
+  unit: PERCENTAGE
+  title: CPU Average Utilization
+totalConnections:
+  goldenMetric: totalConnections
+  unit: COUNT
+  title: Total Connections
+minAvailableMemory:
+  goldenMetric: minAvailableMemory
+  unit: BYTES
+  title: Minimum Available Memory

--- a/entity-types/infra-gcpalloydbinstancenode/dashboard.json
+++ b/entity-types/infra-gcpalloydbinstancenode/dashboard.json
@@ -1,0 +1,273 @@
+{
+  "name": "GCP AlloyDB Instance Node",
+  "description": null,
+  "pages": [
+    {
+      "name": "Summary",
+      "description": null,
+      "widgets": [
+        {
+          "title": "CPU Usage",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.alloydb.node.cpu.usage_time`) AS 'CPU Usage %' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Available Memory",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.area"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.alloydb.node.memory.available_memory`) AS 'Available Memory (bytes)' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Total Connections",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.alloydb.node.postgres.backends`) AS 'Total Connections' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Connections by State",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.alloydb.node.postgres.backends_by_state`) AS 'Connections' FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.state` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Transaction Count",
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(sum(`gcp.alloydb.node.postgres.transaction_count`), 1 minute) AS 'Transactions/min' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Replication Lag",
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT max(`gcp.alloydb.node.postgres.replay_lag`) AS 'Replication Lag (ms)' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Network Received Bytes",
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(sum(`gcp.alloydb.node.network.received_bytes_count`), 1 minute) AS 'Received (bytes/min)' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Network Sent Bytes",
+          "layout": {
+            "column": 5,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(sum(`gcp.alloydb.node.network.sent_bytes_count`), 1 minute) AS 'Sent (bytes/min)' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Ultra Fast Cache Hit Rate",
+          "layout": {
+            "column": 9,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.alloydb.node.postgres.ultrafastcache_hitrate`) AS 'Cache Hit Rate' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpalloydbinstancenode/definition.yml
+++ b/entity-types/infra-gcpalloydbinstancenode/definition.yml
@@ -1,11 +1,12 @@
 domain: INFRA
-type: GCPAIPLATFORMFEATUREONLINESTORE
-goldenTags:
-  - gcp.projectId
-  - gcp.region
+type: GCPALLOYDBINSTANCENODE
 configuration:
   entityExpirationTime: DAILY
   alertable: true
+
+goldenTags:
+  - gcp.projectId
+  - gcp.region
 
 ownership:
   primaryOwner:

--- a/entity-types/infra-gcpalloydbinstancenode/golden_metrics.yml
+++ b/entity-types/infra-gcpalloydbinstancenode/golden_metrics.yml
@@ -1,0 +1,27 @@
+cpuUsageTime:
+  title: CPU Usage
+  unit: PERCENTAGE
+  queries:
+    gcp:
+      select: average(`gcp.alloydb.node.cpu.usage_time`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+backends:
+  title: Total Connections
+  unit: COUNT
+  queries:
+    gcp:
+      select: sum(`gcp.alloydb.node.postgres.backends`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+availableMemory:
+  title: Available Memory
+  unit: BYTES
+  queries:
+    gcp:
+      select: average(`gcp.alloydb.node.memory.available_memory`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-gcpalloydbinstancenode/summary_metrics.yml
+++ b/entity-types/infra-gcpalloydbinstancenode/summary_metrics.yml
@@ -1,0 +1,22 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: GCP account
+  unit: STRING
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
+cpuUsageTime:
+  goldenMetric: cpuUsageTime
+  unit: PERCENTAGE
+  title: CPU Usage
+backends:
+  goldenMetric: backends
+  unit: COUNT
+  title: Total Connections
+availableMemory:
+  goldenMetric: availableMemory
+  unit: BYTES
+  title: Available Memory


### PR DESCRIPTION
## Context / Problem Statement

GCP resources (like AI Platform and AlloyDB) are monitored by gcp-polling-v2, which pulls metrics from GCP's Cloud Monitoring API. At present, they are monitored as **Sample** but not as **Dimensional Metrics**.

## Design

Adds dimensional metrics (`gcp` query type) support for 9 GCP entities across two services: AlloyDB and AI Platform (Vertex AI).

## Proposed Solution

For GCP AI Platform and AlloyDB resources, the following repositories are updated:

**Repository 1: `newrelic/entity-definitions` (this PR)**

Each entity includes updates to:
- `definition.yml` — entity type definition and golden tags
- `golden_metrics.yml` — metric queries (both `gcpSample` and `gcp` dimensional types)
- `summary_metrics.yml` — summary panel metrics referencing golden metrics
- `dashboard.json` — entity overview dashboard

**Repository 2: `entity-platform/entity-type-ui-definitions-service`** (separate PR)

- `definition_ui.yml` — configures the UI nerdlet experience

## Golden Metrics

| Entity Type | Golden Metric 1 | Golden Metric 2 | Golden Metric 3 | Golden Metric 4 |
|---|---|---|---|---|
| GCPAIPLATFORMENDPOINT | CPU Utilization | Memory Usage | Network Bytes Sent | Network Bytes Received |
| GCPAIPLATFORMFEATUREONLINESTORE | Total Requests | Latency | Stored Bytes | — |
| GCPAIPLATFORMFEATURESTORE | Stored Bytes | CPU Load | Latency | — |
| GCPAIPLATFORMINDEX | Total Requests | Latency | Datapoint Count | — |
| GCPAIPLATFORMLOCATION | Pipeline Tasks | Online Prediction Requests Per Base Model | — | — |
| GCPAIPLATFORMPIPELINEJOB | Runtime Seconds | Total Completed Tasks | — | — |
| GCPALLOYDBCLUSTER | Storage Usage | Last Backup Time | — | — |
| GCPALLOYDBDATABASE | Client Connections | Committed Transactions | Execution Time | — |
| GCPALLOYDBINSTANCE | CPU Average Utilization | Total Connections | Minimum Available Memory | — |
| GCPALLOYDBINSTANCENODE | CPU Usage | Total Connections | Available Memory | — |

## ARB Ticket

https://new-relic.atlassian.net/browse/NR-567584

## Test Plan

- [ ] Validate entity definitions pass schema validation (`npm run validate` in `validator/`)
- [ ] Verify `gcp` dimensional metric queries return data in staging account
- [ ] Verify `gcpSample` queries continue to work (backwards compatibility)
- [ ] Verify dashboards render correctly in New Relic staging
- [ ] Confirm `summary_metrics.yml` entries resolve via `goldenMetric:` references

🤖 Generated with [Claude Code](https://claude.com/claude-code)