### PR TITLE
feat(redis): Add OTel Redis entity synthesis, golden metrics, and relationships

### DIFF
--- a/entity-types/infra-redisinstance/definition.stg.yml
+++ b/entity-types/infra-redisinstance/definition.stg.yml
@@ -4,6 +4,7 @@ type: REDISINSTANCE
 synthesis:
   # Apart from this rule REDISINSTANCE entities are also created from infra pipeline.
   rules:
+  # Composite rule: server.address:server.port with otelcol/redisreceiver
   - ruleName: infra_redisinstance_composite
     compositeIdentifier:
       separator: ":"
@@ -21,7 +22,7 @@ synthesis:
       - attribute: instrumentation.provider
         value: opentelemetry
       # This filters only metrics coming from redis receiver, given that metrics
-      # could deffer between different runtime receivers. 
+      # could deffer between different runtime receivers.
       - attribute: otel.library.name
         value: otelcol/redisreceiver
     tags:
@@ -29,6 +30,18 @@ synthesis:
       redis.version:
       # Attributes
       redis.role:
+      # Host attributes
+      host.id:
+        ttl: P1D
+      host.name:
+        ttl: P1D
+      # Kubernetes attributes (optional)
+      k8s.namespace.name:
+        ttl: P1D
+      k8s.pod.name:
+        ttl: P1D
+      # Redis cluster
+      redis.cluster.name:
       # Environment resource attributes
       host.type:
       cloud.provider:
@@ -41,32 +54,75 @@ synthesis:
         entityTagName: instrumentation.name
       server.address:
       server.port:
-  # OpenTelemetry synthesis rule - service.instance.id pattern
-  - ruleName: infra_redisinstance_otel
-    identifier: service.instance.id
-    name: service.instance.id
+
+  # Composite rule: server.address:server.port with github.com receiver
+  - ruleName: infra_redisinstance_composite_1
+    compositeIdentifier:
+      separator: ":"
+      attributes:
+        - server.address
+        - server.port
+    name: server.address
     encodeIdentifierInGUID: true
     conditions:
       - attribute: eventType
         value: Metric
-      # Support both redis. and redis_ prefix metrics
       - attribute: metricName
         prefix: redis.
       - attribute: instrumentation.provider
         value: opentelemetry
-      # Only trigger when service.instance.id pattern is used (not server.address pattern)
-      - attribute: service.instance.id
+      - attribute: otel.library.name
+        value: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redisreceiver"
+    tags:
+      # Default resource attributes
+      redis.version:
+      # Attributes
+      redis.role:
+      # Host attributes
+      host.id:
+        ttl: P1D
+      host.name:
+        ttl: P1D
+      # Kubernetes attributes (optional)
+      k8s.namespace.name:
+        ttl: P1D
+      k8s.pod.name:
+        ttl: P1D
+      # Redis cluster
+      redis.cluster.name:
+      # Environment resource attributes
+      host.type:
+      cloud.provider:
+      cloud.account.id:
+      cloud.region:
+      # OTel attributes
+      otel.library.name:
+        entityTagName: instrumentation.name
+      server.address:
+      server.port:
+
+  # OpenTelemetry synthesis rule - redis.instance.id pattern with github.com receiver
+  - ruleName: infra_redisinstance_otel
+    identifier: redis.instance.id
+    name: redis.instance.id
+    encodeIdentifierInGUID: true
+    conditions:
+      - attribute: eventType
+        value: Metric
+      - attribute: metricName
+        prefix: redis.
+      - attribute: instrumentation.provider
+        value: opentelemetry
+      # Only trigger when redis.instance.id pattern is used (not server.address pattern)
+      - attribute: redis.instance.id
         present: true
       - attribute: server.address
         present: false
-      # Entity creation triggered by redis.role present OR service.name containing redis
-      - attribute: redis.role
-        present: true
       - attribute: otel.library.name
         value: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redisreceiver"
     tags:
       # Required resource attributes
-      service.instance.id:
+      redis.instance.id:
       redis.version:
       redis.role:
       redis.port:
@@ -90,6 +146,122 @@ synthesis:
       k8s.pod.name:
         ttl: P1D
       # OTel attributes
+      otel.library.name:
+        entityTagName: instrumentation.name
+
+  # OpenTelemetry synthesis rule - redis.instance.id pattern with otelcol receiver
+  - ruleName: infra_redisinstance_otel_1
+    identifier: redis.instance.id
+    name: redis.instance.id
+    encodeIdentifierInGUID: true
+    conditions:
+      - attribute: eventType
+        value: Metric
+      - attribute: metricName
+        prefix: redis.
+      - attribute: instrumentation.provider
+        value: opentelemetry
+      - attribute: redis.instance.id
+        present: true
+      - attribute: server.address
+        present: false
+      - attribute: otel.library.name
+        value: otelcol/redisreceiver
+    tags:
+      # Required resource attributes
+      redis.instance.id:
+      redis.version:
+      redis.role:
+      redis.port:
+      host.name:
+        ttl: P1D
+      host.id:
+        ttl: P1D
+      # Optional resource attributes
+      redis.cluster.name:
+      redis.cluster.enabled:
+      redis.maxmemory:
+      redis.persistence.enabled:
+      # Environment resource attributes
+      host.type:
+      cloud.provider:
+      cloud.account.id:
+      cloud.region:
+      # Kubernetes attributes (optional)
+      k8s.namespace.name:
+        ttl: P1D
+      k8s.pod.name:
+        ttl: P1D
+      # OTel attributes
+      otel.library.name:
+        entityTagName: instrumentation.name
+
+  # Log-based synthesis rule: server.address:server.port from Log event type
+  - ruleName: infra_redisinstance_otel_logs
+    compositeIdentifier:
+      separator: ":"
+      attributes:
+        - server.address
+        - server.port
+    name: server.address
+    encodeIdentifierInGUID: true
+    conditions:
+      - attribute: eventType
+        value: Log
+      - attribute: newrelic.source
+        value: 'api.logs.otlp'
+      - attribute: instrumentation.provider
+        value: opentelemetry
+      - attribute: server.address
+        present: true
+      - attribute: server.port
+        present: true
+    tags:
+      redis.version:
+      redis.role:
+      host.id:
+        ttl: P1D
+      host.name:
+        ttl: P1D
+      k8s.namespace.name:
+        ttl: P1D
+      k8s.pod.name:
+        ttl: P1D
+      redis.cluster.name:
+      server.address:
+      server.port:
+      otel.library.name:
+        entityTagName: instrumentation.name
+
+  # Log-based synthesis rule: redis.instance.id from Log event type
+  - ruleName: infra_redisinstance_otel_logs_service_instance
+    identifier: redis.instance.id
+    name: redis.instance.id
+    encodeIdentifierInGUID: true
+    conditions:
+      - attribute: eventType
+        value: Log
+      - attribute: newrelic.source
+        value: 'api.logs.otlp'
+      - attribute: instrumentation.provider
+        value: opentelemetry
+      - attribute: redis.instance.id
+        present: true
+      - attribute: server.address
+        present: false
+    tags:
+      redis.instance.id:
+      redis.version:
+      redis.role:
+      host.id:
+        ttl: P1D
+      host.name:
+        ttl: P1D
+      k8s.namespace.name:
+        ttl: P1D
+      k8s.pod.name:
+        ttl: P1D
+      redis.cluster.name:
       otel.library.name:
         entityTagName: instrumentation.name
 
@@ -117,9 +289,9 @@ goldenTags:
 # OpenTelemetry - server.address pattern
 - server.address
 - server.port
-# OpenTelemetry - service.instance.id pattern
+# OpenTelemetry - redis.instance.id pattern
 - service.name
-- service.instance.id
+- redis.instance.id
 - host.name
 - host.id
 - redis.cluster.name

--- a/entity-types/infra-redisinstance/golden_metrics.yml
+++ b/entity-types/infra-redisinstance/golden_metrics.yml
@@ -1,27 +1,3 @@
-keyspaceHitsPerSecond:
-  title: Keyspace hits per second
-  unit: OPERATIONS_PER_SECOND
-  queries:
-    newRelic:
-      select: average(db.keyspaceHitsPerSecond)
-      from: RedisSample
-      eventId: entityGuid
-      eventName: entityName
-    # defaulting to newRelic query for now since we cannot match value functions for OpenTelemetry cumulative metrics.
-    # opentelemetry:
-    #   select: rate(sum(redis.keyspace.hits), 1 second)
-keyspaceMissesPerSecond:
-  title: Keyspace misses per second
-  unit: OPERATIONS_PER_SECOND
-  queries:
-    newRelic:
-      select: average(db.keyspaceMissesPerSecond)
-      from: RedisSample
-      eventId: entityGuid
-      eventName: entityName
-    # defaulting to newRelic query for now since we cannot match value functions for OpenTelemetry cumulative metrics.
-    # opentelemetry:
-    #   select: rate(sum(redis.keyspace.misses), 1 second)
 connectedClients:
   title: Connected clients
   unit: COUNT
@@ -33,3 +9,55 @@ connectedClients:
       eventName: entityName
     opentelemetry:
       select: average(redis.clients.connected)
+      from: Metric
+      where: metricName = 'redis.clients.connected'
+      eventId: entity.guid
+      eventName: entity.name
+
+keyspaceHitsPerSecond:
+  title: Keyspace hits per second
+  unit: OPERATIONS_PER_SECOND
+  queries:
+    newRelic:
+      select: average(db.keyspaceHitsPerSecond)
+      from: RedisSample
+      eventId: entityGuid
+      eventName: entityName
+    opentelemetry:
+      select: sum(redis.keyspace.hits) / sum((endTimestamp - timestamp) / 1000)
+      from: Metric
+      where: metricName = 'redis.keyspace.hits'
+      eventId: entity.guid
+      eventName: entity.name
+
+keyspaceMissesPerSecond:
+  title: Keyspace misses per second
+  unit: OPERATIONS_PER_SECOND
+  queries:
+    newRelic:
+      select: average(db.keyspaceMissesPerSecond)
+      from: RedisSample
+      eventId: entityGuid
+      eventName: entityName
+    opentelemetry:
+      select: sum(redis.keyspace.misses) / sum((endTimestamp - timestamp) / 1000)
+      from: Metric
+      where: metricName = 'redis.keyspace.misses'
+      eventId: entity.guid
+      eventName: entity.name
+
+memoryUsed:
+  title: Memory used
+  unit: BYTES
+  queries:
+    newRelic:
+      select: average(system.usedMemoryBytes)
+      from: RedisSample
+      eventId: entityGuid
+      eventName: entityName
+    opentelemetry:
+      select: average(redis.memory.used)
+      from: Metric
+      where: metricName = 'redis.memory.used'
+      eventId: entity.guid
+      eventName: entity.name

--- a/relationships/synthesis/EXT-SERVICE-to-INFRA-REDISINSTANCE.stg.yml
+++ b/relationships/synthesis/EXT-SERVICE-to-INFRA-REDISINSTANCE.stg.yml
@@ -1,0 +1,125 @@
+relationships:
+  # OTel APM Service CALLS Redis instance via span (server.address:server.port pattern)
+  - name: extServiceCallsOtelRedisinstanceComposite
+    version: "1"
+    origins:
+      - Distributed Tracing
+      - OpenTelemetry
+    conditions:
+      - attribute: eventType
+        anyOf: [ "Span" ]
+      - attribute: newrelic.source
+        anyOf: [ "api.traces.otlp" ]
+      - attribute: entity.type
+        anyOf: [ "SERVICE" ]
+      - attribute: db.system
+        anyOf: [ "redis" ]
+      - attribute: server.address
+        present: true
+      - attribute: server.port
+        present: true
+    relationship:
+      expires: PT75M
+      relationshipType: CALLS
+      source:
+        extractGuid:
+          attribute: entity.guid
+      target:
+        buildGuid:
+          account:
+            lookup: true
+          domain:
+            value: INFRA
+          type:
+            value: REDISINSTANCE
+            valueInGuid: NA
+          identifier:
+            fragments:
+              - attribute: server.address
+              - value: ":"
+              - attribute: server.port
+            hashAlgorithm: FARM_HASH
+
+  # OTel APM Service CALLS Redis instance via span (net.peer.name:net.peer.port pattern - semconv 1.20)
+  - name: extServiceCallsOtelRedisinstanceComposite120
+    version: "1"
+    origins:
+      - Distributed Tracing
+      - OpenTelemetry
+    conditions:
+      - attribute: eventType
+        anyOf: [ "Span" ]
+      - attribute: newrelic.source
+        anyOf: [ "api.traces.otlp" ]
+      - attribute: entity.type
+        anyOf: [ "SERVICE" ]
+      - attribute: db.system
+        anyOf: [ "redis" ]
+      - attribute: net.peer.name
+        present: true
+      - attribute: net.peer.port
+        present: true
+      - attribute: server.address
+        present: false
+    relationship:
+      expires: PT75M
+      relationshipType: CALLS
+      source:
+        extractGuid:
+          attribute: entity.guid
+      target:
+        buildGuid:
+          account:
+            lookup: true
+          domain:
+            value: INFRA
+          type:
+            value: REDISINSTANCE
+            valueInGuid: NA
+          identifier:
+            fragments:
+              - attribute: net.peer.name
+              - value: ":"
+              - attribute: net.peer.port
+            hashAlgorithm: FARM_HASH
+
+  # OTel APM Service CALLS Redis instance via span (redis.instance.id pattern)
+  - name: extServiceCallsOtelRedisinstanceById
+    version: "1"
+    origins:
+      - Distributed Tracing
+      - OpenTelemetry
+    conditions:
+      - attribute: eventType
+        anyOf: [ "Span" ]
+      - attribute: newrelic.source
+        anyOf: [ "api.traces.otlp" ]
+      - attribute: entity.type
+        anyOf: [ "SERVICE" ]
+      - attribute: db.system
+        anyOf: [ "redis" ]
+      - attribute: redis.instance.id
+        present: true
+      - attribute: server.address
+        present: false
+      - attribute: net.peer.name
+        present: false
+    relationship:
+      expires: PT75M
+      relationshipType: CALLS
+      source:
+        extractGuid:
+          attribute: entity.guid
+      target:
+        buildGuid:
+          account:
+            lookup: true
+          domain:
+            value: INFRA
+          type:
+            value: REDISINSTANCE
+            valueInGuid: NA
+          identifier:
+            fragments:
+              - attribute: redis.instance.id
+            hashAlgorithm: FARM_HASH

--- a/relationships/synthesis/INFRA-CONTAINER-to-INFRA-REDISINSTANCE.stg.yml
+++ b/relationships/synthesis/INFRA-CONTAINER-to-INFRA-REDISINSTANCE.stg.yml
@@ -1,0 +1,172 @@
+relationships:
+  # OTel Redis (plain Docker) -> OTel Container (dockerstats receiver)
+  - name: OtelRedisinstanceToOtelDockerContainer
+    version: "1"
+    origins:
+      - OpenTelemetry
+    conditions:
+      - attribute: eventType
+        anyOf: ["Metric", "Log"]
+      - attribute: instrumentation.provider
+        anyOf: ["opentelemetry"]
+      - attribute: entity.type
+        anyOf: ["REDISINSTANCE"]
+      - attribute: container.id
+        present: true
+      - attribute: k8s.cluster.name
+        present: false
+    relationship:
+      expires: PT75M
+      relationshipType: IS
+      source:
+        buildGuid:
+          account:
+            attribute: accountId
+          domain:
+            value: INFRA
+          type:
+            value: CONTAINER
+          identifier:
+            fragments:
+              - attribute: container.id
+            hashAlgorithm: FARM_HASH
+      target:
+        extractGuid:
+          attribute: entity.guid
+          entityType:
+            attribute: entity.type
+
+  # OTel Redis (plain Docker) -> NR native Container (ContainerSample)
+  - name: OtelRedisinstanceToNrDockerContainer
+    version: "1"
+    origins:
+      - OpenTelemetry
+    conditions:
+      - attribute: eventType
+        anyOf: ["Metric", "Log"]
+      - attribute: instrumentation.provider
+        anyOf: ["opentelemetry"]
+      - attribute: entity.type
+        anyOf: ["REDISINSTANCE"]
+      - attribute: container.id
+        present: true
+      - attribute: k8s.cluster.name
+        present: false
+    relationship:
+      expires: PT75M
+      relationshipType: IS
+      source:
+        buildGuid:
+          account:
+            attribute: accountId
+          domain:
+            value: INFRA
+          type:
+            value: CONTAINER
+            valueInGuid: NA
+          identifier:
+            fragments:
+              - value: "docker:"
+              - attribute: container.id
+            hashAlgorithm: FARM_HASH
+      target:
+        extractGuid:
+          attribute: entity.guid
+          entityType:
+            attribute: entity.type
+
+  # OTel Redis (K8s) -> OTel K8s Container (kube-state-metrics / cAdvisor / kubeletstats)
+  - name: OtelRedisinstanceToOtelK8sContainer
+    version: "1"
+    origins:
+      - OpenTelemetry
+    conditions:
+      - attribute: eventType
+        anyOf: ["Metric", "Log"]
+      - attribute: instrumentation.provider
+        anyOf: ["opentelemetry"]
+      - attribute: entity.type
+        anyOf: ["REDISINSTANCE"]
+      - attribute: k8s.cluster.name
+        present: true
+      - attribute: k8s.namespace.name
+        present: true
+      - attribute: k8s.pod.name
+        present: true
+      - attribute: k8s.container.name
+        present: true
+    relationship:
+      expires: PT75M
+      relationshipType: IS
+      source:
+        buildGuid:
+          account:
+            attribute: accountId
+          domain:
+            value: INFRA
+          type:
+            value: CONTAINER
+          identifier:
+            fragments:
+              - attribute: k8s.cluster.name
+              - value: ":"
+              - attribute: k8s.namespace.name
+              - value: ":"
+              - attribute: k8s.pod.name
+              - value: ":"
+              - attribute: k8s.container.name
+            hashAlgorithm: FARM_HASH
+      target:
+        extractGuid:
+          attribute: entity.guid
+          entityType:
+            attribute: entity.type
+
+  # OTel Redis (K8s) -> NR native K8s Container (K8sContainerSample)
+  - name: OtelRedisinstanceToNrK8sContainer
+    version: "1"
+    origins:
+      - OpenTelemetry
+    conditions:
+      - attribute: eventType
+        anyOf: ["Metric", "Log"]
+      - attribute: instrumentation.provider
+        anyOf: ["opentelemetry"]
+      - attribute: entity.type
+        anyOf: ["REDISINSTANCE"]
+      - attribute: k8s.cluster.name
+        present: true
+      - attribute: k8s.namespace.name
+        present: true
+      - attribute: k8s.pod.name
+        present: true
+      - attribute: k8s.container.name
+        present: true
+    relationship:
+      expires: PT75M
+      relationshipType: IS
+      source:
+        buildGuid:
+          account:
+            attribute: accountId
+          domain:
+            value: INFRA
+          type:
+            value: CONTAINER
+            valueInGuid: NA
+          identifier:
+            fragments:
+              - value: "k8s:"
+              - attribute: k8s.cluster.name
+              - value: ":"
+              - attribute: k8s.namespace.name
+              - value: ":"
+              - attribute: k8s.pod.name
+              - value: ":container:"
+              - attribute: k8s.container.name
+            hashAlgorithm: FARM_HASH
+      target:
+        extractGuid:
+          attribute: entity.guid
+          entityType:
+            attribute: entity.type

--- a/relationships/synthesis/INFRA-HOST-to-INFRA-REDISINSTANCE.stg.yml
+++ b/relationships/synthesis/INFRA-HOST-to-INFRA-REDISINSTANCE.stg.yml
@@ -1,0 +1,78 @@
+relationships:
+  # OTel: Host HOSTS Redis instance (local scenario - redis on same host)
+  - name: hostHostsOtelRedisinstanceLocal
+    version: "1"
+    origins:
+      - OpenTelemetry
+    conditions:
+      - attribute: eventType
+        anyOf: [ "Metric" ]
+      - attribute: instrumentation.provider
+        anyOf: [ "opentelemetry" ]
+      - attribute: host.id
+        present: true
+      - attribute: entity.type
+        anyOf: [ "REDISINSTANCE" ]
+      - attribute: k8s.pod.name # condition to exclude k8s pod based hosts
+        present: false
+    relationship:
+      expires: PT75M
+      relationshipType: HOSTS
+      source:
+        buildGuid:
+          account:
+            attribute: accountId
+          domain:
+            value: INFRA
+          type:
+            value: HOST
+            valueInGuid: NA
+          identifier:
+            fragments:
+              - attribute: host.id
+            hashAlgorithm: FARM_HASH
+      target:
+        extractGuid:
+          attribute: entity.guid
+          entityType:
+            value: REDISINSTANCE
+
+  # OTel: Host MEASURES Redis instance (remote scenario - host.name based)
+  - name: hostMeasuresOtelRedisinstanceRemote
+    version: "1"
+    origins:
+      - OpenTelemetry
+    conditions:
+      - attribute: eventType
+        anyOf: [ "Metric" ]
+      - attribute: instrumentation.provider
+        anyOf: [ "opentelemetry" ]
+      - attribute: host.id
+        present: true
+      - attribute: entity.type
+        anyOf: [ "REDISINSTANCE" ]
+      - attribute: server.address
+        present: true
+      - attribute: k8s.pod.name # condition to exclude k8s pod based hosts
+        present: false
+    relationship:
+      expires: PT75M
+      relationshipType: MEASURES
+      source:
+        buildGuid:
+          account:
+            attribute: accountId
+          domain:
+            value: INFRA
+          type:
+            value: HOST
+            valueInGuid: NA
+          identifier:
+            fragments:
+              - attribute: host.id
+            hashAlgorithm: FARM_HASH
+      target:
+        extractGuid:
+          attribute: entity.guid
+          entityType:
+            value: REDISINSTANCE

--- a/relationships/synthesis/INFRA-KUBERNETES_POD-to-INFRA-REDISINSTANCE.stg.yml
+++ b/relationships/synthesis/INFRA-KUBERNETES_POD-to-INFRA-REDISINSTANCE.stg.yml
@@ -1,0 +1,88 @@
+relationships:
+  # OTel: K8s Pod HOSTS Redis instance (k8s.cluster.name based)
+  - name: k8sPodHostsOtelRedisinstance
+    version: "1"
+    origins:
+      - OpenTelemetry
+    conditions:
+      - attribute: eventType
+        anyOf: [ "Metric" ]
+      - attribute: metricName
+        startsWith: redis.
+      - attribute: instrumentation.provider
+        anyOf: [ "opentelemetry" ]
+      - attribute: k8s.cluster.name
+        present: true
+      - attribute: k8s.namespace.name
+        present: true
+      - attribute: k8s.pod.name
+        present: true
+    relationship:
+      expires: PT75M
+      relationshipType: HOSTS
+      source:
+        buildGuid:
+          account:
+            lookup: true
+          domain:
+            value: INFRA
+          type:
+            value: KUBERNETES_POD
+          identifier:
+            fragments:
+              - attribute: k8s.cluster.name
+              - value: ":"
+              - attribute: k8s.namespace.name
+              - value: ":"
+              - attribute: k8s.pod.name
+            hashAlgorithm: FARM_HASH
+      target:
+        extractGuid:
+          attribute: entity.guid
+          entityType:
+            value: REDISINSTANCE
+
+  # OTel: K8s Pod HOSTS Redis instance (Log event type)
+  - name: k8sPodHostsOtelRedisinstanceLogs
+    version: "1"
+    origins:
+      - OpenTelemetry
+    conditions:
+      - attribute: eventType
+        anyOf: [ "Log" ]
+      - attribute: newrelic.source
+        anyOf: [ "api.logs.otlp" ]
+      - attribute: instrumentation.provider
+        anyOf: [ "opentelemetry" ]
+      - attribute: entity.type
+        anyOf: [ "REDISINSTANCE" ]
+      - attribute: k8s.cluster.name
+        present: true
+      - attribute: k8s.namespace.name
+        present: true
+      - attribute: k8s.pod.name
+        present: true
+    relationship:
+      expires: PT75M
+      relationshipType: HOSTS
+      source:
+        buildGuid:
+          account:
+            lookup: true
+          domain:
+            value: INFRA
+          type:
+            value: KUBERNETES_POD
+          identifier:
+            fragments:
+              - attribute: k8s.cluster.name
+              - value: ":"
+              - attribute: k8s.namespace.name
+              - value: ":"
+              - attribute: k8s.pod.name
+            hashAlgorithm: FARM_HASH
+      target:
+        extractGuid:
+          attribute: entity.guid
+          entityType:
+            value: REDISINSTANCE


### PR DESCRIPTION
## Summary

- **Story 2 (Entity Synthesis Rules):** Updated `definition.stg.yml` for INFRA-REDISINSTANCE with 6 synthesis rules supporting cross-collector OTel Redis:
  - `infra_redisinstance_composite` — server.address:server.port with `otelcol/redisreceiver`
  - `infra_redisinstance_composite_1` — server.address:server.port with `github.com/.../redisreceiver`
  - `infra_redisinstance_otel` — redis.instance.id with `github.com/.../redisreceiver`
  - `infra_redisinstance_otel_1` — redis.instance.id with `otelcol/redisreceiver`
  - `infra_redisinstance_otel_logs` — server.address:server.port from Log event type
  - `infra_redisinstance_otel_logs_service_instance` — redis.instance.id from Log event type
- **Story 3 (Golden Metrics):** Updated `golden_metrics.yml` with proper entity-scoped OTel queries for connectedClients, keyspaceHitsPerSec, keyspaceMissesPerSec, and memoryUsed using `Metric` event type with `metricName` filters and `entity.guid`/`entity.name` scoping.
- **Story 4 (Relationship Synthesis):** Added 4 staging relationship files:
  - `INFRA-HOST-to-INFRA-REDISINSTANCE.stg.yml` — Host HOSTS/MEASURES Redis (OTel)
  - `INFRA-CONTAINER-to-INFRA-REDISINSTANCE.stg.yml` — Container IS Redis (Docker + K8s)
  - `INFRA-KUBERNETES_POD-to-INFRA-REDISINSTANCE.stg.yml` — Pod HOSTS Redis
  - `EXT-SERVICE-to-INFRA-REDISINSTANCE.stg.yml` — APM Service CALLS Redis

## Test plan

- [ ] Verify entity synthesis produces correct GUIDs for both `server.address:server.port` and `redis.instance.id` identifier patterns
- [ ] Confirm OTel golden metrics queries return data when scoped to the synthesized entity GUID
- [ ] Validate relationship rules create correct links between Host/Container/Pod/APM-Service and Redis entities
- [ ] Test with both `otelcol/redisreceiver` and `github.com/.../redisreceiver` library names
- [ ] Verify log-based synthesis rules fire for OTel log data with `api.logs.otlp` source

## Related

- EPIC: NR-576327 (OTel Redis Integration)
- Related PR: #2938

🤖 Generated with [Claude Code](https://claude.com/claude-code)