### PR TITLE
feat: Add GCPSPANNERINSTANCE dashboard and update summary_metrics

### DIFF
--- a/entity-types/infra-gcpspannerinstance/dashboard.json
+++ b/entity-types/infra-gcpspannerinstance/dashboard.json
@@ -1,0 +1,302 @@
+{
+  "name": "GCP Spanner Instance",
+  "description": null,
+  "pages": [
+    {
+      "name": "Summary",
+      "description": null,
+      "widgets": [
+        {
+          "title": "CPU Utilization",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.spanner.instance.cpu.utilization`) * 100 AS 'CPU Utilization %' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "CPU Smoothed Utilization",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.spanner.instance.cpu.smoothed_utilization`) * 100 AS 'Smoothed CPU Utilization %' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Node Count",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`gcp.spanner.instance.node_count`) AS 'Nodes' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Storage Used (Bytes)",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.spanner.instance.storage.used_bytes`) AS 'Storage Used (Bytes)' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Sessions in Use",
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`gcp.spanner.instance.session_count`) AS 'Sessions' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "API Request Count",
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.spanner.api.request_count`) AS 'Requests' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "API Request Count by Status",
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.spanner.api.request_count`) AS 'Requests' FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.status` TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "API Request Count by Method",
+          "layout": {
+            "column": 7,
+            "row": 7,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.spanner.api.request_count`) AS 'Requests' FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.method` TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "API Request Latencies (ms)",
+          "layout": {
+            "column": 1,
+            "row": 10,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.spanner.api.request_latencies`) AS 'Avg Latency (ms)' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "CPU Utilization by Priority",
+          "layout": {
+            "column": 7,
+            "row": 10,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.spanner.instance.cpu.utilization_by_priority`) * 100 AS 'CPU Utilization %' FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.priority` TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpspannerinstance/summary_metrics.yml
+++ b/entity-types/infra-gcpspannerinstance/summary_metrics.yml
@@ -3,15 +3,29 @@ providerAccountName:
     key: providerAccountName
   title: GCP account
   unit: STRING
+
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
+
 Nodes:
   goldenMetric: Nodes
   unit: COUNT
   title: Nodes
+
 cpuUtilization:
   goldenMetric: cpuUtilization
   unit: PERCENTAGE
   title: CPU utilization
+
 diskUsage:
   goldenMetric: diskUsage
   unit: BYTES
   title: Disk usage
+
+sessions:
+  goldenMetric: sessions
+  unit: COUNT
+  title: Sessions in use


### PR DESCRIPTION
### Relevant information

Updating GCPSPANNERINSTANCE entity definition for GCP Cloud Spanner Instance.

This PR adds:
- dashboard.json with entity-scoped Metric-based queries for CPU utilization, storage, nodes, sessions, API request count/latencies, CPU by priority
- summary_metrics.yml updated: added required gcpProjectId tag entry and sessions golden metric reference

### Metrics used (all validated via NR MCP - return 0/no errors in accounts 686923, 10876283, 12208939)
- gcp.spanner.instance.cpu.utilization
- gcp.spanner.instance.cpu.smoothed_utilization
- gcp.spanner.instance.node_count
- gcp.spanner.instance.storage.used_bytes
- gcp.spanner.instance.session_count
- gcp.spanner.api.request_count
- gcp.spanner.api.request_latencies

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid.
* [x] I've confirmed that my entity type wasn't already defined.