### PR TITLE
feat: Add GCP V2 Datastore Request entity definitions (NR-565785)

### DIFF
--- a/entity-types/infra-gcpdatastorerequest/dashboard.json
+++ b/entity-types/infra-gcpdatastorerequest/dashboard.json
@@ -1,0 +1,100 @@
+{
+  "name": "GCP Datastore Request",
+  "description": null,
+  "pages": [
+    {
+      "name": "GCP Datastore Request",
+      "description": null,
+      "widgets": [
+        {
+          "title": "API Request Count",
+          "layout": {"column": 1, "row": 1, "width": 4, "height": 3},
+          "visualization": {"id": "viz.line"},
+          "rawConfiguration": {
+            "facet": {"showOtherSeries": false},
+            "legend": {"enabled": true},
+            "nrqlQueries": [{"accountId": 0, "query": "FROM Metric SELECT sum(`gcp.datastore.api.request_count`) AS 'Requests' WHERE `entity.guid` = '{{entity.guid}}' TIMESERIES AUTO"}],
+            "yAxisLeft": {"zero": true}
+          }
+        },
+        {
+          "title": "Error Requests",
+          "layout": {"column": 5, "row": 1, "width": 4, "height": 3},
+          "visualization": {"id": "viz.line"},
+          "rawConfiguration": {
+            "facet": {"showOtherSeries": false},
+            "legend": {"enabled": true},
+            "nrqlQueries": [{"accountId": 0, "query": "FROM Metric SELECT sum(`gcp.datastore.api.request_count`) AS 'Error Requests' WHERE `entity.guid` = '{{entity.guid}}' AND `metric.response_code` NOT IN ('OK') TIMESERIES AUTO"}],
+            "yAxisLeft": {"zero": true}
+          }
+        },
+        {
+          "title": "Index Writes",
+          "layout": {"column": 9, "row": 1, "width": 4, "height": 3},
+          "visualization": {"id": "viz.line"},
+          "rawConfiguration": {
+            "facet": {"showOtherSeries": false},
+            "legend": {"enabled": true},
+            "nrqlQueries": [{"accountId": 0, "query": "FROM Metric SELECT sum(`gcp.datastore.index.write_count`) AS 'Index Writes' WHERE `entity.guid` = '{{entity.guid}}' TIMESERIES AUTO"}],
+            "yAxisLeft": {"zero": true}
+          }
+        },
+        {
+          "title": "Requests by API Method",
+          "layout": {"column": 1, "row": 4, "width": 4, "height": 3},
+          "visualization": {"id": "viz.line"},
+          "rawConfiguration": {
+            "facet": {"showOtherSeries": false},
+            "legend": {"enabled": true},
+            "nrqlQueries": [{"accountId": 0, "query": "FROM Metric SELECT sum(`gcp.datastore.api.request_count`) AS 'Requests' WHERE `entity.guid` = '{{entity.guid}}' FACET `metric.api_method` TIMESERIES AUTO"}],
+            "yAxisLeft": {"zero": true}
+          }
+        },
+        {
+          "title": "Requests by Response Code",
+          "layout": {"column": 5, "row": 4, "width": 4, "height": 3},
+          "visualization": {"id": "viz.line"},
+          "rawConfiguration": {
+            "facet": {"showOtherSeries": false},
+            "legend": {"enabled": true},
+            "nrqlQueries": [{"accountId": 0, "query": "FROM Metric SELECT sum(`gcp.datastore.api.request_count`) AS 'Requests' WHERE `entity.guid` = '{{entity.guid}}' FACET `metric.response_code` TIMESERIES AUTO"}],
+            "yAxisLeft": {"zero": true}
+          }
+        },
+        {
+          "title": "Read Entity Sizes (bytes, p50)",
+          "layout": {"column": 9, "row": 4, "width": 4, "height": 3},
+          "visualization": {"id": "viz.line"},
+          "rawConfiguration": {
+            "facet": {"showOtherSeries": false},
+            "legend": {"enabled": true},
+            "nrqlQueries": [{"accountId": 0, "query": "FROM Metric SELECT average(`gcp.datastore.entity.read_sizes`) AS 'Read Size (bytes)' WHERE `entity.guid` = '{{entity.guid}}' TIMESERIES AUTO"}],
+            "yAxisLeft": {"zero": true}
+          }
+        },
+        {
+          "title": "Written Entity Sizes (bytes, p50)",
+          "layout": {"column": 1, "row": 7, "width": 4, "height": 3},
+          "visualization": {"id": "viz.line"},
+          "rawConfiguration": {
+            "facet": {"showOtherSeries": false},
+            "legend": {"enabled": true},
+            "nrqlQueries": [{"accountId": 0, "query": "FROM Metric SELECT average(`gcp.datastore.entity.write_sizes`) AS 'Write Size (bytes)' WHERE `entity.guid` = '{{entity.guid}}' TIMESERIES AUTO"}],
+            "yAxisLeft": {"zero": true}
+          }
+        },
+        {
+          "title": "TTL Deletion Count",
+          "layout": {"column": 5, "row": 7, "width": 4, "height": 3},
+          "visualization": {"id": "viz.line"},
+          "rawConfiguration": {
+            "facet": {"showOtherSeries": false},
+            "legend": {"enabled": true},
+            "nrqlQueries": [{"accountId": 0, "query": "FROM Metric SELECT sum(`gcp.datastore.entity.ttl_deletion_count`) AS 'TTL Deletions' WHERE `entity.guid` = '{{entity.guid}}' TIMESERIES AUTO"}],
+            "yAxisLeft": {"zero": true}
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpdatastorerequest/definition.yml
+++ b/entity-types/infra-gcpdatastorerequest/definition.yml
@@ -1,5 +1,8 @@
 domain: INFRA
 type: GCPDATASTOREREQUEST
+goldenTags:
+- gcp.projectId
+- gcp.region
 configuration:
   entityExpirationTime: DAILY
   alertable: true

--- a/entity-types/infra-gcpdatastorerequest/golden_metrics.yml
+++ b/entity-types/infra-gcpdatastorerequest/golden_metrics.yml
@@ -1,0 +1,30 @@
+requestCount:
+  title: Request Count
+  unit: COUNT
+  queries:
+    gcp:
+      select: sum(gcp.datastore.api.request_count)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+
+errorCount:
+  title: Error Request Count
+  unit: COUNT
+  queries:
+    gcp:
+      select: sum(gcp.datastore.api.request_count)
+      from: Metric
+      where: "`metric.response_code` NOT IN ('OK')"
+      eventId: entity.guid
+      eventName: entity.name
+
+indexWriteCount:
+  title: Index Writes
+  unit: COUNT
+  queries:
+    gcp:
+      select: sum(gcp.datastore.index.write_count)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-gcpdatastorerequest/summary_metrics.yml
+++ b/entity-types/infra-gcpdatastorerequest/summary_metrics.yml
@@ -1,0 +1,26 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: GCP account
+  unit: STRING
+
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
+
+requestCount:
+  goldenMetric: requestCount
+  title: Request Count
+  unit: COUNT
+
+errorCount:
+  goldenMetric: errorCount
+  title: Error Request Count
+  unit: COUNT
+
+indexWriteCount:
+  goldenMetric: indexWriteCount
+  title: Index Writes
+  unit: COUNT


### PR DESCRIPTION
## Summary
- Add GCP V2 entity definitions for GCPDATASTOREREQUEST (NR-565785)
- Adds `entity_type` to enable entity synthesis in gcp-polling-v2
- Adds golden_metrics.yml, summary_metrics.yml, dashboard.json (Metric-only, GCP V2)
- Adds infra-summary templates (generic-metrics + generic-overview)
- Adds dimensional metrics dashboard template

## Metrics
- Request Count (`gcp.datastore.api.request_count`)
- Error Request Count (filtered on non-OK response codes)
- Index Writes (`gcp.datastore.index.write_count`)

## Test plan
- [ ] Verify entity synthesis with datastore_request resource type
- [ ] Confirm Metric data flowing for datastore.googleapis.com metrics
- [ ] Validate dashboard NRQL queries return data

🤖 Generated with Claude Code