### PR TITLE
feat: Add GCP Memorystore entity definitions (GCPMEMORYSTOREINSTANCE + GCPMEMORYSTOREINSTANCENODE)

### DIFF
--- a/entity-types/infra-gcpmemorystoreinstance/dashboard.json
+++ b/entity-types/infra-gcpmemorystoreinstance/dashboard.json
@@ -1,0 +1,172 @@
+{
+  "name": "GCP Memorystore Instance",
+  "description": null,
+  "pages": [
+    {
+      "name": "GCP Memorystore Instance",
+      "description": null,
+      "widgets": [
+        {
+          "title": "CPU Utilization (%)",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT max(`gcp.memorystore.instance.cpu.maximum_utilization`) * 100 AS 'CPU %' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND `collector.name` = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Memory Utilization (%)",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT max(`gcp.memorystore.instance.memory.maximum_utilization`) * 100 AS 'Memory %' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND `collector.name` = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Connected Clients",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.memorystore.instance.clients.total_connected_clients`) AS 'Clients' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND `collector.name` = 'gcp-polling-v2' FACET `metric.role` TIMESERIES AUTO"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Total Keys",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`gcp.memorystore.instance.keyspace.total_keys`) AS 'Keys' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND `collector.name` = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Memory Used (Bytes)",
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`gcp.memorystore.instance.memory.total_used_memory`) AS 'Used Memory' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND `collector.name` = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Cache Hit Ratio (%)",
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.memorystore.instance.stats.average_keyspace_hits`) / (average(`gcp.memorystore.instance.stats.average_keyspace_hits`) + average(`gcp.memorystore.instance.stats.average_keyspace_misses`)) * 100 AS 'Cache Hit %' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND `collector.name` = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Evicted Keys",
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.memorystore.instance.stats.average_evicted_keys`) AS 'Evicted Keys' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND `collector.name` = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Network Input/Output (Bytes/s)",
+          "layout": {
+            "column": 5,
+            "row": 7,
+            "width": 8,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(sum(`gcp.memorystore.instance.stats.total_net_input_bytes_count`), 1 minute) AS 'Net In', rate(sum(`gcp.memorystore.instance.stats.total_net_output_bytes_count`), 1 minute) AS 'Net Out' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND `collector.name` = 'gcp-polling-v2' FACET `metric.role` TIMESERIES AUTO"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpmemorystoreinstance/definition.yml
+++ b/entity-types/infra-gcpmemorystoreinstance/definition.yml
@@ -1,0 +1,11 @@
+domain: INFRA
+type: GCPMEMORYSTOREINSTANCE
+goldenTags:
+- gcp.project_id
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-gcpmemorystoreinstance/golden_metrics.yml
+++ b/entity-types/infra-gcpmemorystoreinstance/golden_metrics.yml
@@ -1,0 +1,29 @@
+cpuUtilization:
+  title: CPU utilization (%)
+  unit: PERCENTAGE
+  queries:
+    gcp:
+      select: max(`gcp.memorystore.instance.cpu.maximum_utilization`) * 100
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+
+memoryUtilization:
+  title: Memory utilization (%)
+  unit: PERCENTAGE
+  queries:
+    gcp:
+      select: max(`gcp.memorystore.instance.memory.maximum_utilization`) * 100
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+
+connectedClients:
+  title: Connected clients
+  unit: COUNT
+  queries:
+    gcp:
+      select: average(`gcp.memorystore.instance.clients.total_connected_clients`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-gcpmemorystoreinstance/summary_metrics.yml
+++ b/entity-types/infra-gcpmemorystoreinstance/summary_metrics.yml
@@ -1,0 +1,20 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: GCP account
+  unit: STRING
+
+cpuUtilization:
+  goldenMetric: cpuUtilization
+  title: CPU utilization (%)
+  unit: PERCENTAGE
+
+memoryUtilization:
+  goldenMetric: memoryUtilization
+  title: Memory utilization (%)
+  unit: PERCENTAGE
+
+connectedClients:
+  goldenMetric: connectedClients
+  title: Connected clients
+  unit: COUNT

--- a/entity-types/infra-gcpmemorystoreinstancenode/dashboard.json
+++ b/entity-types/infra-gcpmemorystoreinstancenode/dashboard.json
@@ -1,0 +1,215 @@
+{
+  "name": "GCP Memorystore Instance Node",
+  "description": null,
+  "pages": [
+    {
+      "name": "Summary",
+      "description": null,
+      "widgets": [
+        {
+          "title": "CPU Utilization",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.memorystore.instance.node.cpu.utilization`) * 100 FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.role` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Memory Utilization",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.memorystore.instance.node.memory.utilization`) * 100 FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.role` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Connected Clients",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.memorystore.instance.node.clients.connected_clients`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.role` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Blocked Clients",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.memorystore.instance.node.clients.blocked_clients`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.role` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Commands Count",
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(sum(`gcp.memorystore.instance.node.commandstats.calls_count`), 1 minute) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.role`, `metric.command` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Total Keys",
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.memorystore.instance.node.keyspace.total_keys`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.role` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Memory Usage (bytes)",
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 12,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.memorystore.instance.node.memory.usage`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.role` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpmemorystoreinstancenode/definition.yml
+++ b/entity-types/infra-gcpmemorystoreinstancenode/definition.yml
@@ -1,0 +1,11 @@
+domain: INFRA
+type: GCPMEMORYSTOREINSTANCENODE
+goldenTags:
+- gcp.projectId
+- gcp.region
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-gcpmemorystoreinstancenode/golden_metrics.yml
+++ b/entity-types/infra-gcpmemorystoreinstancenode/golden_metrics.yml
@@ -1,0 +1,27 @@
+cpuUtilization:
+  title: CPU utilization (%)
+  unit: PERCENTAGE
+  queries:
+    gcp:
+      select: average(`gcp.memorystore.instance.node.cpu.utilization`) * 100
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+memoryUtilization:
+  title: Memory utilization (%)
+  unit: PERCENTAGE
+  queries:
+    gcp:
+      select: average(`gcp.memorystore.instance.node.memory.utilization`) * 100
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+connectedClients:
+  title: Connected clients
+  unit: COUNT
+  queries:
+    gcp:
+      select: average(`gcp.memorystore.instance.node.clients.connected_clients`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-gcpmemorystoreinstancenode/summary_metrics.yml
+++ b/entity-types/infra-gcpmemorystoreinstancenode/summary_metrics.yml
@@ -1,0 +1,12 @@
+cpuUtilization:
+  goldenMetric: cpuUtilization
+  title: CPU utilization (%)
+  unit: PERCENTAGE
+memoryUtilization:
+  goldenMetric: memoryUtilization
+  title: Memory utilization (%)
+  unit: PERCENTAGE
+connectedClients:
+  goldenMetric: connectedClients
+  title: Connected clients
+  unit: COUNT


### PR DESCRIPTION
## Summary

Consolidates Memorystore entity definitions into a single PR:

- **GCPMEMORYSTOREINSTANCENODE** – definition, golden metrics, summary metrics, dashboard
- **GCPMEMORYSTOREINSTANCE** – definition, golden metrics, summary metrics, dashboard

Closes #2864
Closes #2867