### PR TITLE
feat: Add GCPKUBERNETESNODE entity definition

### DIFF
--- a/entity-types/infra-gcpkubernetesnode/dashboard.json
+++ b/entity-types/infra-gcpkubernetesnode/dashboard.json
@@ -1,0 +1,331 @@
+{
+  "name": "GCP Kubernetes Node",
+  "description": null,
+  "pages": [
+    {
+      "name": "Summary",
+      "description": null,
+      "widgets": [
+        {
+          "title": "CPU Core Usage Time",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.kubernetes.node.cpu.core_usage_time`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "CPU Allocatable Utilization",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.kubernetes.node.cpu.allocatable_utilization`) * 100 AS 'CPU Allocatable Utilization %' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Allocatable CPU Cores",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.kubernetes.node.cpu.allocatable_cores`) AS 'Allocatable Cores', average(`gcp.kubernetes.node.cpu.total_cores`) AS 'Total Cores' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Memory Used Bytes",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.kubernetes.node.memory.used_bytes`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.memory_type` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Memory Allocatable Utilization",
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.kubernetes.node.memory.allocatable_utilization`) * 100 AS 'Memory Allocatable Utilization %' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Memory Bytes (Allocatable vs Total)",
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.kubernetes.node.memory.allocatable_bytes`) AS 'Allocatable Bytes', average(`gcp.kubernetes.node.memory.total_bytes`) AS 'Total Bytes' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Network Bytes Received",
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(sum(`gcp.kubernetes.node.network.received_bytes_count`), 1 minute) AS 'Bytes Received/min' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Network Bytes Sent",
+          "layout": {
+            "column": 5,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(sum(`gcp.kubernetes.node.network.sent_bytes_count`), 1 minute) AS 'Bytes Sent/min' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "PID Usage vs Limit",
+          "layout": {
+            "column": 9,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.kubernetes.node.pid_used`) AS 'PIDs Used', average(`gcp.kubernetes.node.pid_limit`) AS 'PID Limit' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Ephemeral Storage Used vs Allocatable",
+          "layout": {
+            "column": 1,
+            "row": 10,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.kubernetes.node.ephemeral_storage.used_bytes`) AS 'Used Bytes', average(`gcp.kubernetes.node.ephemeral_storage.allocatable_bytes`) AS 'Allocatable Bytes', average(`gcp.kubernetes.node.ephemeral_storage.total_bytes`) AS 'Total Bytes' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Node Status Condition",
+          "layout": {
+            "column": 7,
+            "row": 10,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`gcp.kubernetes.node.status_condition`) AS 'Status' FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.condition`, `metric.status` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpkubernetesnode/definition.yml
+++ b/entity-types/infra-gcpkubernetesnode/definition.yml
@@ -1,5 +1,8 @@
 domain: INFRA
 type: GCPKUBERNETESNODE
+goldenTags:
+- gcp.projectId
+- gcp.region
 configuration:
   entityExpirationTime: DAILY
   alertable: true

--- a/entity-types/infra-gcpkubernetesnode/summary_metrics.yml
+++ b/entity-types/infra-gcpkubernetesnode/summary_metrics.yml
@@ -3,6 +3,13 @@ providerAccountName:
     key: providerAccountName
   title: GCP account
   unit: STRING
+
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
+
 cpuUsage:
   goldenMetric: cpuUsage
   unit: SECONDS


### PR DESCRIPTION
### Relevant information

Adding GCPKUBERNETESNODE entity definition for GCP Kubernetes K8s Node.

This PR adds:
- `goldenTags` (gcp.projectId, gcp.region) to definition.yml
- `gcpProjectId` tag entry to summary_metrics.yml (critical entry per GCP entity standards)
- `dashboard.json` with widgets for: CPU core usage time, CPU allocatable utilization, allocatable vs total CPU cores, memory used bytes by type, memory allocatable utilization, memory allocatable vs total bytes, network bytes received/sent, PID usage vs limit, ephemeral storage used vs allocatable, and node status condition

All metrics are GA-stage from official GCP Kubernetes metrics documentation.
Metric naming follows the confirmed `gcp.kubernetes.node.*` pattern.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid.
* [x] I've confirmed that my entity type wasn't already defined.