### PR TITLE
fix(apacheserver): correct OTel golden-metric

### DIFF
--- a/entity-types/infra-apacheserver/golden_metrics.yml
+++ b/entity-types/infra-apacheserver/golden_metrics.yml
@@ -34,8 +34,6 @@ busyWorkers:
       select: average(apache.workers)
       from: Metric
       where: state = 'busy'
-      eventId: entityGuid
-      eventName: entityName
 idleWorkers:
   title: Current number of idle workers
   unit: COUNT
@@ -49,5 +47,3 @@ idleWorkers:
       select: average(apache.workers)
       from: Metric
       where: state = 'idle'
-      eventId: entityGuid
-      eventName: entityName


### PR DESCRIPTION
## Summary

Follow-up to #2893 / [NR-570460](https://new-relic.atlassian.net/browse/NR-570460).

Golden metrics for apacheserver from OTel are not working.

Dropping the four override lines restores the documented defaults (`entity.guid` / `entity.name` for the OTel block. 
These lines had probably been copied over from the nri-apache OHI parts by mistake.

## Audit

I scanned every other INFRA entity with OTel synthesis to confirm this bug is unique to apacheserver. All 19 are correct (either omit `eventId` / `eventName` and pick up the defaults, or set them explicitly to `entity.guid` / `entity.name`):

```
container, host, elasticsearchcluster, elasticsearchnode, haproxyinstance,
kafkabroker, kafkacluster, kafkatopic, mongodb_instance, mssqlinstance,
mysqlnode, nginxserver, oracledbinstance, postgresqlinstance,
rabbitmqnode, rabbitmqqueue, redisinstance, awsecscluster, awsecstask
```

## Test plan

- [x] `validator/npm run check` passes
- [ ] Reviewer confirms `busyWorkers` / `idleWorkers` golden metrics show data on an OTel-synthesized Apache entity post-deploy

[NR-570460]: https://new-relic.atlassian.net/browse/NR-570460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ