### PR TITLE
feat: Add golden metrics, summary metrics, and dashboard for GCP VPC Access Connector

### DIFF
--- a/entity-types/infra-gcpvpcaccessconnector/dashboard.json
+++ b/entity-types/infra-gcpvpcaccessconnector/dashboard.json
@@ -1,0 +1,186 @@
+{
+  "name": "GCP VPC Access Connector",
+  "description": null,
+  "pages": [
+    {
+      "name": "GCP VPC Access Connector",
+      "description": null,
+      "widgets": [
+        {
+          "title": "Active Instances",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.vpcaccess.connector.instances`) AS 'Active Instances' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND collector.name = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Received Bytes",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.vpcaccess.connector.received_bytes_count`) AS 'Received Bytes' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND collector.name = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Sent Bytes",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.vpcaccess.connector.sent_bytes_count`) AS 'Sent Bytes' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND collector.name = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Received Packets",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.vpcaccess.connector.received_packets_count`) AS 'Received Packets' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND collector.name = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Sent Packets",
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.vpcaccess.connector.sent_packets_count`) AS 'Sent Packets' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND collector.name = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "CPU Utilization Distribution",
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.vpcaccess.connector.cpu.utilizations`) AS 'CPU Utilization (%)' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND collector.name = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpvpcaccessconnector/definition.yml
+++ b/entity-types/infra-gcpvpcaccessconnector/definition.yml
@@ -1,5 +1,8 @@
 domain: INFRA
 type: GCPVPCACCESSCONNECTOR
+goldenTags:
+- gcp.projectId
+- gcp.region
 configuration:
   entityExpirationTime: DAILY
   alertable: true

--- a/entity-types/infra-gcpvpcaccessconnector/golden_metrics.yml
+++ b/entity-types/infra-gcpvpcaccessconnector/golden_metrics.yml
@@ -1,0 +1,29 @@
+activeInstances:
+  title: Active instances
+  unit: COUNT
+  queries:
+    gcp:
+      select: sum(gcp.vpcaccess.connector.instances)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+
+receivedBytes:
+  title: Received bytes
+  unit: BYTES
+  queries:
+    gcp:
+      select: sum(gcp.vpcaccess.connector.received_bytes_count)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+
+sentBytes:
+  title: Sent bytes
+  unit: BYTES
+  queries:
+    gcp:
+      select: sum(gcp.vpcaccess.connector.sent_bytes_count)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-gcpvpcaccessconnector/summary_metrics.yml
+++ b/entity-types/infra-gcpvpcaccessconnector/summary_metrics.yml
@@ -1,0 +1,26 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: GCP account
+  unit: STRING
+
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
+
+activeInstances:
+  goldenMetric: activeInstances
+  title: Active instances
+  unit: COUNT
+
+receivedBytes:
+  goldenMetric: receivedBytes
+  title: Received bytes
+  unit: BYTES
+
+sentBytes:
+  goldenMetric: sentBytes
+  title: Sent bytes
+  unit: BYTES


### PR DESCRIPTION
## Summary

- Adds `golden_metrics.yml` with 3 key metrics: `activeInstances`, `receivedBytes`, `sentBytes`
- Adds `summary_metrics.yml` with providerAccountName, gcpProjectId, and golden metric references
- Adds `dashboard.json` with 6 widgets covering all available metrics (instances, bytes, packets, CPU)
- Updates `definition.yml` with `goldenTags` (`gcp.projectId`, `gcp.region`)

## Metrics

All metrics sourced from official GCP documentation (vpcaccess.googleapis.com, all BETA):
- `gcp.vpcaccess.connector.instances` — active instances count
- `gcp.vpcaccess.connector.received_bytes_count` — bytes received (DELTA)
- `gcp.vpcaccess.connector.sent_bytes_count` — bytes sent (DELTA)
- `gcp.vpcaccess.connector.received_packets_count` — packets received (DELTA)
- `gcp.vpcaccess.connector.sent_packets_count` — packets sent (DELTA)
- `gcp.vpcaccess.connector.cpu.utilizations` — CPU utilization distribution (GAUGE)

## Test plan

- [x] `npm --prefix validator run sanitize-dashboards` — dashboard.json sanitized (no forbidden fields)
- [x] `validate-definition` — exits 0
- [x] `validate-golden-metrics` — exits 0
- [x] `validate-summary-metrics` — exits 0
- [x] `validate-dashboard` — exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)