### PR TITLE
feat: Add GCP Pub/Sub entity definitions (GCPPUBSUBSUBSCRIPTION + GCPPUBSUBTOPIC + GCPPUBSUBSNAPSHOT)

### DIFF
--- a/entity-types/infra-gcppubsubsnapshot/dashboard.json
+++ b/entity-types/infra-gcppubsubsnapshot/dashboard.json
@@ -1,0 +1,244 @@
+{
+  "name": "GCP Pub/Sub Snapshot",
+  "description": null,
+  "pages": [
+    {
+      "name": "Summary",
+      "description": null,
+      "widgets": [
+        {
+          "title": "Backlog Bytes",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.pubsub.snapshot.backlog_bytes`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Number of Messages",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.pubsub.snapshot.num_messages`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Oldest Message Age (seconds)",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`gcp.pubsub.snapshot.oldest_message_age`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Backlog Bytes by Region",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.pubsub.snapshot.backlog_bytes_by_region`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.region` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Number of Messages by Region",
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.pubsub.snapshot.num_messages_by_region`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.region` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Oldest Message Age by Region (seconds)",
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`gcp.pubsub.snapshot.oldest_message_age_by_region`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.region` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Configuration Operations",
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.pubsub.snapshot.config_updates_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.operation_type` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Configuration Operations by Response Code",
+          "layout": {
+            "column": 7,
+            "row": 7,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.pubsub.snapshot.config_updates_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.response_code` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcppubsubsnapshot/definition.yml
+++ b/entity-types/infra-gcppubsubsnapshot/definition.yml
@@ -1,0 +1,11 @@
+domain: INFRA
+type: GCPPUBSUBSNAPSHOT
+goldenTags:
+- gcp.projectId
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-gcppubsubsnapshot/golden_metrics.yml
+++ b/entity-types/infra-gcppubsubsnapshot/golden_metrics.yml
@@ -1,0 +1,27 @@
+backlogBytes:
+  title: Backlog bytes
+  unit: BYTES
+  queries:
+    gcp:
+      select: sum(`gcp.pubsub.snapshot.backlog_bytes`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+numMessages:
+  title: Number of messages
+  unit: COUNT
+  queries:
+    gcp:
+      select: sum(`gcp.pubsub.snapshot.num_messages`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+oldestMessageAge:
+  title: Oldest message age
+  unit: SECONDS
+  queries:
+    gcp:
+      select: latest(`gcp.pubsub.snapshot.oldest_message_age`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-gcppubsubsnapshot/summary_metrics.yml
+++ b/entity-types/infra-gcppubsubsnapshot/summary_metrics.yml
@@ -1,0 +1,17 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: GCP account
+  unit: STRING
+backlogBytes:
+  goldenMetric: backlogBytes
+  unit: BYTES
+  title: Backlog bytes
+numMessages:
+  goldenMetric: numMessages
+  unit: COUNT
+  title: Number of messages
+oldestMessageAge:
+  goldenMetric: oldestMessageAge
+  unit: SECONDS
+  title: Oldest message age

--- a/entity-types/infra-gcppubsubsubscription/dashboard.json
+++ b/entity-types/infra-gcppubsubsubscription/dashboard.json
@@ -1,0 +1,186 @@
+{
+  "name": "GCP Pub/Sub Subscription",
+  "description": null,
+  "pages": [
+    {
+      "name": "Summary",
+      "description": null,
+      "widgets": [
+        {
+          "title": "Undelivered Messages",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.pubsub.subscription.num_undelivered_messages`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Backlog Size (bytes)",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.pubsub.subscription.backlog_bytes`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Oldest Unacked Message Age (s)",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`gcp.pubsub.subscription.oldest_unacked_message_age`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Acked Message Count by Delivery Type",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.pubsub.subscription.ack_message_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.delivery_type` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Pull Request Count",
+          "layout": {
+            "column": 7,
+            "row": 4,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.pubsub.subscription.pull_request_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.response_class` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Push Request Count",
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.pubsub.subscription.push_request_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.response_class` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcppubsubsubscription/definition.yml
+++ b/entity-types/infra-gcppubsubsubscription/definition.yml
@@ -1,5 +1,9 @@
 domain: INFRA
 type: GCPPUBSUBSUBSCRIPTION
+goldenTags:
+- gcp.projectId
+- gcp.subscriptionId
+- gcp.topicId
 configuration:
   entityExpirationTime: DAILY
   alertable: true

--- a/entity-types/infra-gcppubsubsubscription/golden_metrics.yml
+++ b/entity-types/infra-gcppubsubsubscription/golden_metrics.yml
@@ -1,14 +1,41 @@
 undeliveredMessages:
-  query:
-    eventId: entityGuid
-    select: sum(`subscription.NumUndeliveredMessages`)
-    from: GcpPubSubSubscriptionSample
-  unit: COUNT
   title: Undelivered messages
-outstandingSize:
-  query:
-    eventId: entityGuid
-    select: sum(`subscription.NumOutstandingMessages`)
-    from: GcpPubSubSubscriptionSample
   unit: COUNT
+  queries:
+    gcp:
+      select: sum(`gcp.pubsub.subscription.num_undelivered_messages`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    gcpSample:
+      select: sum(`subscription.NumUndeliveredMessages`)
+      from: GcpPubSubSubscriptionSample
+      eventId: entityGuid
+      eventName: entityName
+backlogSize:
+  title: Backlog size (bytes)
+  unit: BYTES
+  queries:
+    gcp:
+      select: sum(`gcp.pubsub.subscription.backlog_bytes`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+oldestUnackedMessageAge:
+  title: Oldest unacked message age (s)
+  unit: SECONDS
+  queries:
+    gcp:
+      select: latest(`gcp.pubsub.subscription.oldest_unacked_message_age`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+outstandingSize:
   title: Outstanding messages
+  unit: COUNT
+  queries:
+    gcpSample:
+      select: sum(`subscription.NumOutstandingMessages`)
+      from: GcpPubSubSubscriptionSample
+      eventId: entityGuid
+      eventName: entityName

--- a/entity-types/infra-gcppubsubsubscription/golden_metrics.yml
+++ b/entity-types/infra-gcppubsubsubscription/golden_metrics.yml
@@ -34,6 +34,11 @@ outstandingSize:
   title: Outstanding messages
   unit: COUNT
   queries:
+    gcp:
+      select: sum(`gcp.pubsub.subscription.num_outstanding_messages`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
     gcpSample:
       select: sum(`subscription.NumOutstandingMessages`)
       from: GcpPubSubSubscriptionSample

--- a/entity-types/infra-gcppubsubsubscription/summary_metrics.yml
+++ b/entity-types/infra-gcppubsubsubscription/summary_metrics.yml
@@ -3,10 +3,23 @@ providerAccountName:
     key: providerAccountName
   title: GCP account
   unit: STRING
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
 undeliveredMessages:
   goldenMetric: undeliveredMessages
   unit: COUNT
   title: Undelivered messages
+backlogSize:
+  goldenMetric: backlogSize
+  unit: BYTES
+  title: Backlog size (bytes)
+oldestUnackedMessageAge:
+  goldenMetric: oldestUnackedMessageAge
+  unit: SECONDS
+  title: Oldest unacked message age (s)
 outstandingSize:
   goldenMetric: outstandingSize
   unit: COUNT

--- a/entity-types/infra-gcppubsubtopic/dashboard.json
+++ b/entity-types/infra-gcppubsubtopic/dashboard.json
@@ -1,0 +1,186 @@
+{
+  "name": "GCP Pub/Sub Topic",
+  "description": null,
+  "pages": [
+    {
+      "name": "Summary",
+      "description": null,
+      "widgets": [
+        {
+          "title": "Publish Requests",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.pubsub.topic.send_request_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Publish Error Rate",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT filter(sum(`gcp.pubsub.topic.send_request_count`), WHERE `metric.response_class` = 'invalid' OR `metric.response_class` = 'internal') * 100 / sum(`gcp.pubsub.topic.send_request_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Publish Requests by Response Class",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.pubsub.topic.send_request_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.response_class` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Unacknowledged Messages by Region",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.pubsub.topic.num_unacked_messages_by_region`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.region` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Retained Messages",
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.pubsub.topic.num_retained_messages`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Retained Bytes",
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.pubsub.topic.retained_bytes`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcppubsubtopic/definition.yml
+++ b/entity-types/infra-gcppubsubtopic/definition.yml
@@ -1,5 +1,7 @@
 domain: INFRA
 type: GCPPUBSUBTOPIC
+goldenTags:
+- gcp.projectId
 configuration:
   entityExpirationTime: DAILY
   alertable: true

--- a/entity-types/infra-gcppubsubtopic/golden_metrics.yml
+++ b/entity-types/infra-gcppubsubtopic/golden_metrics.yml
@@ -2,23 +2,34 @@ sendMessageRequests:
   queries:
     gcp:
       eventId: entity.guid
-      select: (rate(sum(`gcp.pubsub.topic.send_message_operation_count`), 1 minute)) / 60
-      from: Metric 
-    gcpSample: 
+      eventName: entity.name
+      select: sum(`gcp.pubsub.topic.send_request_count`)
+      from: Metric
+    gcpSample:
       eventId: entityGuid
       select: (rate(sum(`topic.SendMessageOperation`), 1 minute)) / 60
       from: GcpPubSubTopicSample
-  unit: MESSAGES_PER_SECOND
-  title: Send rate
+  unit: COUNT
+  title: Publish requests
 unackedMessages:
   queries:
     gcp:
       eventId: entity.guid
-      select: sum(`gcp.pubsub.subscription.num_unacked_messages_by_region`)
-      from: Metric 
-    gcpSample: 
+      eventName: entity.name
+      select: sum(`gcp.pubsub.topic.num_unacked_messages_by_region`)
+      from: Metric
+    gcpSample:
       eventId: entityGuid
       select: sum(`topic.NumUnackedMessagesByRegion`)
       from: GcpPubSubTopicSample
   unit: COUNT
   title: Unacknowledged messages
+retainedMessages:
+  queries:
+    gcp:
+      eventId: entity.guid
+      eventName: entity.name
+      select: sum(`gcp.pubsub.topic.num_retained_messages`)
+      from: Metric
+  unit: COUNT
+  title: Retained messages

--- a/entity-types/infra-gcppubsubtopic/summary_metrics.yml
+++ b/entity-types/infra-gcppubsubtopic/summary_metrics.yml
@@ -3,11 +3,20 @@ providerAccountName:
     key: providerAccountName
   title: GCP account
   unit: STRING
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
 sendMessageRequests:
   goldenMetric: sendMessageRequests
-  unit: MESSAGES_PER_SECOND
-  title: Send rate
+  unit: COUNT
+  title: Publish requests
 unackedMessages:
   goldenMetric: unackedMessages
   unit: COUNT
   title: Unacknowledged messages
+retainedMessages:
+  goldenMetric: retainedMessages
+  unit: COUNT
+  title: Retained messages


### PR DESCRIPTION
## Summary

Consolidates GCP Pub/Sub entity definitions into a single PR:

- **GCPPUBSUBSUBSCRIPTION** – definition, golden metrics, summary metrics, dashboard
- **GCPPUBSUBTOPIC** – definition, golden metrics, summary metrics, dashboard
- **GCPPUBSUBSNAPSHOT** – definition, golden metrics, summary metrics, dashboard

Closes #2866
Closes #2868
Closes #2869