### PR TITLE
feat: Add GCPSTORAGEBUCKET entity definition

### DIFF
--- a/entity-types/infra-gcpstoragebucket/dashboard.json
+++ b/entity-types/infra-gcpstoragebucket/dashboard.json
@@ -1,0 +1,150 @@
+{
+  "name": "GCP Cloud Storage GCS Bucket",
+  "description": null,
+  "pages": [
+    {
+      "name": "GCP Cloud Storage GCS Bucket",
+      "description": null,
+      "widgets": [
+        {
+          "title": "Network Received Bytes",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(gcp.storage.network.received_bytes_count) FROM Metric WHERE entity.guid = '{{entity.guid}}' AND collector.name = 'gcp-polling-v2' FACET metric.response_code TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Network Sent Bytes",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(gcp.storage.network.sent_bytes_count) FROM Metric WHERE entity.guid = '{{entity.guid}}' AND collector.name = 'gcp-polling-v2' FACET metric.response_code TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "API Request Count",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(gcp.storage.api.request_count) FROM Metric WHERE entity.guid = '{{entity.guid}}' AND collector.name = 'gcp-polling-v2' FACET metric.response_code TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "API Request Count by Method",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(gcp.storage.api.request_count) FROM Metric WHERE entity.guid = '{{entity.guid}}' AND collector.name = 'gcp-polling-v2' FACET metric.method TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Object Count by Storage Class",
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.bar"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(gcp.storage.storage.object_count) FROM Metric WHERE entity.guid = '{{entity.guid}}' AND collector.name = 'gcp-polling-v2' FACET metric.storage_class"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Total Bytes by Storage Class",
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.bar"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(gcp.storage.storage.total_bytes) FROM Metric WHERE entity.guid = '{{entity.guid}}' AND collector.name = 'gcp-polling-v2' FACET metric.storage_class"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpstoragebucket/definition.yml
+++ b/entity-types/infra-gcpstoragebucket/definition.yml
@@ -2,7 +2,6 @@ domain: INFRA
 type: GCPSTORAGEBUCKET
 goldenTags:
 - gcp.projectId
-- gcp.zone
 configuration:
   entityExpirationTime: DAILY
   alertable: true

--- a/entity-types/infra-gcpstoragebucket/definition.yml
+++ b/entity-types/infra-gcpstoragebucket/definition.yml
@@ -2,6 +2,7 @@ domain: INFRA
 type: GCPSTORAGEBUCKET
 goldenTags:
 - gcp.projectId
+- gcp.zone
 configuration:
   entityExpirationTime: DAILY
   alertable: true

--- a/entity-types/infra-gcpstoragebucket/golden_metrics.yml
+++ b/entity-types/infra-gcpstoragebucket/golden_metrics.yml
@@ -28,7 +28,7 @@ sentBytes:
       eventName: entityName
 apiRequests:
   title: Number API calls
-  unit: COUNT      
+  unit: COUNT
   queries:
     gcp:
       select: sum(gcp.storage.api.request_count)
@@ -40,3 +40,21 @@ apiRequests:
       from: GcpStorageBucketSample
       eventId: entityGuid
       eventName: entityName
+objectCount:
+  title: Object count
+  unit: COUNT
+  queries:
+    gcp:
+      select: sum(gcp.storage.storage.object_count)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+totalBytes:
+  title: Total bytes
+  unit: BYTES
+  queries:
+    gcp:
+      select: sum(gcp.storage.storage.total_bytes)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-gcpstoragebucket/summary_metrics.yml
+++ b/entity-types/infra-gcpstoragebucket/summary_metrics.yml
@@ -3,6 +3,11 @@ providerAccountName:
     key: providerAccountName
   title: GCP account
   unit: STRING
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
 receivedBytes:
   goldenMetric: receivedBytes
   unit: BYTES
@@ -15,3 +20,11 @@ apiRequests:
   goldenMetric: apiRequests
   unit: COUNT
   title: API calls
+objectCount:
+  goldenMetric: objectCount
+  unit: COUNT
+  title: Object count
+totalBytes:
+  goldenMetric: totalBytes
+  unit: BYTES
+  title: Total bytes


### PR DESCRIPTION
### Relevant information

Adding GCPSTORAGEBUCKET entity definition updates for GCP Cloud Storage GCS Bucket.

This PR adds/updates:
- `definition.yml` — fixed goldenTags (removed incorrect `gcp.zone`, kept `gcp.projectId`)
- `golden_metrics.yml` — added `objectCount` and `totalBytes` Metric-based entries alongside existing metrics
- `summary_metrics.yml` — added `gcpProjectId` tag entry (critical GCP requirement) and golden metric references for new metrics
- `dashboard.json` — new entity dashboard with 6 widgets covering network bytes, API requests, object count and total bytes

### Metrics added
- `gcp.storage.storage.object_count` (GA) — total objects per bucket by storage class
- `gcp.storage.storage.total_bytes` (GA) — total bucket size by storage class

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid.
* [x] I've confirmed that my entity type wasn't already defined.