### PR TITLE
feat: Add GCP Router entity definitions (GCPROUTERCLOUDROUTER + GCPROUTERNATGATEWAY)

### DIFF
--- a/entity-types/infra-gcproutercloudrouter/dashboard.json
+++ b/entity-types/infra-gcproutercloudrouter/dashboard.json
@@ -1,0 +1,273 @@
+{
+  "name": "GCP Cloud Router",
+  "description": null,
+  "pages": [
+    {
+      "name": "Summary",
+      "description": null,
+      "widgets": [
+        {
+          "title": "BGP Sessions Up",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.router.bgp_sessions_up_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "BGP Sessions Down",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.router.bgp_sessions_down_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Sent Routes Count",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.router.sent_routes_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Best Routes Count",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.router.best_routes_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "BGP Received Routes by Peer",
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.router.bgp.received_routes_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.bgp_peer_name` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "BGP Session Up by Peer",
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`gcp.router.bgp.session_up`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.bgp_peer_name` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Router Up Tasks",
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`gcp.router.router_up`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "BFD Session Up by Peer",
+          "layout": {
+            "column": 5,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`gcp.router.bfd.session_up`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.peer_ip` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "BFD Control Packets (Received vs Transmitted)",
+          "layout": {
+            "column": 9,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.router.bfd.control.received_packets_count`) AS 'Received', sum(`gcp.router.bfd.control.transmitted_packets_count`) AS 'Transmitted' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcproutercloudrouter/definition.yml
+++ b/entity-types/infra-gcproutercloudrouter/definition.yml
@@ -1,9 +1,11 @@
 domain: INFRA
 type: GCPROUTERCLOUDROUTER
+goldenTags:
+- gcp.projectId
+- gcp.region
 configuration:
   entityExpirationTime: DAILY
   alertable: true
-
 ownership:
   primaryOwner:
     teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-gcproutercloudrouter/golden_metrics.yml
+++ b/entity-types/infra-gcproutercloudrouter/golden_metrics.yml
@@ -1,0 +1,27 @@
+bgpSessionsUp:
+  title: BGP Sessions Up
+  unit: COUNT
+  queries:
+    gcp:
+      select: sum(`gcp.router.bgp_sessions_up_count`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+bgpSessionsDown:
+  title: BGP Sessions Down
+  unit: COUNT
+  queries:
+    gcp:
+      select: sum(`gcp.router.bgp_sessions_down_count`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+sentRoutesCount:
+  title: Sent Routes Count
+  unit: COUNT
+  queries:
+    gcp:
+      select: sum(`gcp.router.sent_routes_count`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-gcproutercloudrouter/summary_metrics.yml
+++ b/entity-types/infra-gcproutercloudrouter/summary_metrics.yml
@@ -1,0 +1,22 @@
+nrAccountId:
+  tag:
+    key: nrAccount.id
+  title: NR Account ID
+  unit: STRING
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
+bgpSessionsUp:
+  goldenMetric: bgpSessionsUp
+  unit: COUNT
+  title: BGP Sessions Up
+bgpSessionsDown:
+  goldenMetric: bgpSessionsDown
+  unit: COUNT
+  title: BGP Sessions Down
+sentRoutesCount:
+  goldenMetric: sentRoutesCount
+  unit: COUNT
+  title: Sent Routes Count

--- a/entity-types/infra-gcprouternatgateway/dashboard.json
+++ b/entity-types/infra-gcprouternatgateway/dashboard.json
@@ -27,7 +27,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT sum(`gcp.router.nat.open_connections`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+                "query": "SELECT sum(`gcp.compute.nat.open_connections`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
               }
             ],
             "yAxisLeft": {
@@ -56,7 +56,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT sum(`gcp.router.nat.sent_bytes_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+                "query": "SELECT sum(`gcp.compute.nat.sent_bytes_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
               }
             ],
             "yAxisLeft": {
@@ -85,7 +85,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT sum(`gcp.router.nat.dropped_sent_packets_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+                "query": "SELECT sum(`gcp.compute.nat.dropped_sent_packets_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
               }
             ],
             "yAxisLeft": {
@@ -114,7 +114,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT sum(`gcp.router.nat.allocated_ports`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.nat_ip` TIMESERIES auto"
+                "query": "SELECT sum(`gcp.compute.nat.allocated_ports`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.nat_ip` TIMESERIES auto"
               }
             ],
             "yAxisLeft": {
@@ -143,7 +143,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT sum(`gcp.router.nat.open_connections`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.ip_protocol` TIMESERIES auto"
+                "query": "SELECT sum(`gcp.compute.nat.open_connections`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.ip_protocol` TIMESERIES auto"
               }
             ],
             "yAxisLeft": {
@@ -172,7 +172,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT sum(`gcp.router.nat.dropped_sent_packets_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.reason` TIMESERIES auto"
+                "query": "SELECT sum(`gcp.compute.nat.dropped_sent_packets_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.reason` TIMESERIES auto"
               }
             ],
             "yAxisLeft": {
@@ -201,7 +201,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT sum(`gcp.router.nat.received_bytes_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+                "query": "SELECT sum(`gcp.compute.nat.received_bytes_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
               }
             ],
             "yAxisLeft": {
@@ -230,7 +230,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT sum(`gcp.router.nat.new_connections_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.ip_protocol` TIMESERIES auto"
+                "query": "SELECT sum(`gcp.compute.nat.new_connections_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.ip_protocol` TIMESERIES auto"
               }
             ],
             "yAxisLeft": {
@@ -259,7 +259,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT max(`gcp.router.nat.port_usage`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.ip_protocol` TIMESERIES auto"
+                "query": "SELECT max(`gcp.compute.nat.port_usage`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.ip_protocol` TIMESERIES auto"
               }
             ],
             "yAxisLeft": {

--- a/entity-types/infra-gcprouternatgateway/dashboard.json
+++ b/entity-types/infra-gcprouternatgateway/dashboard.json
@@ -1,0 +1,273 @@
+{
+  "name": "GCP Router NAT Gateway",
+  "description": null,
+  "pages": [
+    {
+      "name": "Summary",
+      "description": null,
+      "widgets": [
+        {
+          "title": "Open Connections",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.router.nat.open_connections`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Sent Bytes Count",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.router.nat.sent_bytes_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Dropped Sent Packets Count",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.router.nat.dropped_sent_packets_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Allocated Ports by NAT IP",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.router.nat.allocated_ports`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.nat_ip` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Open Connections by Protocol",
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.router.nat.open_connections`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.ip_protocol` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Dropped Sent Packets by Reason",
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.router.nat.dropped_sent_packets_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.reason` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Received Bytes Count",
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.router.nat.received_bytes_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "New Connections Count by Protocol",
+          "layout": {
+            "column": 5,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.router.nat.new_connections_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.ip_protocol` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Port Usage",
+          "layout": {
+            "column": 9,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT max(`gcp.router.nat.port_usage`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.ip_protocol` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcprouternatgateway/definition.yml
+++ b/entity-types/infra-gcprouternatgateway/definition.yml
@@ -1,9 +1,11 @@
 domain: INFRA
 type: GCPROUTERNATGATEWAY
+goldenTags:
+- gcp.projectId
+- gcp.region
 configuration:
   entityExpirationTime: DAILY
   alertable: true
-
 ownership:
   primaryOwner:
     teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-gcprouternatgateway/golden_metrics.yml
+++ b/entity-types/infra-gcprouternatgateway/golden_metrics.yml
@@ -1,0 +1,27 @@
+openConnections:
+  title: Open Connections
+  unit: COUNT
+  queries:
+    gcp:
+      select: sum(`gcp.router.nat.open_connections`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+sentBytesCount:
+  title: Sent Bytes Count
+  unit: BYTES
+  queries:
+    gcp:
+      select: sum(`gcp.router.nat.sent_bytes_count`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+droppedSentPacketsCount:
+  title: Dropped Sent Packets Count
+  unit: COUNT
+  queries:
+    gcp:
+      select: sum(`gcp.router.nat.dropped_sent_packets_count`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-gcprouternatgateway/golden_metrics.yml
+++ b/entity-types/infra-gcprouternatgateway/golden_metrics.yml
@@ -3,7 +3,7 @@ openConnections:
   unit: COUNT
   queries:
     gcp:
-      select: sum(`gcp.router.nat.open_connections`)
+      select: sum(`gcp.compute.nat.open_connections`)
       from: Metric
       eventId: entity.guid
       eventName: entity.name
@@ -12,7 +12,7 @@ sentBytesCount:
   unit: BYTES
   queries:
     gcp:
-      select: sum(`gcp.router.nat.sent_bytes_count`)
+      select: sum(`gcp.compute.nat.sent_bytes_count`)
       from: Metric
       eventId: entity.guid
       eventName: entity.name
@@ -21,7 +21,7 @@ droppedSentPacketsCount:
   unit: COUNT
   queries:
     gcp:
-      select: sum(`gcp.router.nat.dropped_sent_packets_count`)
+      select: sum(`gcp.compute.nat.dropped_sent_packets_count`)
       from: Metric
       eventId: entity.guid
       eventName: entity.name

--- a/entity-types/infra-gcprouternatgateway/summary_metrics.yml
+++ b/entity-types/infra-gcprouternatgateway/summary_metrics.yml
@@ -1,0 +1,22 @@
+nrAccountId:
+  tag:
+    key: nrAccount.id
+  title: NR Account ID
+  unit: STRING
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
+openConnections:
+  goldenMetric: openConnections
+  unit: COUNT
+  title: Open Connections
+sentBytesCount:
+  goldenMetric: sentBytesCount
+  unit: BYTES
+  title: Sent Bytes Count
+droppedSentPacketsCount:
+  goldenMetric: droppedSentPacketsCount
+  unit: COUNT
+  title: Dropped Sent Packets Count


### PR DESCRIPTION
## Summary

Consolidates GCP Router entity definitions into a single PR:

- **GCPROUTERCLOUDROUTER** – definition, golden metrics, summary metrics, dashboard
- **GCPROUTERNATGATEWAY** – definition, golden metrics, summary metrics, dashboard

Closes #2870
Closes #2873