### PR TITLE
feat: Add GCPKUBERNETESCONTAINER entity definition

### DIFF
--- a/entity-types/infra-gcpkubernetescontainer/dashboard.json
+++ b/entity-types/infra-gcpkubernetescontainer/dashboard.json
@@ -1,0 +1,186 @@
+{
+  "name": "GCP Kubernetes Container",
+  "description": null,
+  "pages": [
+    {
+      "name": "Summary",
+      "description": null,
+      "widgets": [
+        {
+          "title": "CPU Core Usage Time",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.kubernetes.container.cpu.core_usage_time`) AS 'CPU Usage Time (s)' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "CPU Limit Utilization",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.kubernetes.container.cpu.limit_utilization`) * 100 AS 'CPU Limit Utilization (%)' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "CPU Request Utilization",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.kubernetes.container.cpu.request_utilization`) * 100 AS 'CPU Request Utilization (%)' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Memory Used Bytes",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.kubernetes.container.memory.used_bytes`) AS 'Memory Used (bytes)' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Memory Limit Utilization",
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.kubernetes.container.memory.limit_utilization`) * 100 AS 'Memory Limit Utilization (%)' FROM Metric WHERE entity.guid = '{{entity.id}}' FACET metric.memory_type TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Container Restarts",
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.kubernetes.container.restart_count`) AS 'Restarts' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpkubernetescontainer/definition.yml
+++ b/entity-types/infra-gcpkubernetescontainer/definition.yml
@@ -1,5 +1,8 @@
 domain: INFRA
 type: GCPKUBERNETESCONTAINER
+goldenTags:
+- gcp.projectId
+- gcp.region
 configuration:
   entityExpirationTime: DAILY
   alertable: true

--- a/entity-types/infra-gcpkubernetescontainer/summary_metrics.yml
+++ b/entity-types/infra-gcpkubernetescontainer/summary_metrics.yml
@@ -3,6 +3,13 @@ providerAccountName:
     key: providerAccountName
   title: GCP account
   unit: STRING
+
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
+
 cpuUsage:
   goldenMetric: cpuUsage
   unit: SECONDS


### PR DESCRIPTION
### Relevant information

Adding GCPKUBERNETESCONTAINER entity definition for GCP Kubernetes Container (k8s_container monitored resource type).

This PR adds:
- `goldenTags` (gcp.projectId, gcp.region) to `definition.yml`
- `gcpProjectId` tag entry to `summary_metrics.yml` (required alongside existing providerAccountName)
- `dashboard.json` with 6 widgets covering CPU core usage time, CPU limit/request utilization, memory used bytes, memory limit utilization, and container restart count

All metrics are GA launch stage from `kubernetes.googleapis.com`, mapped to NR format as `gcp.kubernetes.container.*`.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid.
* [x] I've confirmed that my entity type wasn't already defined.