### PR TITLE
fix: remove k8s.pod.name exclusion from Host→HAProxy relationship rule

### DIFF
--- a/relationships/synthesis/INFRA-HOST-to-INFRA-HAPROXYINSTANCE.stg.yml
+++ b/relationships/synthesis/INFRA-HOST-to-INFRA-HAPROXYINSTANCE.stg.yml
@@ -16,8 +16,6 @@ relationships:
         anyOf: ["opentelemetry"]
       - attribute: host.id
         present: true
-      - attribute: k8s.pod.name
-        present: false
     relationship:
       expires: PT75M
       relationshipType: HOSTS


### PR DESCRIPTION
Remove the k8s.pod.name: present: false condition to match the production NGINX Host relationship pattern (INFRA-HOST-to-INFRA-NGINXSERVER.yml) which works without k8s exclusion. In K8s scenarios, both Host and Pod relationships can coexist (same pattern as NGINX).

Only a small change, and change is only in staging. won't impact production.