### PR TITLE
feat: Add tag for OTel Java agent for EXT service

### DIFF
--- a/entity-types/ext-service/definition.stg.yml
+++ b/entity-types/ext-service/definition.stg.yml
@@ -386,6 +386,42 @@ synthesis:
       service.namespace:
 
 
+    # Detects OTel Java agent 1.x — fires when process.runtime.jvm.* metrics arrive
+  - ruleName: ext_service_otel_jvm_agent_1x
+    identifier: service.name
+    name: service.name
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: service.name
+      present: true
+    - attribute: instrumentation.provider
+      value: opentelemetry
+    - attribute: metricName
+      prefix: process.runtime.jvm
+    tags:
+      otel.library.version:
+        entityTagName: jvmInstrumentationVersion
+        multiValue: false
+        ttl: P1D
+
+    # Detects OTel Java agent 2.x — fires when jvm.* metrics arrive (renamed in 2.x)
+  - ruleName: ext_service_otel_jvm_agent_2x
+    identifier: service.name
+    name: service.name
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: service.name
+      present: true
+    - attribute: instrumentation.provider
+      value: opentelemetry
+    - attribute: metricName
+      prefix: jvm.
+    tags:
+      otel.library.version:
+        entityTagName: jvmInstrumentationVersion
+        multiValue: false
+        ttl: P1D
+
 configuration:
   entityExpirationTime: EIGHT_DAYS
   alertable: true


### PR DESCRIPTION
### Relevant information
  Added two synthesis rules in definition.stg.yml to detect whether an EXT_SERVICE entity is using OTel Java agent 1.x or 2.x.

  Rules:
  - ext_service_otel_jvm_agent_1x: fires on process.runtime.jvm.* metrics
  - ext_service_otel_jvm_agent_2x: fires on jvm.* metrics

  Both copy `otel.library.version` into tag `jvmInstrumentationVersion`
  with multiValue: false and ttl: P1D.



<!--
  Describe what you have done.
  Provide details that are relevant to the PR

  Always think that the person reviewing the PR doesn't have the context you have.

  Links to examples, documentation and similar resources make the process easier to review.
-->

<!--
  Contributions to this repository are reviewed at least twice a week

  There's no further action required once the PR has been created.
 -->

#### Api Review Board (ARB)

Any pull request with changes to this repository has to be linked with an ARB ticket, which has to be approved before merging.

If you are an external contributor please contact New Relic Support.

If you don't know about the ARB process check [this](https://newrelic.enterprise.slack.com/docs/T02D34WJD/F08AW240NSV)

ARB Jira ticket:
https://new-relic.atlassian.net/browse/NR-XXXX

### Checklist

* [X] I've read the guidelines and understand the acceptance criteria.
* [X] The value of the attribute marked as `identifier` will be unique and valid.
* [X] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
* [ ] I've linked an ARB ticket & received approval from API Review Board in order to make these changes
