### PR TITLE
Add INFRA-AZUREALARM entity type for Azure Monitor alert rules

### DIFF
--- a/entity-types/infra-azurealarm/definition.yml
+++ b/entity-types/infra-azurealarm/definition.yml
@@ -1,0 +1,46 @@
+domain: INFRA
+type: AZUREALARM
+goldenTags:
+  - azure.regionName
+  - azure.subscriptionId
+  - azure.resourceGroupName
+  - azure.type
+  - alarm_type
+configuration:
+  entityExpirationTime: DAILY
+  alertable: false
+synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
+    alarm_type:
+    enabled:
+      multiValue: false
+    severity:
+      multiValue: false
+  rules:
+    - ruleName: infra_azurealarm_metricalert_azure_resourceId
+      identifier: azure.resourceId
+      name: displayName
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: azure.resourceType
+          value: microsoft.insights/metricalerts
+    - ruleName: infra_azurealarm_scheduledqueryrule_azure_resourceId
+      identifier: azure.resourceId
+      name: displayName
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: azure.resourceType
+          value: microsoft.insights/scheduledqueryrules
+    - ruleName: infra_azurealarm_activitylogalert_azure_resourceId
+      identifier: azure.resourceId
+      name: displayName
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: azure.resourceType
+          value: microsoft.insights/activitylogalerts
+
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"


### PR DESCRIPTION
### Relevant information

Adds a new `INFRA` domain entity type `AZUREALARM` covering three Azure Monitor alert-rule ARM types:

- `microsoft.insights/metricalerts`
- `microsoft.insights/scheduledqueryrules`
- `microsoft.insights/activitylogalerts`

This entity type is part of New Relic's Cloud Monitoring Platform team's **cloud-alert-events** feature, which ingests Azure Monitor + AWS CloudWatch alert state changes into NRDB. Three sub-stories shipping in `azure-configuration-fetcher` ([beyond/azure-configuration-fetcher PRs #24-#27](https://source.datanerd.us/beyond/azure-configuration-fetcher/pulls)) route these alert rules through the existing CI fetcher pipeline. They emit as `EntityNotSupported` until this synthesis rule lands.

### Design choices

- **One entity type, three synthesis rules.** Spec FR-10.7 carries `alarm_type ∈ {metric, log, activityLog}` as a discriminator attribute on each event — strongly implies one shared type, not three. Mirrors [`infra-azurefunctionsworkflow`](../infra-azurefunctionsworkflow/definition.yml) which similarly collapses multiple ARM `resourceType`/`resourceKind` combinations into one entity type.
- **`configuration.alertable: false`.** You do not alert *on* an alarm — you alert *with* one.
- **`encodeIdentifierInGUID: true`.** Azure resource IDs frequently exceed the 50-char GUID limit (`docs/entities/guid_spec.md`).
- **No `legacyFeatures.overrideGuidType`.** Per [`docs/entities/synthesis.md` line 414](../../docs/entities/synthesis.md), `legacyFeatures` is reserved for existing entity types being modified — not net-new types.
- **`alarm_type` in `goldenTags`** because spec calls it out as the primary user-visible discriminator.
- **`enabled` and `severity` use `multiValue: false`** so latest value replaces previous (matches `k8s.status` precedent in `synthesis.md` line 224-234).

### Validation

Local validation passes:

```
cd validator && npm run validate-definition
```

The new `entity-types/infra-azurealarm/definition.yml` is **not** in the list of invalid files; only pre-existing master errors in `infra-aws_media*` directories remain (unrelated to this PR).

#### Api Review Board (ARB)

Any pull request with changes to this repository has to be linked with an ARB ticket, which has to be approved before merging.

If you are an external contributor please contact New Relic Support.

If you don't know about the ARB process check [this](https://newrelic.enterprise.slack.com/docs/T02D34WJD/F08AW240NSV)

ARB Jira ticket:
**TBD — drafting team will create and link before requesting review.** Marked as draft PR for now.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. (`azure.resourceId` is the full ARM ID — globally unique per Azure.)
* [x] I've confirmed that my entity type wasn't already defined. (Searched repo for `AZUREALARM`, `AwsAlarm`, `INFRA-AZUREALARM`, `microsoft.insights/metricalerts` — net-new.)
* [ ] I've linked an ARB ticket & received approval from API Review Board in order to make these changes — **pending**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)