### PR TITLE
fix: Enable alerting for AI Agent and AI Tool entities

### DIFF
--- a/entity-types/apm-ai_agent/definition.stg.yml
+++ b/entity-types/apm-ai_agent/definition.stg.yml
@@ -2,7 +2,7 @@ domain: APM
 type: AI_AGENT
 
 configuration:
-  alertable: false
+  alertable: true
   entityExpirationTime: QUARTERLY
 
 dashboardTemplates:

--- a/entity-types/apm-ai_agent/definition.yml
+++ b/entity-types/apm-ai_agent/definition.yml
@@ -2,7 +2,7 @@ domain: APM
 type: AI_AGENT
 
 configuration:
-  alertable: false
+  alertable: true
   entityExpirationTime: QUARTERLY
 
 ownership:

--- a/entity-types/apm-ai_tool/definition.stg.yml
+++ b/entity-types/apm-ai_tool/definition.stg.yml
@@ -2,7 +2,7 @@ domain: APM
 type: AI_TOOL
 
 configuration:
-  alertable: false
+  alertable: true
   entityExpirationTime: QUARTERLY
 
 dashboardTemplates:

--- a/entity-types/apm-ai_tool/definition.yml
+++ b/entity-types/apm-ai_tool/definition.yml
@@ -2,7 +2,7 @@ domain: APM
 type: AI_TOOL
 
 configuration:
-  alertable: false
+  alertable: true
   entityExpirationTime: QUARTERLY
 
 ownership:


### PR DESCRIPTION
### Summary
Sets alertable: true for the AI_AGENT and AI_TOOL APM entity types, which were previously alertable: false.

### Changes
entity-types/apm-ai_agent/definition.yml — alertable: false → true
entity-types/apm-ai_agent/definition.stg.yml — alertable: false → true
entity-types/apm-ai_tool/definition.yml — alertable: false → true
entity-types/apm-ai_tool/definition.stg.yml — alertable: false → true

### Why
AI Agent and AI Tool entities should support alerting so users can create alert conditions against them, consistent with other APM entity types. The alertable flag was initially set to false when these entity types were introduced; this enables the alerting capability now that it's needed.



#### Api Review Board (ARB)

ARB Jira ticket: https://new-relic.atlassian.net/browse/NR-543093

Jira ticket : https://new-relic.atlassian.net/browse/NR-575119


