### PR TITLE
feat: Add GCP Redis entity definitions (GCPREDISCLUSTER + GCPREDISCLUSTERNODE + GCPREDISINSTANCE)

### DIFF
--- a/entity-types/infra-gcprediscluster/dashboard.json
+++ b/entity-types/infra-gcprediscluster/dashboard.json
@@ -1,0 +1,273 @@
+{
+  "name": "GCP Redis Cluster",
+  "description": null,
+  "pages": [
+    {
+      "name": "GCP Redis Cluster",
+      "description": null,
+      "widgets": [
+        {
+          "title": "CPU Utilization (%)",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.redis.cluster.cpu.average_utilization`) * 100 AS 'CPU %' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND collector.name = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Memory Utilization (%)",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.redis.cluster.memory.average_utilization`) * 100 AS 'Memory %' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND collector.name = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Total Memory Usage (bytes)",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.redis.cluster.memory.total_used_memory`) AS 'Memory Used (bytes)' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND collector.name = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Commands Count",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.redis.cluster.commandstats.total_calls_count`) AS 'Commands' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND collector.name = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Commands by Type",
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.redis.cluster.commandstats.total_calls_count`) AS 'Commands' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND collector.name = 'gcp-polling-v2' FACET `metric.command` TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Connected Clients",
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.redis.cluster.clients.total_connected_clients`) AS 'Clients' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND collector.name = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Total Keys",
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.redis.cluster.keyspace.total_keys`) AS 'Keys' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND collector.name = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Evicted Keys",
+          "layout": {
+            "column": 5,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.redis.cluster.stats.total_evicted_keys_count`) AS 'Evicted Keys' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND collector.name = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Network I/O (bytes)",
+          "layout": {
+            "column": 9,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.redis.cluster.stats.total_net_input_bytes_count`) AS 'Input Bytes', sum(`gcp.redis.cluster.stats.total_net_output_bytes_count`) AS 'Output Bytes' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND collector.name = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcprediscluster/definition.yml
+++ b/entity-types/infra-gcprediscluster/definition.yml
@@ -1,0 +1,11 @@
+domain: INFRA
+type: GCPREDISCLUSTER
+goldenTags:
+- gcp.projectId
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-gcprediscluster/golden_metrics.yml
+++ b/entity-types/infra-gcprediscluster/golden_metrics.yml
@@ -1,0 +1,29 @@
+cpuAverageUtilization:
+  title: CPU Utilization (%)
+  unit: PERCENTAGE
+  queries:
+    gcp:
+      select: average(gcp.redis.cluster.cpu.average_utilization) * 100
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+
+memoryAverageUtilization:
+  title: Memory Utilization (%)
+  unit: PERCENTAGE
+  queries:
+    gcp:
+      select: average(gcp.redis.cluster.memory.average_utilization) * 100
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+
+commandsTotalCallsCount:
+  title: Commands Count
+  unit: COUNT
+  queries:
+    gcp:
+      select: sum(gcp.redis.cluster.commandstats.total_calls_count)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-gcprediscluster/summary_metrics.yml
+++ b/entity-types/infra-gcprediscluster/summary_metrics.yml
@@ -1,0 +1,22 @@
+nrAccountId:
+  tag:
+    key: nrAccount.id
+  title: NR Account ID
+  unit: STRING
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
+cpuAverageUtilization:
+  goldenMetric: cpuAverageUtilization
+  unit: PERCENTAGE
+  title: CPU Utilization (%)
+memoryAverageUtilization:
+  goldenMetric: memoryAverageUtilization
+  unit: PERCENTAGE
+  title: Memory Utilization (%)
+commandsTotalCallsCount:
+  goldenMetric: commandsTotalCallsCount
+  unit: COUNT
+  title: Commands Count

--- a/entity-types/infra-gcpredisclusternode/dashboard.json
+++ b/entity-types/infra-gcpredisclusternode/dashboard.json
@@ -1,0 +1,246 @@
+{
+  "name": "GCP Redis Cluster Node",
+  "description": null,
+  "pages": [
+    {
+      "name": "GCP Redis Cluster Node",
+      "description": null,
+      "widgets": [
+        {
+          "title": "CPU Utilization",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.redis.cluster.node.cpu.utilization`) * 100 AS 'CPU %' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND collector.name = 'gcp-polling-v2' FACET `metric.state` TIMESERIES AUTO"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Memory Utilization",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.redis.cluster.node.memory.utilization`) * 100 AS 'Memory %' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND collector.name = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Memory Usage (Bytes)",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`gcp.redis.cluster.node.memory.usage`) AS 'Memory Bytes' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND collector.name = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Connected Clients",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`gcp.redis.cluster.node.clients.connected_clients`) AS 'Connected' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND collector.name = 'gcp-polling-v2' FACET `metric.role` TIMESERIES AUTO"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Total Keys",
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`gcp.redis.cluster.node.keyspace.total_keys`) AS 'Keys' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND collector.name = 'gcp-polling-v2' FACET `metric.role` TIMESERIES AUTO"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Keyspace Hits vs Misses",
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.redis.cluster.node.stats.keyspace_hits_count`) AS 'Hits', sum(`gcp.redis.cluster.node.stats.keyspace_misses_count`) AS 'Misses' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND collector.name = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Evicted Keys",
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.redis.cluster.node.stats.evicted_keys_count`) AS 'Evicted' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND collector.name = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Commands Executed",
+          "layout": {
+            "column": 5,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.redis.cluster.node.commandstats.calls_count`) AS 'Commands' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND collector.name = 'gcp-polling-v2' FACET `metric.command` TIMESERIES AUTO"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Network Throughput (Bytes)",
+          "layout": {
+            "column": 9,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.redis.cluster.node.stats.net_input_bytes_count`) AS 'Bytes In', sum(`gcp.redis.cluster.node.stats.net_output_bytes_count`) AS 'Bytes Out' FROM Metric WHERE `entity.guid` = '{{entity.guid}}' AND collector.name = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpredisclusternode/definition.yml
+++ b/entity-types/infra-gcpredisclusternode/definition.yml
@@ -1,0 +1,11 @@
+domain: INFRA
+type: GCPREDISCLUSTERNODE
+goldenTags:
+- gcp.projectId
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-gcpredisclusternode/golden_metrics.yml
+++ b/entity-types/infra-gcpredisclusternode/golden_metrics.yml
@@ -1,0 +1,29 @@
+cpuUtilization:
+  title: CPU utilization
+  unit: PERCENTAGE
+  queries:
+    gcp:
+      select: average(`gcp.redis.cluster.node.cpu.utilization`) * 100
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+
+memoryUtilization:
+  title: Memory utilization
+  unit: PERCENTAGE
+  queries:
+    gcp:
+      select: average(`gcp.redis.cluster.node.memory.utilization`) * 100
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+
+connectedClients:
+  title: Connected clients
+  unit: COUNT
+  queries:
+    gcp:
+      select: latest(`gcp.redis.cluster.node.clients.connected_clients`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-gcpredisclusternode/summary_metrics.yml
+++ b/entity-types/infra-gcpredisclusternode/summary_metrics.yml
@@ -1,0 +1,26 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: GCP account
+  unit: STRING
+
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
+
+cpuUtilization:
+  goldenMetric: cpuUtilization
+  unit: PERCENTAGE
+  title: CPU utilization
+
+memoryUtilization:
+  goldenMetric: memoryUtilization
+  unit: PERCENTAGE
+  title: Memory utilization
+
+connectedClients:
+  goldenMetric: connectedClients
+  unit: COUNT
+  title: Connected clients

--- a/entity-types/infra-gcpredisinstance/dashboard.json
+++ b/entity-types/infra-gcpredisinstance/dashboard.json
@@ -1,0 +1,273 @@
+{
+  "name": "GCP Redis Instance",
+  "description": null,
+  "pages": [
+    {
+      "name": "Summary",
+      "description": null,
+      "widgets": [
+        {
+          "title": "Cache Hit Ratio (%)",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(gcp.redis.stats.cache_hit_ratio) * 100 AS 'Cache Hit Ratio (%)' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Memory Usage Ratio (%)",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(gcp.redis.stats.memory.usage_ratio) * 100 AS 'Memory Usage Ratio (%)' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Connected Clients",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(gcp.redis.clients.connected) AS 'Connected Clients' FROM Metric WHERE entity.guid = '{{entity.id}}' FACET metric.role TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "CPU Utilization (seconds)",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(gcp.redis.stats.cpu_utilization) AS 'CPU Utilization (s)' FROM Metric WHERE entity.guid = '{{entity.id}}' FACET metric.role TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Network Traffic (bytes)",
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(gcp.redis.stats.network_traffic) AS 'Network Traffic (bytes)' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Keyspace Hits vs Misses",
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(gcp.redis.stats.keyspace_hits) AS 'Hits', sum(gcp.redis.stats.keyspace_misses) AS 'Misses' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Memory Usage (bytes)",
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(gcp.redis.stats.memory.usage) AS 'Used Memory (bytes)', average(gcp.redis.stats.memory.maxmemory) AS 'Max Memory (bytes)' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Evicted & Expired Keys",
+          "layout": {
+            "column": 5,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(gcp.redis.stats.evicted_keys) AS 'Evicted Keys', sum(gcp.redis.stats.expired_keys) AS 'Expired Keys' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Blocked Clients",
+          "layout": {
+            "column": 9,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(gcp.redis.clients.blocked) AS 'Blocked Clients' FROM Metric WHERE entity.guid = '{{entity.id}}' FACET metric.role TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpredisinstance/definition.yml
+++ b/entity-types/infra-gcpredisinstance/definition.yml
@@ -1,6 +1,7 @@
 domain: INFRA
 type: GCPREDISINSTANCE
 goldenTags:
+- gcp.projectId
 - gcp.regionName
 - gcp.subscriptionId
 configuration:

--- a/entity-types/infra-gcpredisinstance/golden_metrics.yml
+++ b/entity-types/infra-gcpredisinstance/golden_metrics.yml
@@ -3,7 +3,7 @@ cacheHitRatio:
   unit: PERCENTAGE
   queries:
     gcp:
-      select: average(gcp.redis.instance.stats.cacheHitRatio)
+      select: average(gcp.redis.stats.cache_hit_ratio) * 100
       from: Metric
       eventId: entity.guid
       eventName: entity.name
@@ -17,7 +17,7 @@ cpuSecondsConsumedS:
   unit: SECONDS
   queries:
     gcp:
-      select: average(gcp.redis.instance.stats.cpuUtilization)
+      select: sum(gcp.redis.stats.cpu_utilization)
       from: Metric
       eventId: entity.guid
       eventName: entity.name
@@ -31,7 +31,7 @@ memoryUsageRatio:
   unit: PERCENTAGE
   queries:
     gcp:
-      select: average(gcp.redis.instance.stats.memory.usageRatio)
+      select: average(gcp.redis.stats.memory.usage_ratio) * 100
       from: Metric
       eventId: entity.guid
       eventName: entity.name
@@ -45,7 +45,7 @@ totalNetworkTrafficBytes:
   unit: BYTES        
   queries:
     gcp:
-      select: average(gcp.redis.instance.stats.networkTraffic)
+      select: sum(gcp.redis.stats.network_traffic)
       from: Metric
       eventId: entity.guid
       eventName: entity.name

--- a/entity-types/infra-gcpredisinstance/summary_metrics.yml
+++ b/entity-types/infra-gcpredisinstance/summary_metrics.yml
@@ -1,0 +1,21 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: GCP account
+  unit: STRING
+cacheHitRatio:
+  goldenMetric: cacheHitRatio
+  unit: PERCENTAGE
+  title: Cache hit ratio
+memoryUsageRatio:
+  goldenMetric: memoryUsageRatio
+  unit: PERCENTAGE
+  title: Memory usage ratio
+cpuSecondsConsumedS:
+  goldenMetric: cpuSecondsConsumedS
+  unit: SECONDS
+  title: CPU utilization
+totalNetworkTrafficBytes:
+  goldenMetric: totalNetworkTrafficBytes
+  unit: BYTES
+  title: Network traffic


### PR DESCRIPTION
## Summary

Consolidates GCP Redis entity definitions into a single PR:

- **GCPREDISCLUSTER** – definition, golden metrics, summary metrics, dashboard
- **GCPREDISCLUSTERNODE** – definition, golden metrics, summary metrics, dashboard
- **GCPREDISINSTANCE** – definition, golden metrics (existing), summary metrics, dashboard

Closes #2871
Closes #2874
Closes #2875