### PR TITLE
fix(validator): relationship-synthesis rule-name uniqueness per env

### DIFF
--- a/validator/tools/utils.js
+++ b/validator/tools/utils.js
@@ -30,6 +30,62 @@ module.exports = {
       }
     }));
   },
+
+  // Returns relationship synthesis definitions partitioned into the file sets
+  // that load in each environment, mirroring the override mechanic described
+  // in README.md ("`.stg` file will replace original in STG while original
+  // will be used for PRODUCTION"):
+  //   - prod:    every non-.stg.yml file
+  //   - staging: for each base name, the .stg.yml override if present,
+  //              otherwise the .yml; plus any .stg.yml that has no .yml peer
+  // Each entry is `{ filePath, definitions }` so callers can attribute
+  // validation errors to the originating file.
+  async getRelationshipSynthesisDefinitionsByEnvironment () {
+    const STG_SUFFIX = '.stg.yml';
+    const PROD_SUFFIX = '.yml';
+
+    const files = (await getFiles(RELATIONSHIPS_SYNTHESIS_DIR))
+      .filter(file => file.endsWith(PROD_SUFFIX));
+
+    for (const filename of files) {
+      const justFileName = filename.split('/').pop();
+      if (!regex.test(justFileName)) {
+        const message = `Incorrect filename. Format must be ORIGIN-to-TARGET: ${justFileName}`;
+        await githubHelper.createReviewPR(message, githubHelper.GH_PR_EVENT_REQUEST_CHANGES);
+        throw message;
+      }
+    }
+
+    const prodFiles = new Map(); // baseName -> path
+    const stgOverrides = new Map(); // baseName -> path
+    for (const f of files) {
+      const justFileName = f.split('/').pop();
+      if (justFileName.endsWith(STG_SUFFIX)) {
+        stgOverrides.set(justFileName.slice(0, -STG_SUFFIX.length), f);
+      } else {
+        prodFiles.set(justFileName.slice(0, -PROD_SUFFIX.length), f);
+      }
+    }
+
+    const prodEnvPaths = [...prodFiles.values()];
+    const stagingEnvPaths = [];
+    for (const [baseName, prodPath] of prodFiles) {
+      stagingEnvPaths.push(stgOverrides.get(baseName) ?? prodPath);
+    }
+    for (const [baseName, stgPath] of stgOverrides) {
+      if (!prodFiles.has(baseName)) stagingEnvPaths.push(stgPath);
+    }
+
+    const loadFile = (filePath) => ({
+      filePath,
+      definitions: yaml.load(fs.readFileSync(filePath, 'utf8'))
+    });
+
+    return {
+      prod: prodEnvPaths.map(loadFile),
+      staging: stagingEnvPaths.map(loadFile)
+    };
+  },
   async getAllDefinitions () {
     const files = await getFiles(DEFINITIONS_DIR);
     const definitionFiles = files.filter(file => file.includes(DEFINITION_FILE_NAME) || file.includes(DEFINITION_FILE_NAME_STG));

--- a/validator/tools/validate_relationship_synthesis_rules.js
+++ b/validator/tools/validate_relationship_synthesis_rules.js
@@ -38,10 +38,15 @@ const VALID_CONDITIONS = new Map([
   ['Network Monitoring', []]
 ]);
 
+// Per-environment name registry. Reset between environment passes so that
+// the same rule name can legally appear in both `INFRA_X-to-Y.yml` (prod)
+// and `INFRA_X-to-Y.stg.yml` (staging override) — they never co-exist at
+// runtime in the same environment.
 let ALL_RELATIONSHIP_SYNTHESIS;
+let CURRENT_ENV;
 function validateAndRecord (rule) {
   if (ALL_RELATIONSHIP_SYNTHESIS.has(rule.name)) {
-    throw new Error('There already exists a rule with name ' + rule.name);
+    throw new Error(`There already exists a rule with name ${rule.name} in the ${CURRENT_ENV} environment`);
   }
   ALL_RELATIONSHIP_SYNTHESIS.set(rule.name, rule);
 }
@@ -145,24 +150,33 @@ const RULES = [
 ];
 
 (async () => {
-  ALL_RELATIONSHIP_SYNTHESIS = new Map();
-  const allRelationships = await utils.getAllRelationshipSynthesisDefinitions();
-  allRelationships.forEach(setDefinitionsInFile => {
-    setDefinitionsInFile.relationships.forEach(relationship => {
-      RULES.forEach(rule => {
-        try {
-          rule.apply(relationship);
-        } catch (errorMessage) {
-          const message = `Definition for ${relationship.name} violates rule "${rule.name}":`;
-          console.error(message);
-          console.error(errorMessage);
-          githubHelper.createReviewPR(`${message}\n${errorMessage}`, githubHelper.GH_PR_EVENT_REQUEST_CHANGES)
-            .then(process.exit(1))
-            .catch(error => console.error(error));
-        }
+  const byEnv = await utils.getRelationshipSynthesisDefinitionsByEnvironment();
+  // Validate prod and staging independently. Most checks (resolvers, TTL,
+  // condition/origin) are rule-local and would pass either way; only the
+  // name-uniqueness check is environment-sensitive. Running each pass with
+  // its own ALL_RELATIONSHIP_SYNTHESIS map lets the override mechanic work
+  // (same name in `X.yml` and `X.stg.yml`) without weakening the check
+  // within a single environment.
+  for (const [envName, envFiles] of [['production', byEnv.prod], ['staging', byEnv.staging]]) {
+    ALL_RELATIONSHIP_SYNTHESIS = new Map();
+    CURRENT_ENV = envName;
+    envFiles.forEach(({ filePath, definitions }) => {
+      definitions.relationships.forEach(relationship => {
+        RULES.forEach(rule => {
+          try {
+            rule.apply(relationship);
+          } catch (errorMessage) {
+            const message = `[${envName}] Definition for ${relationship.name} (${filePath.split('/').pop()}) violates rule "${rule.name}":`;
+            console.error(message);
+            console.error(errorMessage);
+            githubHelper.createReviewPR(`${message}\n${errorMessage}`, githubHelper.GH_PR_EVENT_REQUEST_CHANGES)
+              .then(process.exit(1))
+              .catch(error => console.error(error));
+          }
+        });
       });
     });
-  });
+  }
 })().catch(error => {
   console.error(error);
   process.exit(1);


### PR DESCRIPTION
The relationship-synthesis validator (validator/tools/validate_relationship_synthesis_rules.js) gathers every `.yml` file under `relationships/synthesis/` into a single flat list and checks `name` uniqueness against one global Map. That doesn't match the runtime semantics documented in README.md:

> `.stg` file will **replace** [the] original in STG while original will be used for
> PRODUCTION

So `INFRA_X-to-Y.yml` and `INFRA_X-to-Y.stg.yml` never co-exist in any deployed environment, yet the validator treats them as if they did. This forces authors to suffix override identifiers (e.g. `mySuperRule -> mySuperRuleStgOverride`) purely to satisfy CI, even when the override's intent is to *be* the same rule with one specific change for staging — and creates a needless rename on every promotion.

This fix introduces a new helper, `getRelationshipSynthesisDefinitionsByEnvironment`, that partitions definition files into the two file sets that load in each environment (prod = non-.stg.yml; staging = .stg.yml override if present otherwise the .yml). The validator now runs the existing per-rule checks once per environment with its own name-uniqueness map. Cross-environment collisions are no longer flagged; in-environment collisions still fail (now with the env name in the error message for clarity).