### PR TITLE
feat: add GCP Kubernetes Pod (GCPKUBERNETESPOD) entity definition

### DIFF
--- a/entity-types/infra-gcpkubernetespod/dashboard.json
+++ b/entity-types/infra-gcpkubernetespod/dashboard.json
@@ -1,0 +1,112 @@
+{
+  "name": "GcpKubernetesPod",
+  "description": null,
+  "pages": [
+    {
+      "name": "GcpKubernetesPod",
+      "description": null,
+      "widgets": [
+        {
+          "title": "Network Bytes Received",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.kubernetes.pod.network.received_bytes_count`) AS 'Bytes Received' FROM Metric WHERE `entity.guid` = '{{entity.id}}' AND collector.name = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Network Bytes Sent",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.kubernetes.pod.network.sent_bytes_count`) AS 'Bytes Sent' FROM Metric WHERE `entity.guid` = '{{entity.id}}' AND collector.name = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Volume Utilization (%)",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.kubernetes.pod.volume.utilization`) * 100 AS 'Volume Utilization %' FROM Metric WHERE `entity.guid` = '{{entity.id}}' AND collector.name = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Volume Used Bytes",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.kubernetes.pod.volume.used_bytes`) AS 'Used Bytes' FROM Metric WHERE `entity.guid` = '{{entity.id}}' AND collector.name = 'gcp-polling-v2' FACET `metric.volume_name` TIMESERIES AUTO"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Volume Total Bytes",
+          "layout": {
+            "column": 7,
+            "row": 4,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.kubernetes.pod.volume.total_bytes`) AS 'Total Bytes' FROM Metric WHERE `entity.guid` = '{{entity.id}}' AND collector.name = 'gcp-polling-v2' FACET `metric.volume_name` TIMESERIES AUTO"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpkubernetespod/definition.yml
+++ b/entity-types/infra-gcpkubernetespod/definition.yml
@@ -1,0 +1,12 @@
+domain: INFRA
+type: GCPKUBERNETESPOD
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+
+goldenTags:
+  - gcp.projectId
+
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-gcpkubernetespod/golden_metrics.yml
+++ b/entity-types/infra-gcpkubernetespod/golden_metrics.yml
@@ -1,0 +1,29 @@
+networkReceivedBytes:
+  title: Network bytes received
+  unit: BYTES
+  queries:
+    gcp:
+      eventId: entity.guid
+      select: sum(gcp.kubernetes.pod.network.received_bytes_count)
+      from: Metric
+      eventName: entity.name
+
+networkSentBytes:
+  title: Network bytes sent
+  unit: BYTES
+  queries:
+    gcp:
+      eventId: entity.guid
+      select: sum(gcp.kubernetes.pod.network.sent_bytes_count)
+      from: Metric
+      eventName: entity.name
+
+volumeUtilization:
+  title: Volume utilization
+  unit: PERCENTAGE
+  queries:
+    gcp:
+      eventId: entity.guid
+      select: average(gcp.kubernetes.pod.volume.utilization) * 100
+      from: Metric
+      eventName: entity.name

--- a/entity-types/infra-gcpkubernetespod/summary_metrics.yml
+++ b/entity-types/infra-gcpkubernetespod/summary_metrics.yml
@@ -1,0 +1,26 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: GCP account
+  unit: STRING
+
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
+
+networkReceivedBytes:
+  goldenMetric: networkReceivedBytes
+  title: Network bytes received
+  unit: BYTES
+
+networkSentBytes:
+  goldenMetric: networkSentBytes
+  title: Network bytes sent
+  unit: BYTES
+
+volumeUtilization:
+  goldenMetric: volumeUtilization
+  title: Volume utilization
+  unit: PERCENTAGE


### PR DESCRIPTION
## Summary

- Add `entity-types/infra-gcpkubernetespod/` with all required files
- **definition.yml**: `GCPKUBERNETESPOD` domain INFRA, `entityExpirationTime: DAILY`, `alertable: true`, `goldenTags: [gcp.projectId]`
- **golden_metrics.yml**: 3 GA metrics — `networkReceivedBytes`, `networkSentBytes`, `volumeUtilization`
- **summary_metrics.yml**: `providerAccountName` + `gcpProjectId` tags + golden metric refs
- **dashboard.json**: 5 widgets for network bytes in/out, volume utilization, used bytes, total bytes

## Metrics (all GA from official GCP Cloud Monitoring docs)

| NR Metric | GCP Source | Type |
|-----------|-----------|------|
| `gcp.kubernetes.pod.network.received_bytes_count` | `kubernetes.io/pod/network/received_bytes_count` | CUMULATIVE, INT64, Bytes |
| `gcp.kubernetes.pod.network.sent_bytes_count` | `kubernetes.io/pod/network/sent_bytes_count` | CUMULATIVE, INT64, Bytes |
| `gcp.kubernetes.pod.volume.utilization` | `kubernetes.io/pod/volume/utilization` | GAUGE, DOUBLE, fraction |
| `gcp.kubernetes.pod.volume.used_bytes` | `kubernetes.io/pod/volume/used_bytes` | GAUGE, INT64, Bytes |
| `gcp.kubernetes.pod.volume.total_bytes` | `kubernetes.io/pod/volume/total_bytes` | GAUGE, INT64, Bytes |

## Related PRs

- entity-type-ui-definitions-service: PR to source.datanerd.us/entity-platform/entity-type-ui-definitions-service
- infra-summary: PR to source.datanerd.us/Pegasus/infra-summary
- infrastructure: PR to source.datanerd.us/Pegasus/infrastructure
- gcp-polling-v2: Synthesizer entry already present (no changes needed)

## Test plan

- [ ] Verify entity synthesizes correctly with `GCPKUBERNETESPOD` type
- [ ] Confirm golden metrics display in entity summary view
- [ ] Validate dashboard widgets load with pod metric data
- [ ] Check `gcp.projectId` goldenTag appears on synthesized entity