### PR TITLE
fix(postgresqlinstance): OTel fallback using service.instance.id

### DIFF
--- a/entity-types/infra-postgresqlinstance/definition.stg.yml
+++ b/entity-types/infra-postgresqlinstance/definition.stg.yml
@@ -22,6 +22,24 @@ synthesis:
         otel.library.name:
           entityTagName: instrumentation.name
 
+    # Fallback for OTel postgres metrics that lack `postgresql.endpoint`.
+    - ruleName: infra_postgresqlinstance_service_instance_id
+      identifier: service.instance.id # host:port
+      name: service.instance.id
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: eventType
+          value: Metric
+        - attribute: metricName
+          prefix: postgresql.
+        - attribute: instrumentation.provider
+          value: opentelemetry
+        - attribute: postgresql.endpoint
+          present: false
+      tags:
+        otel.library.name:
+          entityTagName: instrumentation.name
+
     - ruleName: infra_postgresqlinstance_postgresql_endpoint_2
       identifier: postgresql.endpoint # server.address:server.port
       name: postgresql.endpoint 

--- a/entity-types/infra-postgresqlinstance/definition.stg.yml
+++ b/entity-types/infra-postgresqlinstance/definition.stg.yml
@@ -99,4 +99,4 @@ dashboardTemplates:
 
 ownership:
   primaryOwner:
-    teamName: "no owner"
+    teamName: "Database Integrations"

--- a/entity-types/infra-postgresqlinstance/definition.yml
+++ b/entity-types/infra-postgresqlinstance/definition.yml
@@ -38,4 +38,4 @@ dashboardTemplates:
 
 ownership:
   primaryOwner:
-    teamName: "no owner"
+    teamName: "Database Integrations"


### PR DESCRIPTION
The existing postgresqlreceiver rule keys synthesis off `postgresql.endpoint`, which the contrib receiver has never emitted as a resource attribute (verified across v0.85 → v0.153). With default contrib output, no POSTGRESQLINSTANCE entity is currently created.

Add a fallback rule that keys off `service.instance.id` (added to the receiver in v0.153.0, in `host:port` form — the exact value the existing rule expects), guarded by `postgresql.endpoint present: false` so it stays mutually exclusive with the existing rule. If a future receiver version starts emitting `postgresql.endpoint`, the existing rule takes precedence and we don't double-mint entities with different GUIDs.

