### PR TITLE
fix(apacheserver): drop otel.library.name gating from default OTel dashboard

### DIFF
--- a/entity-types/infra-apacheserver/opentelemetry_dashboard.json
+++ b/entity-types/infra-apacheserver/opentelemetry_dashboard.json
@@ -19,7 +19,7 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "query": "SELECT average(apache.requests) AS `Requests` FROM Metric WHERE otel.library.name='otelcol/apachereceiver' TIMESERIES AUTO",
+                "query": "SELECT average(apache.requests) AS `Requests` FROM Metric TIMESERIES AUTO",
                 "accountId": 0}
             ]
           }
@@ -38,7 +38,7 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "query": "FROM Metric SELECT average(apache.traffic) WHERE otel.library.name = 'otelcol/apachereceiver' TIMESERIES AUTO",
+                "query": "FROM Metric SELECT average(apache.traffic) TIMESERIES AUTO",
                 "accountId": 0}
             ],
              "units": {
@@ -60,7 +60,7 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "query": "FROM Metric SELECT latest(apache.scoreboard) FACET upper(state) WHERE otel.library.name = 'otelcol/apachereceiver'",
+                "query": "FROM Metric SELECT latest(apache.scoreboard) FACET upper(state)",
                 "accountId": 0}
             ]
           }
@@ -79,7 +79,7 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "query": "FROM Metric SELECT average(apache.scoreboard) FACET upper(state) WHERE otel.library.name = 'otelcol/apachereceiver' and state not in('waiting','open') TIMESERIES AUTO",
+                "query": "FROM Metric SELECT average(apache.scoreboard) FACET upper(state) WHERE state NOT IN ('waiting', 'open') TIMESERIES AUTO",
                 "accountId": 0}
             ]
           }
@@ -98,7 +98,7 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "query": "FROM Metric SELECT sum(apache.workers) WHERE otel.library.name = 'otelcol/apachereceiver' FACET upper(state) TIMESERIES AUTO",
+                "query": "FROM Metric SELECT sum(apache.workers) FACET upper(state) TIMESERIES AUTO",
                 "accountId": 0}
             ]
           }


### PR DESCRIPTION
## Summary

Follow-up to #2893 / [NR-570460](https://new-relic.atlassian.net/browse/NR-570460).

After #2893, Apache entities are now synthesized from both legacy (`otelcol/apachereceiver`) and modern (`github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachereceiver`) `otel.library.name` values. Entities show up correctly, **but every chart in the default OpenTelemetry view stays empty** for entities synthesized from the modern full-URL form.

The cause: all 5 widgets in `opentelemetry_dashboard.json` still hard-code `WHERE otel.library.name = 'otelcol/apachereceiver'`. That clause filters out every metric coming from a current `opentelemetry-collector-contrib` build.

## Fix

Remove the `otel.library.name` clause from all 5 widget queries. 
Entity dashboards are filtered by `entity.guid` by default (see `docs/entities/entity_summary.md`), so the receiver-name clause was redundant defensive filtering — dropping it makes the widgets work for both legacy and modern collectors with no risk of cross-entity contamination.


## Test plan

- [x] `validator/npm run check` passes (schema, rules, folders, dashboard, etc.)
- [x] `validator/npm run sanitize-dashboards` produces no diff
- [ ] Reviewer confirms the widgets render data for both legacy `otelcol/apachereceiver` and modern `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachereceiver` Apache entities

[NR-570460]: https://new-relic.atlassian.net/browse/NR-570460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ