### PR TITLE
feat: Add GCP Kubernetes entity definitions (GCPKUBERNETESNODE + GCPKUBERNETESCONTAINER + GCPKUBERNETESPOD)

### DIFF
--- a/entity-types/infra-gcpkubernetescontainer/dashboard.json
+++ b/entity-types/infra-gcpkubernetescontainer/dashboard.json
@@ -1,0 +1,186 @@
+{
+  "name": "GCP Kubernetes Container",
+  "description": null,
+  "pages": [
+    {
+      "name": "Summary",
+      "description": null,
+      "widgets": [
+        {
+          "title": "CPU Core Usage Time",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.kubernetes.container.cpu.core_usage_time`) AS 'CPU Usage Time (s)' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "CPU Limit Utilization",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.kubernetes.container.cpu.limit_utilization`) * 100 AS 'CPU Limit Utilization (%)' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "CPU Request Utilization",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.kubernetes.container.cpu.request_utilization`) * 100 AS 'CPU Request Utilization (%)' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Memory Used Bytes",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.kubernetes.container.memory.used_bytes`) AS 'Memory Used (bytes)' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Memory Limit Utilization",
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.kubernetes.container.memory.limit_utilization`) * 100 AS 'Memory Limit Utilization (%)' FROM Metric WHERE entity.guid = '{{entity.id}}' FACET metric.memory_type TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Container Restarts",
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.kubernetes.container.restart_count`) AS 'Restarts' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpkubernetescontainer/definition.yml
+++ b/entity-types/infra-gcpkubernetescontainer/definition.yml
@@ -1,5 +1,8 @@
 domain: INFRA
 type: GCPKUBERNETESCONTAINER
+goldenTags:
+- gcp.projectId
+- gcp.region
 configuration:
   entityExpirationTime: DAILY
   alertable: true

--- a/entity-types/infra-gcpkubernetescontainer/summary_metrics.yml
+++ b/entity-types/infra-gcpkubernetescontainer/summary_metrics.yml
@@ -3,6 +3,13 @@ providerAccountName:
     key: providerAccountName
   title: GCP account
   unit: STRING
+
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
+
 cpuUsage:
   goldenMetric: cpuUsage
   unit: SECONDS

--- a/entity-types/infra-gcpkubernetesnode/dashboard.json
+++ b/entity-types/infra-gcpkubernetesnode/dashboard.json
@@ -1,0 +1,331 @@
+{
+  "name": "GCP Kubernetes Node",
+  "description": null,
+  "pages": [
+    {
+      "name": "Summary",
+      "description": null,
+      "widgets": [
+        {
+          "title": "CPU Core Usage Time",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.kubernetes.node.cpu.core_usage_time`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "CPU Allocatable Utilization",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.kubernetes.node.cpu.allocatable_utilization`) * 100 AS 'CPU Allocatable Utilization %' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Allocatable CPU Cores",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.kubernetes.node.cpu.allocatable_cores`) AS 'Allocatable Cores', average(`gcp.kubernetes.node.cpu.total_cores`) AS 'Total Cores' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Memory Used Bytes",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.kubernetes.node.memory.used_bytes`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.memory_type` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Memory Allocatable Utilization",
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.kubernetes.node.memory.allocatable_utilization`) * 100 AS 'Memory Allocatable Utilization %' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Memory Bytes (Allocatable vs Total)",
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.kubernetes.node.memory.allocatable_bytes`) AS 'Allocatable Bytes', average(`gcp.kubernetes.node.memory.total_bytes`) AS 'Total Bytes' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Network Bytes Received",
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(sum(`gcp.kubernetes.node.network.received_bytes_count`), 1 minute) AS 'Bytes Received/min' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Network Bytes Sent",
+          "layout": {
+            "column": 5,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(sum(`gcp.kubernetes.node.network.sent_bytes_count`), 1 minute) AS 'Bytes Sent/min' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "PID Usage vs Limit",
+          "layout": {
+            "column": 9,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.kubernetes.node.pid_used`) AS 'PIDs Used', average(`gcp.kubernetes.node.pid_limit`) AS 'PID Limit' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Ephemeral Storage Used vs Allocatable",
+          "layout": {
+            "column": 1,
+            "row": 10,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.kubernetes.node.ephemeral_storage.used_bytes`) AS 'Used Bytes', average(`gcp.kubernetes.node.ephemeral_storage.allocatable_bytes`) AS 'Allocatable Bytes', average(`gcp.kubernetes.node.ephemeral_storage.total_bytes`) AS 'Total Bytes' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Node Status Condition",
+          "layout": {
+            "column": 7,
+            "row": 10,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`gcp.kubernetes.node.status_condition`) AS 'Status' FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.condition`, `metric.status` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpkubernetesnode/definition.yml
+++ b/entity-types/infra-gcpkubernetesnode/definition.yml
@@ -1,5 +1,8 @@
 domain: INFRA
 type: GCPKUBERNETESNODE
+goldenTags:
+- gcp.projectId
+- gcp.region
 configuration:
   entityExpirationTime: DAILY
   alertable: true

--- a/entity-types/infra-gcpkubernetesnode/summary_metrics.yml
+++ b/entity-types/infra-gcpkubernetesnode/summary_metrics.yml
@@ -3,6 +3,13 @@ providerAccountName:
     key: providerAccountName
   title: GCP account
   unit: STRING
+
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
+
 cpuUsage:
   goldenMetric: cpuUsage
   unit: SECONDS

--- a/entity-types/infra-gcpkubernetespod/dashboard.json
+++ b/entity-types/infra-gcpkubernetespod/dashboard.json
@@ -1,0 +1,112 @@
+{
+  "name": "GcpKubernetesPod",
+  "description": null,
+  "pages": [
+    {
+      "name": "GcpKubernetesPod",
+      "description": null,
+      "widgets": [
+        {
+          "title": "Network Bytes Received",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.kubernetes.pod.network.received_bytes_count`) AS 'Bytes Received' FROM Metric WHERE `entity.guid` = '{{entity.id}}' AND collector.name = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Network Bytes Sent",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.kubernetes.pod.network.sent_bytes_count`) AS 'Bytes Sent' FROM Metric WHERE `entity.guid` = '{{entity.id}}' AND collector.name = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Volume Utilization (%)",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.kubernetes.pod.volume.utilization`) * 100 AS 'Volume Utilization %' FROM Metric WHERE `entity.guid` = '{{entity.id}}' AND collector.name = 'gcp-polling-v2' TIMESERIES AUTO"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Volume Used Bytes",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.kubernetes.pod.volume.used_bytes`) AS 'Used Bytes' FROM Metric WHERE `entity.guid` = '{{entity.id}}' AND collector.name = 'gcp-polling-v2' FACET `metric.volume_name` TIMESERIES AUTO"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Volume Total Bytes",
+          "layout": {
+            "column": 7,
+            "row": 4,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.kubernetes.pod.volume.total_bytes`) AS 'Total Bytes' FROM Metric WHERE `entity.guid` = '{{entity.id}}' AND collector.name = 'gcp-polling-v2' FACET `metric.volume_name` TIMESERIES AUTO"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpkubernetespod/definition.yml
+++ b/entity-types/infra-gcpkubernetespod/definition.yml
@@ -1,0 +1,12 @@
+domain: INFRA
+type: GCPKUBERNETESPOD
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+
+goldenTags:
+  - gcp.projectId
+
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-gcpkubernetespod/golden_metrics.yml
+++ b/entity-types/infra-gcpkubernetespod/golden_metrics.yml
@@ -1,0 +1,29 @@
+networkReceivedBytes:
+  title: Network bytes received
+  unit: BYTES
+  queries:
+    gcp:
+      eventId: entity.guid
+      select: sum(gcp.kubernetes.pod.network.received_bytes_count)
+      from: Metric
+      eventName: entity.name
+
+networkSentBytes:
+  title: Network bytes sent
+  unit: BYTES
+  queries:
+    gcp:
+      eventId: entity.guid
+      select: sum(gcp.kubernetes.pod.network.sent_bytes_count)
+      from: Metric
+      eventName: entity.name
+
+volumeUtilization:
+  title: Volume utilization
+  unit: PERCENTAGE
+  queries:
+    gcp:
+      eventId: entity.guid
+      select: average(gcp.kubernetes.pod.volume.utilization) * 100
+      from: Metric
+      eventName: entity.name

--- a/entity-types/infra-gcpkubernetespod/summary_metrics.yml
+++ b/entity-types/infra-gcpkubernetespod/summary_metrics.yml
@@ -1,0 +1,26 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: GCP account
+  unit: STRING
+
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
+
+networkReceivedBytes:
+  goldenMetric: networkReceivedBytes
+  title: Network bytes received
+  unit: BYTES
+
+networkSentBytes:
+  goldenMetric: networkSentBytes
+  title: Network bytes sent
+  unit: BYTES
+
+volumeUtilization:
+  goldenMetric: volumeUtilization
+  title: Volume utilization
+  unit: PERCENTAGE


### PR DESCRIPTION
## Summary

Consolidates GCP Kubernetes entity definitions into a single PR:

- **GCPKUBERNETESNODE** – definition, summary metrics, dashboard
- **GCPKUBERNETESCONTAINER** – definition, summary metrics, dashboard
- **GCPKUBERNETESPOD** – definition, golden metrics, summary metrics, dashboard

Closes #2881
Closes #2882
Closes #2885