### PR TITLE
feat(vsphere): add OTel synthesis rules and dashboards for all vSphere entity types

### DIFF
--- a/entity-types/infra-vspherecluster/definition.stg.yml
+++ b/entity-types/infra-vspherecluster/definition.stg.yml
@@ -1,0 +1,81 @@
+domain: INFRA
+type: VSPHERECLUSTER
+
+synthesis:
+  rules:
+  # OpenTelemetry synthesis rule - new collector format
+  - ruleName: infra_vspherecluster_otel_new
+    compositeIdentifier:
+      separator: ":"
+      attributes:
+        - vcenter.datacenter.name
+        - vcenter.cluster.name
+    name: vcenter.cluster.name
+    encodeIdentifierInGUID: true
+    conditions:
+      - attribute: eventType
+        value: Metric
+      - attribute: metricName
+        prefix: vcenter.cluster.
+      - attribute: instrumentation.provider
+        value: opentelemetry
+      # New collector format
+      - attribute: otel.library.name
+        value: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver"
+    tags:
+      vcenter.datacenter.name:
+      vcenter.cluster.name:
+      otel.library.name:
+        entityTagName: instrumentation.name
+  # OpenTelemetry synthesis rule - old collector format
+  - ruleName: infra_vspherecluster_otel_old
+    compositeIdentifier:
+      separator: ":"
+      attributes:
+        - vcenter.datacenter.name
+        - vcenter.cluster.name
+    name: vcenter.cluster.name
+    encodeIdentifierInGUID: true
+    conditions:
+      - attribute: eventType
+        value: Metric
+      - attribute: metricName
+        prefix: vcenter.cluster.
+      - attribute: instrumentation.provider
+        value: opentelemetry
+      # Old collector format
+      - attribute: otel.library.name
+        value: "otelcol/vcenterreceiver"
+    tags:
+      vcenter.datacenter.name:
+      vcenter.cluster.name:
+      otel.library.name:
+        entityTagName: instrumentation.name
+  tags:
+    # For OpenTelemetry
+    telemetry.sdk.name:
+      entityTagName: instrumentation.provider
+
+goldenTags:
+- vsphere.clusterDatacenterLocation
+- vsphere.clusterDatacenterName
+- vsphere.clusterHostList
+- vsphere.clusterDatastoreList
+# OpenTelemetry
+- vcenter.datacenter.name
+- vcenter.cluster.name
+
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+
+dashboardTemplates:
+  # This should match the entity created from the ohi in the infra pipeline
+  newRelic:
+    template: newrelic_dashboard.json
+  opentelemetry:
+    template: opentelemetry_dashboard.json
+
+ownership:
+  primaryOwner:
+    teamName: "OnHost Agent and Integrations"

--- a/entity-types/infra-vspherecluster/definition.stg.yml
+++ b/entity-types/infra-vspherecluster/definition.stg.yml
@@ -3,8 +3,8 @@ type: VSPHERECLUSTER
 
 synthesis:
   rules:
-  # OpenTelemetry synthesis rule - new collector format
-  - ruleName: infra_vspherecluster_otel_new
+  # OpenTelemetry synthesis rule - covers both old and new collector formats
+  - ruleName: infra_vspherecluster_otel
     compositeIdentifier:
       separator: ":"
       attributes:
@@ -19,33 +19,6 @@ synthesis:
         prefix: vcenter.cluster.
       - attribute: instrumentation.provider
         value: opentelemetry
-      # New collector format
-      - attribute: otel.library.name
-        value: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver"
-    tags:
-      vcenter.datacenter.name:
-      vcenter.cluster.name:
-      otel.library.name:
-        entityTagName: instrumentation.name
-  # OpenTelemetry synthesis rule - old collector format
-  - ruleName: infra_vspherecluster_otel_old
-    compositeIdentifier:
-      separator: ":"
-      attributes:
-        - vcenter.datacenter.name
-        - vcenter.cluster.name
-    name: vcenter.cluster.name
-    encodeIdentifierInGUID: true
-    conditions:
-      - attribute: eventType
-        value: Metric
-      - attribute: metricName
-        prefix: vcenter.cluster.
-      - attribute: instrumentation.provider
-        value: opentelemetry
-      # Old collector format
-      - attribute: otel.library.name
-        value: "otelcol/vcenterreceiver"
     tags:
       vcenter.datacenter.name:
       vcenter.cluster.name:

--- a/entity-types/infra-vspherecluster/opentelemetry_dashboard.json
+++ b/entity-types/infra-vspherecluster/opentelemetry_dashboard.json
@@ -1,0 +1,305 @@
+{
+  "name": "vSphere Cluster (OpenTelemetry)",
+  "pages": [
+    {
+      "name": "Overview",
+      "description": null,
+      "widgets": [
+        {
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "height": 3,
+            "width": 3
+          },
+          "title": "Host count",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT latest(vcenter.cluster.host.count) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.cluster.name",
+                "accountId": 0
+              }
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "layout": {
+            "column": 4,
+            "row": 1,
+            "height": 3,
+            "width": 3
+          },
+          "title": "VM count",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT latest(vcenter.cluster.vm.count) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.cluster.name",
+                "accountId": 0
+              }
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "layout": {
+            "column": 7,
+            "row": 1,
+            "height": 3,
+            "width": 3
+          },
+          "title": "VM template count",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT latest(vcenter.cluster.vm_template.count) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.cluster.name",
+                "accountId": 0
+              }
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "layout": {
+            "column": 10,
+            "row": 1,
+            "height": 3,
+            "width": 3
+          },
+          "title": "CPU effective (MHz)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT latest(vcenter.cluster.cpu.effective) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.cluster.name",
+                "accountId": 0
+              }
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.markdown"
+          },
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "height": 1,
+            "width": 12
+          },
+          "rawConfiguration": {
+            "text": "## CPU"
+          },
+          "title": ""
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 1,
+            "row": 5,
+            "height": 3,
+            "width": 6
+          },
+          "title": "CPU limit (MHz)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT latest(vcenter.cluster.cpu.limit) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.cluster.name TIMESERIES AUTO",
+                "accountId": 0
+              }
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 7,
+            "row": 5,
+            "height": 3,
+            "width": 6
+          },
+          "title": "CPU effective (MHz)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT latest(vcenter.cluster.cpu.effective) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.cluster.name TIMESERIES AUTO",
+                "accountId": 0
+              }
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.markdown"
+          },
+          "layout": {
+            "column": 1,
+            "row": 8,
+            "height": 1,
+            "width": 12
+          },
+          "rawConfiguration": {
+            "text": "## Memory"
+          },
+          "title": ""
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 1,
+            "row": 9,
+            "height": 3,
+            "width": 6
+          },
+          "title": "Memory limit (GiB)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT latest(vcenter.cluster.memory.limit) / 1e9 WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.cluster.name TIMESERIES AUTO",
+                "accountId": 0
+              }
+            ],
+            "units": {
+              "unit": "BYTES"
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 7,
+            "row": 9,
+            "height": 3,
+            "width": 6
+          },
+          "title": "Memory effective (GiB)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT latest(vcenter.cluster.memory.effective) / 1e9 WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.cluster.name TIMESERIES AUTO",
+                "accountId": 0
+              }
+            ],
+            "units": {
+              "unit": "BYTES"
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.markdown"
+          },
+          "layout": {
+            "column": 1,
+            "row": 12,
+            "height": 1,
+            "width": 12
+          },
+          "rawConfiguration": {
+            "text": "## vSAN"
+          },
+          "title": ""
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 1,
+            "row": 13,
+            "height": 3,
+            "width": 4
+          },
+          "title": "vSAN latency avg (\u00b5s)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT average(vcenter.cluster.vsan.latency.avg) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.cluster.name, type TIMESERIES AUTO",
+                "accountId": 0
+              }
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 5,
+            "row": 13,
+            "height": 3,
+            "width": 4
+          },
+          "title": "vSAN operations (ops/s)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT average(vcenter.cluster.vsan.operations) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.cluster.name, type TIMESERIES AUTO",
+                "accountId": 0
+              }
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 9,
+            "row": 13,
+            "height": 3,
+            "width": 4
+          },
+          "title": "vSAN throughput (By/s)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT average(vcenter.cluster.vsan.throughput) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.cluster.name, direction TIMESERIES AUTO",
+                "accountId": 0
+              }
+            ],
+            "units": {
+              "unit": "BYTES_PER_SECOND"
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 1,
+            "row": 16,
+            "height": 3,
+            "width": 12
+          },
+          "title": "vSAN congestions (congestions/s)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT average(vcenter.cluster.vsan.congestions) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.cluster.name TIMESERIES AUTO",
+                "accountId": 0
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-vspherecluster/opentelemetry_dashboard.json
+++ b/entity-types/infra-vspherecluster/opentelemetry_dashboard.json
@@ -20,8 +20,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT latest(vcenter.cluster.host.count) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.cluster.name",
-                "accountId": 0
-              }
+                "accountId": 0}
             ]
           }
         },
@@ -40,8 +39,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT latest(vcenter.cluster.vm.count) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.cluster.name",
-                "accountId": 0
-              }
+                "accountId": 0}
             ]
           }
         },
@@ -60,8 +58,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT latest(vcenter.cluster.vm_template.count) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.cluster.name",
-                "accountId": 0
-              }
+                "accountId": 0}
             ]
           }
         },
@@ -80,8 +77,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT latest(vcenter.cluster.cpu.effective) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.cluster.name",
-                "accountId": 0
-              }
+                "accountId": 0}
             ]
           }
         },
@@ -115,8 +111,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT latest(vcenter.cluster.cpu.limit) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.cluster.name TIMESERIES AUTO",
-                "accountId": 0
-              }
+                "accountId": 0}
             ]
           }
         },
@@ -135,8 +130,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT latest(vcenter.cluster.cpu.effective) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.cluster.name TIMESERIES AUTO",
-                "accountId": 0
-              }
+                "accountId": 0}
             ]
           }
         },
@@ -170,8 +164,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT latest(vcenter.cluster.memory.limit) / 1e9 WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.cluster.name TIMESERIES AUTO",
-                "accountId": 0
-              }
+                "accountId": 0}
             ],
             "units": {
               "unit": "BYTES"
@@ -193,8 +186,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT latest(vcenter.cluster.memory.effective) / 1e9 WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.cluster.name TIMESERIES AUTO",
-                "accountId": 0
-              }
+                "accountId": 0}
             ],
             "units": {
               "unit": "BYTES"
@@ -231,8 +223,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT average(vcenter.cluster.vsan.latency.avg) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.cluster.name, type TIMESERIES AUTO",
-                "accountId": 0
-              }
+                "accountId": 0}
             ]
           }
         },
@@ -251,8 +242,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT average(vcenter.cluster.vsan.operations) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.cluster.name, type TIMESERIES AUTO",
-                "accountId": 0
-              }
+                "accountId": 0}
             ]
           }
         },
@@ -271,8 +261,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT average(vcenter.cluster.vsan.throughput) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.cluster.name, direction TIMESERIES AUTO",
-                "accountId": 0
-              }
+                "accountId": 0}
             ],
             "units": {
               "unit": "BYTES_PER_SECOND"
@@ -294,8 +283,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT average(vcenter.cluster.vsan.congestions) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.cluster.name TIMESERIES AUTO",
-                "accountId": 0
-              }
+                "accountId": 0}
             ]
           }
         }

--- a/entity-types/infra-vspheredatacenter/definition.stg.yml
+++ b/entity-types/infra-vspheredatacenter/definition.stg.yml
@@ -3,8 +3,8 @@ type: VSPHEREDATACENTER
 
 synthesis:
   rules:
-  # OpenTelemetry synthesis rule - new collector format
-  - ruleName: infra_vspheredatacenter_otel_new
+  # OpenTelemetry synthesis rule - covers both old and new collector formats
+  - ruleName: infra_vspheredatacenter_otel
     identifier: vcenter.datacenter.name
     name: vcenter.datacenter.name
     encodeIdentifierInGUID: true
@@ -15,28 +15,6 @@ synthesis:
         prefix: vcenter.datacenter.
       - attribute: instrumentation.provider
         value: opentelemetry
-      # New collector format
-      - attribute: otel.library.name
-        value: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver"
-    tags:
-      vcenter.datacenter.name:
-      otel.library.name:
-        entityTagName: instrumentation.name
-  # OpenTelemetry synthesis rule - old collector format
-  - ruleName: infra_vspheredatacenter_otel_old
-    identifier: vcenter.datacenter.name
-    name: vcenter.datacenter.name
-    encodeIdentifierInGUID: true
-    conditions:
-      - attribute: eventType
-        value: Metric
-      - attribute: metricName
-        prefix: vcenter.datacenter.
-      - attribute: instrumentation.provider
-        value: opentelemetry
-      # Old collector format
-      - attribute: otel.library.name
-        value: "otelcol/vcenterreceiver"
     tags:
       vcenter.datacenter.name:
       otel.library.name:

--- a/entity-types/infra-vspheredatacenter/definition.stg.yml
+++ b/entity-types/infra-vspheredatacenter/definition.stg.yml
@@ -1,0 +1,65 @@
+domain: INFRA
+type: VSPHEREDATACENTER
+
+synthesis:
+  rules:
+  # OpenTelemetry synthesis rule - new collector format
+  - ruleName: infra_vspheredatacenter_otel_new
+    identifier: vcenter.datacenter.name
+    name: vcenter.datacenter.name
+    encodeIdentifierInGUID: true
+    conditions:
+      - attribute: eventType
+        value: Metric
+      - attribute: metricName
+        prefix: vcenter.datacenter.
+      - attribute: instrumentation.provider
+        value: opentelemetry
+      # New collector format
+      - attribute: otel.library.name
+        value: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver"
+    tags:
+      vcenter.datacenter.name:
+      otel.library.name:
+        entityTagName: instrumentation.name
+  # OpenTelemetry synthesis rule - old collector format
+  - ruleName: infra_vspheredatacenter_otel_old
+    identifier: vcenter.datacenter.name
+    name: vcenter.datacenter.name
+    encodeIdentifierInGUID: true
+    conditions:
+      - attribute: eventType
+        value: Metric
+      - attribute: metricName
+        prefix: vcenter.datacenter.
+      - attribute: instrumentation.provider
+        value: opentelemetry
+      # Old collector format
+      - attribute: otel.library.name
+        value: "otelcol/vcenterreceiver"
+    tags:
+      vcenter.datacenter.name:
+      otel.library.name:
+        entityTagName: instrumentation.name
+  tags:
+    # For OpenTelemetry
+    telemetry.sdk.name:
+      entityTagName: instrumentation.provider
+
+goldenTags:
+- vcenter.datacenter.name
+
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+
+dashboardTemplates:
+  # This should match the entity created from the ohi in the infra pipeline
+  newRelic:
+    template: newrelic_dashboard.json
+  opentelemetry:
+    template: opentelemetry_dashboard.json
+
+ownership:
+  primaryOwner:
+    teamName: "OnHost Agent and Integrations"

--- a/entity-types/infra-vspheredatacenter/opentelemetry_dashboard.json
+++ b/entity-types/infra-vspheredatacenter/opentelemetry_dashboard.json
@@ -20,8 +20,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT latest(vcenter.datacenter.cluster.count) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.datacenter.name",
-                "accountId": 0
-              }
+                "accountId": 0}
             ]
           }
         },
@@ -40,8 +39,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT latest(vcenter.datacenter.datastore.count) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.datacenter.name",
-                "accountId": 0
-              }
+                "accountId": 0}
             ]
           }
         },
@@ -60,8 +58,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT latest(vcenter.datacenter.host.count) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.datacenter.name",
-                "accountId": 0
-              }
+                "accountId": 0}
             ]
           }
         },
@@ -80,8 +77,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT latest(vcenter.datacenter.vm.count) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.datacenter.name",
-                "accountId": 0
-              }
+                "accountId": 0}
             ]
           }
         },
@@ -115,8 +111,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT latest(vcenter.datacenter.cpu.limit) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.datacenter.name TIMESERIES AUTO",
-                "accountId": 0
-              }
+                "accountId": 0}
             ]
           }
         },
@@ -135,8 +130,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT latest(vcenter.datacenter.memory.limit) / 1e9 WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.datacenter.name TIMESERIES AUTO",
-                "accountId": 0
-              }
+                "accountId": 0}
             ],
             "units": {
               "unit": "BYTES"
@@ -173,8 +167,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT latest(vcenter.datacenter.disk.space) / 1e9 WHERE instrumentation.provider = 'opentelemetry' AND disk_state = 'used' FACET vcenter.datacenter.name TIMESERIES AUTO",
-                "accountId": 0
-              }
+                "accountId": 0}
             ],
             "units": {
               "unit": "BYTES"
@@ -196,8 +189,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT latest(vcenter.datacenter.disk.space) / 1e9 WHERE instrumentation.provider = 'opentelemetry' AND disk_state = 'available' FACET vcenter.datacenter.name TIMESERIES AUTO",
-                "accountId": 0
-              }
+                "accountId": 0}
             ],
             "units": {
               "unit": "BYTES"
@@ -219,8 +211,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT latest(vcenter.datacenter.disk.space) / 1e9 WHERE instrumentation.provider = 'opentelemetry' FACET disk_state TIMESERIES AUTO",
-                "accountId": 0
-              }
+                "accountId": 0}
             ],
             "units": {
               "unit": "BYTES"
@@ -257,8 +248,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT latest(vcenter.datacenter.host.count) WHERE instrumentation.provider = 'opentelemetry' FACET power_state TIMESERIES AUTO",
-                "accountId": 0
-              }
+                "accountId": 0}
             ]
           }
         },
@@ -277,8 +267,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT latest(vcenter.datacenter.vm.count) WHERE instrumentation.provider = 'opentelemetry' FACET power_state TIMESERIES AUTO",
-                "accountId": 0
-              }
+                "accountId": 0}
             ]
           }
         }

--- a/entity-types/infra-vspheredatacenter/opentelemetry_dashboard.json
+++ b/entity-types/infra-vspheredatacenter/opentelemetry_dashboard.json
@@ -1,0 +1,288 @@
+{
+  "name": "vSphere Datacenter (OpenTelemetry)",
+  "pages": [
+    {
+      "name": "Overview",
+      "description": null,
+      "widgets": [
+        {
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "height": 3,
+            "width": 3
+          },
+          "title": "Cluster count",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT latest(vcenter.datacenter.cluster.count) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.datacenter.name",
+                "accountId": 0
+              }
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "layout": {
+            "column": 4,
+            "row": 1,
+            "height": 3,
+            "width": 3
+          },
+          "title": "Datastore count",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT latest(vcenter.datacenter.datastore.count) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.datacenter.name",
+                "accountId": 0
+              }
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "layout": {
+            "column": 7,
+            "row": 1,
+            "height": 3,
+            "width": 3
+          },
+          "title": "Host count",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT latest(vcenter.datacenter.host.count) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.datacenter.name",
+                "accountId": 0
+              }
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "layout": {
+            "column": 10,
+            "row": 1,
+            "height": 3,
+            "width": 3
+          },
+          "title": "VM count",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT latest(vcenter.datacenter.vm.count) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.datacenter.name",
+                "accountId": 0
+              }
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.markdown"
+          },
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "height": 1,
+            "width": 12
+          },
+          "rawConfiguration": {
+            "text": "## Resources"
+          },
+          "title": ""
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 1,
+            "row": 5,
+            "height": 3,
+            "width": 6
+          },
+          "title": "Total CPU limit (MHz)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT latest(vcenter.datacenter.cpu.limit) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.datacenter.name TIMESERIES AUTO",
+                "accountId": 0
+              }
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 7,
+            "row": 5,
+            "height": 3,
+            "width": 6
+          },
+          "title": "Total memory limit (GiB)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT latest(vcenter.datacenter.memory.limit) / 1e9 WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.datacenter.name TIMESERIES AUTO",
+                "accountId": 0
+              }
+            ],
+            "units": {
+              "unit": "BYTES"
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.markdown"
+          },
+          "layout": {
+            "column": 1,
+            "row": 8,
+            "height": 1,
+            "width": 12
+          },
+          "rawConfiguration": {
+            "text": "## Storage"
+          },
+          "title": ""
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 1,
+            "row": 9,
+            "height": 3,
+            "width": 4
+          },
+          "title": "Disk space used (GiB)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT latest(vcenter.datacenter.disk.space) / 1e9 WHERE instrumentation.provider = 'opentelemetry' AND disk_state = 'used' FACET vcenter.datacenter.name TIMESERIES AUTO",
+                "accountId": 0
+              }
+            ],
+            "units": {
+              "unit": "BYTES"
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 5,
+            "row": 9,
+            "height": 3,
+            "width": 4
+          },
+          "title": "Disk space available (GiB)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT latest(vcenter.datacenter.disk.space) / 1e9 WHERE instrumentation.provider = 'opentelemetry' AND disk_state = 'available' FACET vcenter.datacenter.name TIMESERIES AUTO",
+                "accountId": 0
+              }
+            ],
+            "units": {
+              "unit": "BYTES"
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.area"
+          },
+          "layout": {
+            "column": 9,
+            "row": 9,
+            "height": 3,
+            "width": 4
+          },
+          "title": "Disk space used vs available (GiB)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT latest(vcenter.datacenter.disk.space) / 1e9 WHERE instrumentation.provider = 'opentelemetry' FACET disk_state TIMESERIES AUTO",
+                "accountId": 0
+              }
+            ],
+            "units": {
+              "unit": "BYTES"
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.markdown"
+          },
+          "layout": {
+            "column": 1,
+            "row": 12,
+            "height": 1,
+            "width": 12
+          },
+          "rawConfiguration": {
+            "text": "## Hosts"
+          },
+          "title": ""
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 1,
+            "row": 13,
+            "height": 3,
+            "width": 6
+          },
+          "title": "Host count by power state",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT latest(vcenter.datacenter.host.count) WHERE instrumentation.provider = 'opentelemetry' FACET power_state TIMESERIES AUTO",
+                "accountId": 0
+              }
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 7,
+            "row": 13,
+            "height": 3,
+            "width": 6
+          },
+          "title": "VM count by power state",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT latest(vcenter.datacenter.vm.count) WHERE instrumentation.provider = 'opentelemetry' FACET power_state TIMESERIES AUTO",
+                "accountId": 0
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-vspheredatastore/definition.stg.yml
+++ b/entity-types/infra-vspheredatastore/definition.stg.yml
@@ -1,0 +1,76 @@
+domain: INFRA
+type: VSPHEREDATASTORE
+
+synthesis:
+  rules:
+  # OpenTelemetry synthesis rule - new collector format
+  - ruleName: infra_vspheredatastore_otel_new
+    compositeIdentifier:
+      separator: ":"
+      attributes:
+        - vcenter.datacenter.name
+        - vcenter.datastore.name
+    name: vcenter.datastore.name
+    encodeIdentifierInGUID: true
+    conditions:
+      - attribute: eventType
+        value: Metric
+      - attribute: metricName
+        prefix: vcenter.datastore.
+      - attribute: instrumentation.provider
+        value: opentelemetry
+      # New collector format
+      - attribute: otel.library.name
+        value: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver"
+    tags:
+      vcenter.datacenter.name:
+      vcenter.datastore.name:
+      otel.library.name:
+        entityTagName: instrumentation.name
+  # OpenTelemetry synthesis rule - old collector format
+  - ruleName: infra_vspheredatastore_otel_old
+    compositeIdentifier:
+      separator: ":"
+      attributes:
+        - vcenter.datacenter.name
+        - vcenter.datastore.name
+    name: vcenter.datastore.name
+    encodeIdentifierInGUID: true
+    conditions:
+      - attribute: eventType
+        value: Metric
+      - attribute: metricName
+        prefix: vcenter.datastore.
+      - attribute: instrumentation.provider
+        value: opentelemetry
+      # Old collector format
+      - attribute: otel.library.name
+        value: "otelcol/vcenterreceiver"
+    tags:
+      vcenter.datacenter.name:
+      vcenter.datastore.name:
+      otel.library.name:
+        entityTagName: instrumentation.name
+  tags:
+    # For OpenTelemetry
+    telemetry.sdk.name:
+      entityTagName: instrumentation.provider
+
+goldenTags:
+- vcenter.datacenter.name
+- vcenter.datastore.name
+
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+
+dashboardTemplates:
+  # This should match the entity created from the ohi in the infra pipeline
+  newRelic:
+    template: newrelic_dashboard.json
+  opentelemetry:
+    template: opentelemetry_dashboard.json
+
+ownership:
+  primaryOwner:
+    teamName: "OnHost Agent and Integrations"

--- a/entity-types/infra-vspheredatastore/definition.stg.yml
+++ b/entity-types/infra-vspheredatastore/definition.stg.yml
@@ -3,8 +3,8 @@ type: VSPHEREDATASTORE
 
 synthesis:
   rules:
-  # OpenTelemetry synthesis rule - new collector format
-  - ruleName: infra_vspheredatastore_otel_new
+  # OpenTelemetry synthesis rule - covers both old and new collector formats
+  - ruleName: infra_vspheredatastore_otel
     compositeIdentifier:
       separator: ":"
       attributes:
@@ -19,33 +19,6 @@ synthesis:
         prefix: vcenter.datastore.
       - attribute: instrumentation.provider
         value: opentelemetry
-      # New collector format
-      - attribute: otel.library.name
-        value: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver"
-    tags:
-      vcenter.datacenter.name:
-      vcenter.datastore.name:
-      otel.library.name:
-        entityTagName: instrumentation.name
-  # OpenTelemetry synthesis rule - old collector format
-  - ruleName: infra_vspheredatastore_otel_old
-    compositeIdentifier:
-      separator: ":"
-      attributes:
-        - vcenter.datacenter.name
-        - vcenter.datastore.name
-    name: vcenter.datastore.name
-    encodeIdentifierInGUID: true
-    conditions:
-      - attribute: eventType
-        value: Metric
-      - attribute: metricName
-        prefix: vcenter.datastore.
-      - attribute: instrumentation.provider
-        value: opentelemetry
-      # Old collector format
-      - attribute: otel.library.name
-        value: "otelcol/vcenterreceiver"
     tags:
       vcenter.datacenter.name:
       vcenter.datastore.name:

--- a/entity-types/infra-vspheredatastore/opentelemetry_dashboard.json
+++ b/entity-types/infra-vspheredatastore/opentelemetry_dashboard.json
@@ -1,0 +1,187 @@
+{
+  "name": "vSphere Datastore (OpenTelemetry)",
+  "pages": [
+    {
+      "name": "Overview",
+      "description": null,
+      "widgets": [
+        {
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "height": 3,
+            "width": 4
+          },
+          "title": "Disk utilization (%)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT average(vcenter.datastore.disk.utilization) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.datastore.name",
+                "accountId": 0
+              }
+            ],
+            "units": {
+              "unit": "PERCENTAGE"
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "height": 3,
+            "width": 4
+          },
+          "title": "Disk used (GiB)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT latest(vcenter.datastore.disk.usage) / 1e9 WHERE instrumentation.provider = 'opentelemetry' AND disk_state = 'used' FACET vcenter.datastore.name",
+                "accountId": 0
+              }
+            ],
+            "units": {
+              "unit": "BYTES"
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "height": 3,
+            "width": 4
+          },
+          "title": "Disk available (GiB)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT latest(vcenter.datastore.disk.usage) / 1e9 WHERE instrumentation.provider = 'opentelemetry' AND disk_state = 'available' FACET vcenter.datastore.name",
+                "accountId": 0
+              }
+            ],
+            "units": {
+              "unit": "BYTES"
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.markdown"
+          },
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "height": 1,
+            "width": 12
+          },
+          "rawConfiguration": {
+            "text": "## Storage"
+          },
+          "title": ""
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 1,
+            "row": 5,
+            "height": 3,
+            "width": 4
+          },
+          "title": "Disk used (GiB)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT latest(vcenter.datastore.disk.usage) / 1e9 WHERE instrumentation.provider = 'opentelemetry' AND disk_state = 'used' FACET vcenter.datastore.name TIMESERIES AUTO",
+                "accountId": 0
+              }
+            ],
+            "units": {
+              "unit": "BYTES"
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 5,
+            "row": 5,
+            "height": 3,
+            "width": 4
+          },
+          "title": "Disk available (GiB)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT latest(vcenter.datastore.disk.usage) / 1e9 WHERE instrumentation.provider = 'opentelemetry' AND disk_state = 'available' FACET vcenter.datastore.name TIMESERIES AUTO",
+                "accountId": 0
+              }
+            ],
+            "units": {
+              "unit": "BYTES"
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 9,
+            "row": 5,
+            "height": 3,
+            "width": 4
+          },
+          "title": "Disk utilization (%)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT average(vcenter.datastore.disk.utilization) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.datastore.name TIMESERIES AUTO",
+                "accountId": 0
+              }
+            ],
+            "units": {
+              "unit": "PERCENTAGE"
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.area"
+          },
+          "layout": {
+            "column": 1,
+            "row": 8,
+            "height": 3,
+            "width": 12
+          },
+          "title": "Disk space breakdown (GiB)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT latest(vcenter.datastore.disk.usage) / 1e9 WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.datastore.name, disk_state TIMESERIES AUTO",
+                "accountId": 0
+              }
+            ],
+            "units": {
+              "unit": "BYTES"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-vspheredatastore/opentelemetry_dashboard.json
+++ b/entity-types/infra-vspheredatastore/opentelemetry_dashboard.json
@@ -20,8 +20,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT average(vcenter.datastore.disk.utilization) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.datastore.name",
-                "accountId": 0
-              }
+                "accountId": 0}
             ],
             "units": {
               "unit": "PERCENTAGE"
@@ -43,8 +42,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT latest(vcenter.datastore.disk.usage) / 1e9 WHERE instrumentation.provider = 'opentelemetry' AND disk_state = 'used' FACET vcenter.datastore.name",
-                "accountId": 0
-              }
+                "accountId": 0}
             ],
             "units": {
               "unit": "BYTES"
@@ -66,8 +64,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT latest(vcenter.datastore.disk.usage) / 1e9 WHERE instrumentation.provider = 'opentelemetry' AND disk_state = 'available' FACET vcenter.datastore.name",
-                "accountId": 0
-              }
+                "accountId": 0}
             ],
             "units": {
               "unit": "BYTES"
@@ -104,8 +101,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT latest(vcenter.datastore.disk.usage) / 1e9 WHERE instrumentation.provider = 'opentelemetry' AND disk_state = 'used' FACET vcenter.datastore.name TIMESERIES AUTO",
-                "accountId": 0
-              }
+                "accountId": 0}
             ],
             "units": {
               "unit": "BYTES"
@@ -127,8 +123,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT latest(vcenter.datastore.disk.usage) / 1e9 WHERE instrumentation.provider = 'opentelemetry' AND disk_state = 'available' FACET vcenter.datastore.name TIMESERIES AUTO",
-                "accountId": 0
-              }
+                "accountId": 0}
             ],
             "units": {
               "unit": "BYTES"
@@ -150,8 +145,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT average(vcenter.datastore.disk.utilization) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.datastore.name TIMESERIES AUTO",
-                "accountId": 0
-              }
+                "accountId": 0}
             ],
             "units": {
               "unit": "PERCENTAGE"
@@ -173,8 +167,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT latest(vcenter.datastore.disk.usage) / 1e9 WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.datastore.name, disk_state TIMESERIES AUTO",
-                "accountId": 0
-              }
+                "accountId": 0}
             ],
             "units": {
               "unit": "BYTES"

--- a/entity-types/infra-vspherehost/definition.stg.yml
+++ b/entity-types/infra-vspherehost/definition.stg.yml
@@ -1,0 +1,86 @@
+domain: INFRA
+type: VSPHEREHOST
+
+synthesis:
+  rules:
+  # OpenTelemetry synthesis rule - new collector format
+  - ruleName: infra_vspherehost_otel_new
+    compositeIdentifier:
+      separator: ":"
+      attributes:
+        - vcenter.datacenter.name
+        - vcenter.host.name
+    name: vcenter.host.name
+    encodeIdentifierInGUID: true
+    conditions:
+      - attribute: eventType
+        value: Metric
+      - attribute: metricName
+        prefix: vcenter.host.
+      - attribute: instrumentation.provider
+        value: opentelemetry
+      # New collector format
+      - attribute: otel.library.name
+        value: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver"
+    tags:
+      vcenter.datacenter.name:
+      vcenter.cluster.name:
+      vcenter.host.name:
+      otel.library.name:
+        entityTagName: instrumentation.name
+  # OpenTelemetry synthesis rule - old collector format
+  - ruleName: infra_vspherehost_otel_old
+    compositeIdentifier:
+      separator: ":"
+      attributes:
+        - vcenter.datacenter.name
+        - vcenter.host.name
+    name: vcenter.host.name
+    encodeIdentifierInGUID: true
+    conditions:
+      - attribute: eventType
+        value: Metric
+      - attribute: metricName
+        prefix: vcenter.host.
+      - attribute: instrumentation.provider
+        value: opentelemetry
+      # Old collector format
+      - attribute: otel.library.name
+        value: "otelcol/vcenterreceiver"
+    tags:
+      vcenter.datacenter.name:
+      vcenter.cluster.name:
+      vcenter.host.name:
+      otel.library.name:
+        entityTagName: instrumentation.name
+  tags:
+    # For OpenTelemetry
+    telemetry.sdk.name:
+      entityTagName: instrumentation.provider
+
+goldenTags:
+- vsphere.hostClusterName
+- vsphere.hostOverallStatus
+- vsphere.hostDatacenterName
+- vsphere.hostResourcePoolNameList
+- vsphere.hostDatastoreNameList
+- vsphere.hostHypervisorHostname
+# OpenTelemetry
+- vcenter.datacenter.name
+- vcenter.cluster.name
+- vcenter.host.name
+
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+
+dashboardTemplates:
+  # This should match the entity created from the ohi in the infra pipeline
+  newRelic:
+    template: newrelic_dashboard.json
+  opentelemetry:
+    template: opentelemetry_dashboard.json
+
+ownership:
+  primaryOwner:
+    teamName: "OnHost Agent and Integrations"

--- a/entity-types/infra-vspherehost/definition.stg.yml
+++ b/entity-types/infra-vspherehost/definition.stg.yml
@@ -3,8 +3,8 @@ type: VSPHEREHOST
 
 synthesis:
   rules:
-  # OpenTelemetry synthesis rule - new collector format
-  - ruleName: infra_vspherehost_otel_new
+  # OpenTelemetry synthesis rule - covers both old and new collector formats
+  - ruleName: infra_vspherehost_otel
     compositeIdentifier:
       separator: ":"
       attributes:
@@ -19,34 +19,6 @@ synthesis:
         prefix: vcenter.host.
       - attribute: instrumentation.provider
         value: opentelemetry
-      # New collector format
-      - attribute: otel.library.name
-        value: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver"
-    tags:
-      vcenter.datacenter.name:
-      vcenter.cluster.name:
-      vcenter.host.name:
-      otel.library.name:
-        entityTagName: instrumentation.name
-  # OpenTelemetry synthesis rule - old collector format
-  - ruleName: infra_vspherehost_otel_old
-    compositeIdentifier:
-      separator: ":"
-      attributes:
-        - vcenter.datacenter.name
-        - vcenter.host.name
-    name: vcenter.host.name
-    encodeIdentifierInGUID: true
-    conditions:
-      - attribute: eventType
-        value: Metric
-      - attribute: metricName
-        prefix: vcenter.host.
-      - attribute: instrumentation.provider
-        value: opentelemetry
-      # Old collector format
-      - attribute: otel.library.name
-        value: "otelcol/vcenterreceiver"
     tags:
       vcenter.datacenter.name:
       vcenter.cluster.name:

--- a/entity-types/infra-vspherehost/opentelemetry_dashboard.json
+++ b/entity-types/infra-vspherehost/opentelemetry_dashboard.json
@@ -1,0 +1,233 @@
+{
+  "name": "vSphere Host (OpenTelemetry)",
+  "pages": [
+    {
+      "name": "Overview",
+      "description": null,
+      "widgets": [
+        {
+          "visualization": { "id": "viz.billboard" },
+          "layout": { "column": 1, "row": 1, "height": 3, "width": 3 },
+          "title": "CPU utilization (%)",
+          "rawConfiguration": {
+            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.cpu.utilization) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name", "accountId": 0 }],
+            "units": { "unit": "PERCENTAGE" }
+          }
+        },
+        {
+          "visualization": { "id": "viz.billboard" },
+          "layout": { "column": 4, "row": 1, "height": 3, "width": 3 },
+          "title": "Memory utilization (%)",
+          "rawConfiguration": {
+            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.memory.utilization) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name", "accountId": 0 }],
+            "units": { "unit": "PERCENTAGE" }
+          }
+        },
+        {
+          "visualization": { "id": "viz.billboard" },
+          "layout": { "column": 7, "row": 1, "height": 3, "width": 3 },
+          "title": "Network usage (KiB/s)",
+          "rawConfiguration": {
+            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.network.usage) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name", "accountId": 0 }]
+          }
+        },
+        {
+          "visualization": { "id": "viz.billboard" },
+          "layout": { "column": 10, "row": 1, "height": 3, "width": 3 },
+          "title": "Disk latency avg (ms)",
+          "rawConfiguration": {
+            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.disk.latency.avg) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name", "accountId": 0 }]
+          }
+        },
+        {
+          "visualization": { "id": "viz.markdown" },
+          "layout": { "column": 1, "row": 4, "height": 1, "width": 12 },
+          "title": "",
+          "rawConfiguration": { "text": "## CPU" }
+        },
+        {
+          "visualization": { "id": "viz.line" },
+          "layout": { "column": 1, "row": 5, "height": 3, "width": 4 },
+          "title": "CPU utilization (%)",
+          "rawConfiguration": {
+            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.cpu.utilization) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name TIMESERIES AUTO", "accountId": 0 }],
+            "units": { "unit": "PERCENTAGE" }
+          }
+        },
+        {
+          "visualization": { "id": "viz.line" },
+          "layout": { "column": 5, "row": 5, "height": 3, "width": 4 },
+          "title": "CPU usage (MHz)",
+          "rawConfiguration": {
+            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.cpu.usage) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name TIMESERIES AUTO", "accountId": 0 }]
+          }
+        },
+        {
+          "visualization": { "id": "viz.line" },
+          "layout": { "column": 9, "row": 5, "height": 3, "width": 4 },
+          "title": "CPU capacity (MHz)",
+          "rawConfiguration": {
+            "nrqlQueries": [{ "query": "FROM Metric SELECT latest(vcenter.host.cpu.capacity) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name TIMESERIES AUTO", "accountId": 0 }]
+          }
+        },
+        {
+          "visualization": { "id": "viz.markdown" },
+          "layout": { "column": 1, "row": 8, "height": 1, "width": 12 },
+          "title": "",
+          "rawConfiguration": { "text": "## Memory" }
+        },
+        {
+          "visualization": { "id": "viz.line" },
+          "layout": { "column": 1, "row": 9, "height": 3, "width": 4 },
+          "title": "Memory utilization (%)",
+          "rawConfiguration": {
+            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.memory.utilization) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name TIMESERIES AUTO", "accountId": 0 }],
+            "units": { "unit": "PERCENTAGE" }
+          }
+        },
+        {
+          "visualization": { "id": "viz.line" },
+          "layout": { "column": 5, "row": 9, "height": 3, "width": 4 },
+          "title": "Memory usage (MiB)",
+          "rawConfiguration": {
+            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.memory.usage) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name TIMESERIES AUTO", "accountId": 0 }],
+            "units": { "unit": "BYTES" }
+          }
+        },
+        {
+          "visualization": { "id": "viz.line" },
+          "layout": { "column": 9, "row": 9, "height": 3, "width": 4 },
+          "title": "Memory capacity (MiB)",
+          "rawConfiguration": {
+            "nrqlQueries": [{ "query": "FROM Metric SELECT latest(vcenter.host.memory.capacity) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name TIMESERIES AUTO", "accountId": 0 }],
+            "units": { "unit": "BYTES" }
+          }
+        },
+        {
+          "visualization": { "id": "viz.markdown" },
+          "layout": { "column": 1, "row": 12, "height": 1, "width": 12 },
+          "title": "",
+          "rawConfiguration": { "text": "## Network" }
+        },
+        {
+          "visualization": { "id": "viz.line" },
+          "layout": { "column": 1, "row": 13, "height": 3, "width": 4 },
+          "title": "Network throughput (KiB/s)",
+          "rawConfiguration": {
+            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.network.throughput) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name, direction TIMESERIES AUTO", "accountId": 0 }]
+          }
+        },
+        {
+          "visualization": { "id": "viz.line" },
+          "layout": { "column": 5, "row": 13, "height": 3, "width": 4 },
+          "title": "Network packet rate (packets/s)",
+          "rawConfiguration": {
+            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.network.packet.rate) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name, direction TIMESERIES AUTO", "accountId": 0 }]
+          }
+        },
+        {
+          "visualization": { "id": "viz.line" },
+          "layout": { "column": 9, "row": 13, "height": 3, "width": 4 },
+          "title": "Network packet errors (errors/s)",
+          "rawConfiguration": {
+            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.network.packet.error.rate) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name, direction TIMESERIES AUTO", "accountId": 0 }]
+          }
+        },
+        {
+          "visualization": { "id": "viz.line" },
+          "layout": { "column": 1, "row": 16, "height": 3, "width": 6 },
+          "title": "Network packet drops (packets/s)",
+          "rawConfiguration": {
+            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.network.packet.drop.rate) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name, direction TIMESERIES AUTO", "accountId": 0 }]
+          }
+        },
+        {
+          "visualization": { "id": "viz.line" },
+          "layout": { "column": 7, "row": 16, "height": 3, "width": 6 },
+          "title": "Network combined usage (KiB/s)",
+          "rawConfiguration": {
+            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.network.usage) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name TIMESERIES AUTO", "accountId": 0 }]
+          }
+        },
+        {
+          "visualization": { "id": "viz.markdown" },
+          "layout": { "column": 1, "row": 19, "height": 1, "width": 12 },
+          "title": "",
+          "rawConfiguration": { "text": "## Disk" }
+        },
+        {
+          "visualization": { "id": "viz.line" },
+          "layout": { "column": 1, "row": 20, "height": 3, "width": 4 },
+          "title": "Disk latency avg (ms)",
+          "rawConfiguration": {
+            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.disk.latency.avg) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name, direction TIMESERIES AUTO", "accountId": 0 }]
+          }
+        },
+        {
+          "visualization": { "id": "viz.line" },
+          "layout": { "column": 5, "row": 20, "height": 3, "width": 4 },
+          "title": "Disk latency max (ms)",
+          "rawConfiguration": {
+            "nrqlQueries": [{ "query": "FROM Metric SELECT max(vcenter.host.disk.latency.max) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name TIMESERIES AUTO", "accountId": 0 }]
+          }
+        },
+        {
+          "visualization": { "id": "viz.line" },
+          "layout": { "column": 9, "row": 20, "height": 3, "width": 4 },
+          "title": "Disk throughput (KiB/s)",
+          "rawConfiguration": {
+            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.disk.throughput) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name, direction TIMESERIES AUTO", "accountId": 0 }]
+          }
+        },
+        {
+          "visualization": { "id": "viz.markdown" },
+          "layout": { "column": 1, "row": 23, "height": 1, "width": 12 },
+          "title": "",
+          "rawConfiguration": { "text": "## vSAN" }
+        },
+        {
+          "visualization": { "id": "viz.line" },
+          "layout": { "column": 1, "row": 24, "height": 3, "width": 4 },
+          "title": "vSAN latency avg (µs)",
+          "rawConfiguration": {
+            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.vsan.latency.avg) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name, type TIMESERIES AUTO", "accountId": 0 }]
+          }
+        },
+        {
+          "visualization": { "id": "viz.line" },
+          "layout": { "column": 5, "row": 24, "height": 3, "width": 4 },
+          "title": "vSAN operations (ops/s)",
+          "rawConfiguration": {
+            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.vsan.operations) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name, type TIMESERIES AUTO", "accountId": 0 }]
+          }
+        },
+        {
+          "visualization": { "id": "viz.line" },
+          "layout": { "column": 9, "row": 24, "height": 3, "width": 4 },
+          "title": "vSAN throughput (By/s)",
+          "rawConfiguration": {
+            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.vsan.throughput) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name, direction TIMESERIES AUTO", "accountId": 0 }],
+            "units": { "unit": "BYTES_PER_SECOND" }
+          }
+        },
+        {
+          "visualization": { "id": "viz.line" },
+          "layout": { "column": 1, "row": 27, "height": 3, "width": 6 },
+          "title": "vSAN cache hit rate (%)",
+          "rawConfiguration": {
+            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.vsan.cache.hit_rate) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name TIMESERIES AUTO", "accountId": 0 }],
+            "units": { "unit": "PERCENTAGE" }
+          }
+        },
+        {
+          "visualization": { "id": "viz.line" },
+          "layout": { "column": 7, "row": 27, "height": 3, "width": 6 },
+          "title": "vSAN congestions (congestions/s)",
+          "rawConfiguration": {
+            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.vsan.congestions) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name TIMESERIES AUTO", "accountId": 0 }]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-vspherehost/opentelemetry_dashboard.json
+++ b/entity-types/infra-vspherehost/opentelemetry_dashboard.json
@@ -10,7 +10,7 @@
           "layout": { "column": 1, "row": 1, "height": 3, "width": 3 },
           "title": "CPU utilization (%)",
           "rawConfiguration": {
-            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.cpu.utilization) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name", "accountId": 0 }],
+            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.cpu.utilization) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name", "accountId": 0}],
             "units": { "unit": "PERCENTAGE" }
           }
         },
@@ -19,7 +19,7 @@
           "layout": { "column": 4, "row": 1, "height": 3, "width": 3 },
           "title": "Memory utilization (%)",
           "rawConfiguration": {
-            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.memory.utilization) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name", "accountId": 0 }],
+            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.memory.utilization) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name", "accountId": 0}],
             "units": { "unit": "PERCENTAGE" }
           }
         },
@@ -28,7 +28,7 @@
           "layout": { "column": 7, "row": 1, "height": 3, "width": 3 },
           "title": "Network usage (KiB/s)",
           "rawConfiguration": {
-            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.network.usage) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name", "accountId": 0 }]
+            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.network.usage) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name", "accountId": 0}]
           }
         },
         {
@@ -36,7 +36,7 @@
           "layout": { "column": 10, "row": 1, "height": 3, "width": 3 },
           "title": "Disk latency avg (ms)",
           "rawConfiguration": {
-            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.disk.latency.avg) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name", "accountId": 0 }]
+            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.disk.latency.avg) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name", "accountId": 0}]
           }
         },
         {
@@ -50,7 +50,7 @@
           "layout": { "column": 1, "row": 5, "height": 3, "width": 4 },
           "title": "CPU utilization (%)",
           "rawConfiguration": {
-            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.cpu.utilization) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name TIMESERIES AUTO", "accountId": 0 }],
+            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.cpu.utilization) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name TIMESERIES AUTO", "accountId": 0}],
             "units": { "unit": "PERCENTAGE" }
           }
         },
@@ -59,7 +59,7 @@
           "layout": { "column": 5, "row": 5, "height": 3, "width": 4 },
           "title": "CPU usage (MHz)",
           "rawConfiguration": {
-            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.cpu.usage) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name TIMESERIES AUTO", "accountId": 0 }]
+            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.cpu.usage) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name TIMESERIES AUTO", "accountId": 0}]
           }
         },
         {
@@ -67,7 +67,7 @@
           "layout": { "column": 9, "row": 5, "height": 3, "width": 4 },
           "title": "CPU capacity (MHz)",
           "rawConfiguration": {
-            "nrqlQueries": [{ "query": "FROM Metric SELECT latest(vcenter.host.cpu.capacity) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name TIMESERIES AUTO", "accountId": 0 }]
+            "nrqlQueries": [{ "query": "FROM Metric SELECT latest(vcenter.host.cpu.capacity) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name TIMESERIES AUTO", "accountId": 0}]
           }
         },
         {
@@ -81,7 +81,7 @@
           "layout": { "column": 1, "row": 9, "height": 3, "width": 4 },
           "title": "Memory utilization (%)",
           "rawConfiguration": {
-            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.memory.utilization) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name TIMESERIES AUTO", "accountId": 0 }],
+            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.memory.utilization) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name TIMESERIES AUTO", "accountId": 0}],
             "units": { "unit": "PERCENTAGE" }
           }
         },
@@ -90,7 +90,7 @@
           "layout": { "column": 5, "row": 9, "height": 3, "width": 4 },
           "title": "Memory usage (MiB)",
           "rawConfiguration": {
-            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.memory.usage) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name TIMESERIES AUTO", "accountId": 0 }],
+            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.memory.usage) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name TIMESERIES AUTO", "accountId": 0}],
             "units": { "unit": "BYTES" }
           }
         },
@@ -99,7 +99,7 @@
           "layout": { "column": 9, "row": 9, "height": 3, "width": 4 },
           "title": "Memory capacity (MiB)",
           "rawConfiguration": {
-            "nrqlQueries": [{ "query": "FROM Metric SELECT latest(vcenter.host.memory.capacity) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name TIMESERIES AUTO", "accountId": 0 }],
+            "nrqlQueries": [{ "query": "FROM Metric SELECT latest(vcenter.host.memory.capacity) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name TIMESERIES AUTO", "accountId": 0}],
             "units": { "unit": "BYTES" }
           }
         },
@@ -114,7 +114,7 @@
           "layout": { "column": 1, "row": 13, "height": 3, "width": 4 },
           "title": "Network throughput (KiB/s)",
           "rawConfiguration": {
-            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.network.throughput) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name, direction TIMESERIES AUTO", "accountId": 0 }]
+            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.network.throughput) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name, direction TIMESERIES AUTO", "accountId": 0}]
           }
         },
         {
@@ -122,7 +122,7 @@
           "layout": { "column": 5, "row": 13, "height": 3, "width": 4 },
           "title": "Network packet rate (packets/s)",
           "rawConfiguration": {
-            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.network.packet.rate) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name, direction TIMESERIES AUTO", "accountId": 0 }]
+            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.network.packet.rate) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name, direction TIMESERIES AUTO", "accountId": 0}]
           }
         },
         {
@@ -130,7 +130,7 @@
           "layout": { "column": 9, "row": 13, "height": 3, "width": 4 },
           "title": "Network packet errors (errors/s)",
           "rawConfiguration": {
-            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.network.packet.error.rate) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name, direction TIMESERIES AUTO", "accountId": 0 }]
+            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.network.packet.error.rate) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name, direction TIMESERIES AUTO", "accountId": 0}]
           }
         },
         {
@@ -138,7 +138,7 @@
           "layout": { "column": 1, "row": 16, "height": 3, "width": 6 },
           "title": "Network packet drops (packets/s)",
           "rawConfiguration": {
-            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.network.packet.drop.rate) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name, direction TIMESERIES AUTO", "accountId": 0 }]
+            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.network.packet.drop.rate) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name, direction TIMESERIES AUTO", "accountId": 0}]
           }
         },
         {
@@ -146,7 +146,7 @@
           "layout": { "column": 7, "row": 16, "height": 3, "width": 6 },
           "title": "Network combined usage (KiB/s)",
           "rawConfiguration": {
-            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.network.usage) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name TIMESERIES AUTO", "accountId": 0 }]
+            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.network.usage) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name TIMESERIES AUTO", "accountId": 0}]
           }
         },
         {
@@ -160,7 +160,7 @@
           "layout": { "column": 1, "row": 20, "height": 3, "width": 4 },
           "title": "Disk latency avg (ms)",
           "rawConfiguration": {
-            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.disk.latency.avg) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name, direction TIMESERIES AUTO", "accountId": 0 }]
+            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.disk.latency.avg) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name, direction TIMESERIES AUTO", "accountId": 0}]
           }
         },
         {
@@ -168,7 +168,7 @@
           "layout": { "column": 5, "row": 20, "height": 3, "width": 4 },
           "title": "Disk latency max (ms)",
           "rawConfiguration": {
-            "nrqlQueries": [{ "query": "FROM Metric SELECT max(vcenter.host.disk.latency.max) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name TIMESERIES AUTO", "accountId": 0 }]
+            "nrqlQueries": [{ "query": "FROM Metric SELECT max(vcenter.host.disk.latency.max) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name TIMESERIES AUTO", "accountId": 0}]
           }
         },
         {
@@ -176,7 +176,7 @@
           "layout": { "column": 9, "row": 20, "height": 3, "width": 4 },
           "title": "Disk throughput (KiB/s)",
           "rawConfiguration": {
-            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.disk.throughput) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name, direction TIMESERIES AUTO", "accountId": 0 }]
+            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.disk.throughput) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name, direction TIMESERIES AUTO", "accountId": 0}]
           }
         },
         {
@@ -190,7 +190,7 @@
           "layout": { "column": 1, "row": 24, "height": 3, "width": 4 },
           "title": "vSAN latency avg (µs)",
           "rawConfiguration": {
-            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.vsan.latency.avg) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name, type TIMESERIES AUTO", "accountId": 0 }]
+            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.vsan.latency.avg) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name, type TIMESERIES AUTO", "accountId": 0}]
           }
         },
         {
@@ -198,7 +198,7 @@
           "layout": { "column": 5, "row": 24, "height": 3, "width": 4 },
           "title": "vSAN operations (ops/s)",
           "rawConfiguration": {
-            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.vsan.operations) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name, type TIMESERIES AUTO", "accountId": 0 }]
+            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.vsan.operations) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name, type TIMESERIES AUTO", "accountId": 0}]
           }
         },
         {
@@ -206,7 +206,7 @@
           "layout": { "column": 9, "row": 24, "height": 3, "width": 4 },
           "title": "vSAN throughput (By/s)",
           "rawConfiguration": {
-            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.vsan.throughput) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name, direction TIMESERIES AUTO", "accountId": 0 }],
+            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.vsan.throughput) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name, direction TIMESERIES AUTO", "accountId": 0}],
             "units": { "unit": "BYTES_PER_SECOND" }
           }
         },
@@ -215,7 +215,7 @@
           "layout": { "column": 1, "row": 27, "height": 3, "width": 6 },
           "title": "vSAN cache hit rate (%)",
           "rawConfiguration": {
-            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.vsan.cache.hit_rate) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name TIMESERIES AUTO", "accountId": 0 }],
+            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.vsan.cache.hit_rate) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name TIMESERIES AUTO", "accountId": 0}],
             "units": { "unit": "PERCENTAGE" }
           }
         },
@@ -224,7 +224,7 @@
           "layout": { "column": 7, "row": 27, "height": 3, "width": 6 },
           "title": "vSAN congestions (congestions/s)",
           "rawConfiguration": {
-            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.vsan.congestions) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name TIMESERIES AUTO", "accountId": 0 }]
+            "nrqlQueries": [{ "query": "FROM Metric SELECT average(vcenter.host.vsan.congestions) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.host.name TIMESERIES AUTO", "accountId": 0}]
           }
         }
       ]

--- a/entity-types/infra-vsphereresourcepool/definition.stg.yml
+++ b/entity-types/infra-vsphereresourcepool/definition.stg.yml
@@ -1,0 +1,74 @@
+domain: INFRA
+type: VSPHERERESOURCEPOOL
+
+synthesis:
+  rules:
+  # OpenTelemetry synthesis rule - new collector format
+  - ruleName: infra_vsphereresourcepool_otel_new
+    identifier: vcenter.resource_pool.inventory_path
+    name: vcenter.resource_pool.name
+    encodeIdentifierInGUID: true
+    conditions:
+      - attribute: eventType
+        value: Metric
+      - attribute: metricName
+        prefix: vcenter.resource_pool.
+      - attribute: instrumentation.provider
+        value: opentelemetry
+      # New collector format
+      - attribute: otel.library.name
+        value: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver"
+    tags:
+      vcenter.datacenter.name:
+      vcenter.cluster.name:
+      vcenter.resource_pool.name:
+      vcenter.resource_pool.inventory_path:
+      otel.library.name:
+        entityTagName: instrumentation.name
+  # OpenTelemetry synthesis rule - old collector format
+  - ruleName: infra_vsphereresourcepool_otel_old
+    identifier: vcenter.resource_pool.inventory_path
+    name: vcenter.resource_pool.name
+    encodeIdentifierInGUID: true
+    conditions:
+      - attribute: eventType
+        value: Metric
+      - attribute: metricName
+        prefix: vcenter.resource_pool.
+      - attribute: instrumentation.provider
+        value: opentelemetry
+      # Old collector format
+      - attribute: otel.library.name
+        value: "otelcol/vcenterreceiver"
+    tags:
+      vcenter.datacenter.name:
+      vcenter.cluster.name:
+      vcenter.resource_pool.name:
+      vcenter.resource_pool.inventory_path:
+      otel.library.name:
+        entityTagName: instrumentation.name
+  tags:
+    # For OpenTelemetry
+    telemetry.sdk.name:
+      entityTagName: instrumentation.provider
+
+goldenTags:
+- vcenter.datacenter.name
+- vcenter.cluster.name
+- vcenter.resource_pool.name
+- vcenter.resource_pool.inventory_path
+
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+
+dashboardTemplates:
+  # This should match the entity created from the ohi in the infra pipeline
+  newRelic:
+    template: newrelic_dashboard.json
+  opentelemetry:
+    template: opentelemetry_dashboard.json
+
+ownership:
+  primaryOwner:
+    teamName: "OnHost Agent and Integrations"

--- a/entity-types/infra-vsphereresourcepool/definition.stg.yml
+++ b/entity-types/infra-vsphereresourcepool/definition.stg.yml
@@ -3,8 +3,8 @@ type: VSPHERERESOURCEPOOL
 
 synthesis:
   rules:
-  # OpenTelemetry synthesis rule - new collector format
-  - ruleName: infra_vsphereresourcepool_otel_new
+  # OpenTelemetry synthesis rule - covers both old and new collector formats
+  - ruleName: infra_vsphereresourcepool_otel
     identifier: vcenter.resource_pool.inventory_path
     name: vcenter.resource_pool.name
     encodeIdentifierInGUID: true
@@ -15,31 +15,6 @@ synthesis:
         prefix: vcenter.resource_pool.
       - attribute: instrumentation.provider
         value: opentelemetry
-      # New collector format
-      - attribute: otel.library.name
-        value: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver"
-    tags:
-      vcenter.datacenter.name:
-      vcenter.cluster.name:
-      vcenter.resource_pool.name:
-      vcenter.resource_pool.inventory_path:
-      otel.library.name:
-        entityTagName: instrumentation.name
-  # OpenTelemetry synthesis rule - old collector format
-  - ruleName: infra_vsphereresourcepool_otel_old
-    identifier: vcenter.resource_pool.inventory_path
-    name: vcenter.resource_pool.name
-    encodeIdentifierInGUID: true
-    conditions:
-      - attribute: eventType
-        value: Metric
-      - attribute: metricName
-        prefix: vcenter.resource_pool.
-      - attribute: instrumentation.provider
-        value: opentelemetry
-      # Old collector format
-      - attribute: otel.library.name
-        value: "otelcol/vcenterreceiver"
     tags:
       vcenter.datacenter.name:
       vcenter.cluster.name:

--- a/entity-types/infra-vsphereresourcepool/opentelemetry_dashboard.json
+++ b/entity-types/infra-vsphereresourcepool/opentelemetry_dashboard.json
@@ -20,8 +20,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT average(vcenter.resource_pool.cpu.usage) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.resource_pool.name",
-                "accountId": 0
-              }
+                "accountId": 0}
             ]
           }
         },
@@ -40,8 +39,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT average(vcenter.resource_pool.memory.usage) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.resource_pool.name",
-                "accountId": 0
-              }
+                "accountId": 0}
             ],
             "units": {
               "unit": "BYTES"
@@ -63,8 +61,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT average(vcenter.resource_pool.memory.ballooned) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.resource_pool.name",
-                "accountId": 0
-              }
+                "accountId": 0}
             ],
             "units": {
               "unit": "BYTES"
@@ -101,8 +98,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT average(vcenter.resource_pool.cpu.usage) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.resource_pool.name TIMESERIES AUTO",
-                "accountId": 0
-              }
+                "accountId": 0}
             ]
           }
         },
@@ -121,8 +117,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT latest(vcenter.resource_pool.cpu.shares) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.resource_pool.name TIMESERIES AUTO",
-                "accountId": 0
-              }
+                "accountId": 0}
             ]
           }
         },
@@ -156,8 +151,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT average(vcenter.resource_pool.memory.usage) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.resource_pool.name TIMESERIES AUTO",
-                "accountId": 0
-              }
+                "accountId": 0}
             ],
             "units": {
               "unit": "BYTES"
@@ -179,8 +173,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT average(vcenter.resource_pool.memory.ballooned) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.resource_pool.name TIMESERIES AUTO",
-                "accountId": 0
-              }
+                "accountId": 0}
             ],
             "units": {
               "unit": "BYTES"
@@ -202,8 +195,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT average(vcenter.resource_pool.memory.swapped) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.resource_pool.name TIMESERIES AUTO",
-                "accountId": 0
-              }
+                "accountId": 0}
             ],
             "units": {
               "unit": "BYTES"
@@ -225,8 +217,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT latest(vcenter.resource_pool.memory.shares) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.resource_pool.name TIMESERIES AUTO",
-                "accountId": 0
-              }
+                "accountId": 0}
             ]
           }
         },
@@ -245,8 +236,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT average(vcenter.resource_pool.memory.granted) WHERE instrumentation.provider = 'opentelemetry' AND type = 'private' FACET vcenter.resource_pool.name TIMESERIES AUTO",
-                "accountId": 0
-              }
+                "accountId": 0}
             ],
             "units": {
               "unit": "BYTES"
@@ -268,8 +258,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT average(vcenter.resource_pool.memory.granted) WHERE instrumentation.provider = 'opentelemetry' AND type = 'shared' FACET vcenter.resource_pool.name TIMESERIES AUTO",
-                "accountId": 0
-              }
+                "accountId": 0}
             ],
             "units": {
               "unit": "BYTES"

--- a/entity-types/infra-vsphereresourcepool/opentelemetry_dashboard.json
+++ b/entity-types/infra-vsphereresourcepool/opentelemetry_dashboard.json
@@ -1,0 +1,282 @@
+{
+  "name": "vSphere Resource Pool (OpenTelemetry)",
+  "pages": [
+    {
+      "name": "Overview",
+      "description": null,
+      "widgets": [
+        {
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "height": 3,
+            "width": 4
+          },
+          "title": "CPU usage (MHz)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT average(vcenter.resource_pool.cpu.usage) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.resource_pool.name",
+                "accountId": 0
+              }
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "height": 3,
+            "width": 4
+          },
+          "title": "Memory usage (MiB)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT average(vcenter.resource_pool.memory.usage) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.resource_pool.name",
+                "accountId": 0
+              }
+            ],
+            "units": {
+              "unit": "BYTES"
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "height": 3,
+            "width": 4
+          },
+          "title": "Memory ballooned (MiB)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT average(vcenter.resource_pool.memory.ballooned) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.resource_pool.name",
+                "accountId": 0
+              }
+            ],
+            "units": {
+              "unit": "BYTES"
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.markdown"
+          },
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "height": 1,
+            "width": 12
+          },
+          "rawConfiguration": {
+            "text": "## CPU"
+          },
+          "title": ""
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 1,
+            "row": 5,
+            "height": 3,
+            "width": 6
+          },
+          "title": "CPU usage (MHz)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT average(vcenter.resource_pool.cpu.usage) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.resource_pool.name TIMESERIES AUTO",
+                "accountId": 0
+              }
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 7,
+            "row": 5,
+            "height": 3,
+            "width": 6
+          },
+          "title": "CPU shares",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT latest(vcenter.resource_pool.cpu.shares) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.resource_pool.name TIMESERIES AUTO",
+                "accountId": 0
+              }
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.markdown"
+          },
+          "layout": {
+            "column": 1,
+            "row": 8,
+            "height": 1,
+            "width": 12
+          },
+          "rawConfiguration": {
+            "text": "## Memory"
+          },
+          "title": ""
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 1,
+            "row": 9,
+            "height": 3,
+            "width": 3
+          },
+          "title": "Memory usage (MiB)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT average(vcenter.resource_pool.memory.usage) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.resource_pool.name TIMESERIES AUTO",
+                "accountId": 0
+              }
+            ],
+            "units": {
+              "unit": "BYTES"
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 4,
+            "row": 9,
+            "height": 3,
+            "width": 3
+          },
+          "title": "Memory ballooned (MiB)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT average(vcenter.resource_pool.memory.ballooned) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.resource_pool.name TIMESERIES AUTO",
+                "accountId": 0
+              }
+            ],
+            "units": {
+              "unit": "BYTES"
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 7,
+            "row": 9,
+            "height": 3,
+            "width": 3
+          },
+          "title": "Memory swapped (MiB)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT average(vcenter.resource_pool.memory.swapped) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.resource_pool.name TIMESERIES AUTO",
+                "accountId": 0
+              }
+            ],
+            "units": {
+              "unit": "BYTES"
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 10,
+            "row": 9,
+            "height": 3,
+            "width": 3
+          },
+          "title": "Memory shares",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT latest(vcenter.resource_pool.memory.shares) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.resource_pool.name TIMESERIES AUTO",
+                "accountId": 0
+              }
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 1,
+            "row": 12,
+            "height": 3,
+            "width": 6
+          },
+          "title": "Memory granted - private (MiB)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT average(vcenter.resource_pool.memory.granted) WHERE instrumentation.provider = 'opentelemetry' AND type = 'private' FACET vcenter.resource_pool.name TIMESERIES AUTO",
+                "accountId": 0
+              }
+            ],
+            "units": {
+              "unit": "BYTES"
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 7,
+            "row": 12,
+            "height": 3,
+            "width": 6
+          },
+          "title": "Memory granted - shared (MiB)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT average(vcenter.resource_pool.memory.granted) WHERE instrumentation.provider = 'opentelemetry' AND type = 'shared' FACET vcenter.resource_pool.name TIMESERIES AUTO",
+                "accountId": 0
+              }
+            ],
+            "units": {
+              "unit": "BYTES"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-vspherevm/definition.stg.yml
+++ b/entity-types/infra-vspherevm/definition.stg.yml
@@ -3,8 +3,8 @@ type: VSPHEREVM
 
 synthesis:
   rules:
-  # OpenTelemetry synthesis rule - new collector format
-  - ruleName: infra_vspherevm_otel_new
+  # OpenTelemetry synthesis rule - covers both old and new collector formats
+  - ruleName: infra_vspherevm_otel
     identifier: vcenter.vm.id
     name: vcenter.vm.name
     encodeIdentifierInGUID: true
@@ -15,32 +15,6 @@ synthesis:
         prefix: vcenter.vm.
       - attribute: instrumentation.provider
         value: opentelemetry
-      # New collector format
-      - attribute: otel.library.name
-        value: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver"
-    tags:
-      vcenter.datacenter.name:
-      vcenter.cluster.name:
-      vcenter.host.name:
-      vcenter.vm.id:
-      vcenter.vm.name:
-      otel.library.name:
-        entityTagName: instrumentation.name
-  # OpenTelemetry synthesis rule - old collector format
-  - ruleName: infra_vspherevm_otel_old
-    identifier: vcenter.vm.id
-    name: vcenter.vm.name
-    encodeIdentifierInGUID: true
-    conditions:
-      - attribute: eventType
-        value: Metric
-      - attribute: metricName
-        prefix: vcenter.vm.
-      - attribute: instrumentation.provider
-        value: opentelemetry
-      # Old collector format
-      - attribute: otel.library.name
-        value: "otelcol/vcenterreceiver"
     tags:
       vcenter.datacenter.name:
       vcenter.cluster.name:

--- a/entity-types/infra-vspherevm/definition.stg.yml
+++ b/entity-types/infra-vspherevm/definition.stg.yml
@@ -1,0 +1,84 @@
+domain: INFRA
+type: VSPHEREVM
+
+synthesis:
+  rules:
+  # OpenTelemetry synthesis rule - new collector format
+  - ruleName: infra_vspherevm_otel_new
+    identifier: vcenter.vm.id
+    name: vcenter.vm.name
+    encodeIdentifierInGUID: true
+    conditions:
+      - attribute: eventType
+        value: Metric
+      - attribute: metricName
+        prefix: vcenter.vm.
+      - attribute: instrumentation.provider
+        value: opentelemetry
+      # New collector format
+      - attribute: otel.library.name
+        value: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver"
+    tags:
+      vcenter.datacenter.name:
+      vcenter.cluster.name:
+      vcenter.host.name:
+      vcenter.vm.id:
+      vcenter.vm.name:
+      otel.library.name:
+        entityTagName: instrumentation.name
+  # OpenTelemetry synthesis rule - old collector format
+  - ruleName: infra_vspherevm_otel_old
+    identifier: vcenter.vm.id
+    name: vcenter.vm.name
+    encodeIdentifierInGUID: true
+    conditions:
+      - attribute: eventType
+        value: Metric
+      - attribute: metricName
+        prefix: vcenter.vm.
+      - attribute: instrumentation.provider
+        value: opentelemetry
+      # Old collector format
+      - attribute: otel.library.name
+        value: "otelcol/vcenterreceiver"
+    tags:
+      vcenter.datacenter.name:
+      vcenter.cluster.name:
+      vcenter.host.name:
+      vcenter.vm.id:
+      vcenter.vm.name:
+      otel.library.name:
+        entityTagName: instrumentation.name
+  tags:
+    # For OpenTelemetry
+    telemetry.sdk.name:
+      entityTagName: instrumentation.provider
+
+goldenTags:
+- vsphere.vmClusterName
+- vsphere.vmDatacenterName
+- vsphere.vmHypervisorHostname
+- vsphere.vmResourcePoolName
+- vsphere.vmDatastoreNameList
+- vsphere.vmVmHostname
+# OpenTelemetry
+- vcenter.datacenter.name
+- vcenter.cluster.name
+- vcenter.host.name
+- vcenter.vm.id
+- vcenter.vm.name
+
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+
+dashboardTemplates:
+  # This should match the entity created from the ohi in the infra pipeline
+  newRelic:
+    template: newrelic_dashboard.json
+  opentelemetry:
+    template: opentelemetry_dashboard.json
+
+ownership:
+  primaryOwner:
+    teamName: "OnHost Agent and Integrations"

--- a/entity-types/infra-vspherevm/opentelemetry_dashboard.json
+++ b/entity-types/infra-vspherevm/opentelemetry_dashboard.json
@@ -20,8 +20,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT average(vcenter.vm.cpu.utilization) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.vm.name",
-                "accountId": 0
-              }
+                "accountId": 0}
             ],
             "units": {
               "unit": "PERCENTAGE"
@@ -43,8 +42,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT average(vcenter.vm.memory.utilization) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.vm.name",
-                "accountId": 0
-              }
+                "accountId": 0}
             ],
             "units": {
               "unit": "PERCENTAGE"
@@ -66,8 +64,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT average(vcenter.vm.disk.utilization) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.vm.name",
-                "accountId": 0
-              }
+                "accountId": 0}
             ],
             "units": {
               "unit": "PERCENTAGE"
@@ -89,8 +86,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT average(vcenter.vm.cpu.readiness) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.vm.name",
-                "accountId": 0
-              }
+                "accountId": 0}
             ],
             "units": {
               "unit": "PERCENTAGE"
@@ -127,8 +123,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT average(vcenter.vm.cpu.utilization) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.vm.name TIMESERIES AUTO",
-                "accountId": 0
-              }
+                "accountId": 0}
             ],
             "units": {
               "unit": "PERCENTAGE"
@@ -150,8 +145,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT average(vcenter.vm.cpu.usage) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.vm.name TIMESERIES AUTO",
-                "accountId": 0
-              }
+                "accountId": 0}
             ]
           }
         },
@@ -170,8 +164,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT average(vcenter.vm.cpu.readiness) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.vm.name TIMESERIES AUTO",
-                "accountId": 0
-              }
+                "accountId": 0}
             ],
             "units": {
               "unit": "PERCENTAGE"
@@ -208,8 +201,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT average(vcenter.vm.memory.utilization) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.vm.name TIMESERIES AUTO",
-                "accountId": 0
-              }
+                "accountId": 0}
             ],
             "units": {
               "unit": "PERCENTAGE"
@@ -231,8 +223,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT average(vcenter.vm.memory.usage) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.vm.name TIMESERIES AUTO",
-                "accountId": 0
-              }
+                "accountId": 0}
             ],
             "units": {
               "unit": "BYTES"
@@ -254,8 +245,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT average(vcenter.vm.memory.ballooned) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.vm.name TIMESERIES AUTO",
-                "accountId": 0
-              }
+                "accountId": 0}
             ],
             "units": {
               "unit": "BYTES"
@@ -277,8 +267,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT average(vcenter.vm.memory.swapped) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.vm.name TIMESERIES AUTO",
-                "accountId": 0
-              }
+                "accountId": 0}
             ],
             "units": {
               "unit": "BYTES"
@@ -315,8 +304,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT average(vcenter.vm.network.throughput) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.vm.name, direction TIMESERIES AUTO",
-                "accountId": 0
-              }
+                "accountId": 0}
             ],
             "units": {
               "unit": "BYTES_PER_SECOND"
@@ -338,8 +326,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT average(vcenter.vm.network.packet.rate) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.vm.name, direction TIMESERIES AUTO",
-                "accountId": 0
-              }
+                "accountId": 0}
             ]
           }
         },
@@ -358,8 +345,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT average(vcenter.vm.network.packet.drop.rate) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.vm.name, direction TIMESERIES AUTO",
-                "accountId": 0
-              }
+                "accountId": 0}
             ]
           }
         },
@@ -393,8 +379,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT average(vcenter.vm.disk.utilization) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.vm.name TIMESERIES AUTO",
-                "accountId": 0
-              }
+                "accountId": 0}
             ],
             "units": {
               "unit": "PERCENTAGE"
@@ -416,8 +401,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT average(vcenter.vm.disk.latency.avg) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.vm.name, direction TIMESERIES AUTO",
-                "accountId": 0
-              }
+                "accountId": 0}
             ]
           }
         },
@@ -436,8 +420,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT max(vcenter.vm.disk.latency.max) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.vm.name TIMESERIES AUTO",
-                "accountId": 0
-              }
+                "accountId": 0}
             ]
           }
         },
@@ -456,8 +439,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT average(vcenter.vm.disk.throughput) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.vm.name, direction TIMESERIES AUTO",
-                "accountId": 0
-              }
+                "accountId": 0}
             ]
           }
         },
@@ -476,8 +458,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT latest(vcenter.vm.disk.usage) / 1e9 WHERE instrumentation.provider = 'opentelemetry' AND disk_state = 'used' FACET vcenter.vm.name TIMESERIES AUTO",
-                "accountId": 0
-              }
+                "accountId": 0}
             ],
             "units": {
               "unit": "BYTES"
@@ -499,8 +480,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT latest(vcenter.vm.disk.usage) / 1e9 WHERE instrumentation.provider = 'opentelemetry' AND disk_state = 'available' FACET vcenter.vm.name TIMESERIES AUTO",
-                "accountId": 0
-              }
+                "accountId": 0}
             ],
             "units": {
               "unit": "BYTES"
@@ -537,8 +517,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT average(vcenter.vm.vsan.latency.avg) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.vm.name, type TIMESERIES AUTO",
-                "accountId": 0
-              }
+                "accountId": 0}
             ]
           }
         },
@@ -557,8 +536,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT average(vcenter.vm.vsan.operations) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.vm.name, type TIMESERIES AUTO",
-                "accountId": 0
-              }
+                "accountId": 0}
             ]
           }
         },
@@ -577,8 +555,7 @@
             "nrqlQueries": [
               {
                 "query": "FROM Metric SELECT average(vcenter.vm.vsan.throughput) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.vm.name, direction TIMESERIES AUTO",
-                "accountId": 0
-              }
+                "accountId": 0}
             ],
             "units": {
               "unit": "BYTES_PER_SECOND"

--- a/entity-types/infra-vspherevm/opentelemetry_dashboard.json
+++ b/entity-types/infra-vspherevm/opentelemetry_dashboard.json
@@ -1,0 +1,591 @@
+{
+  "name": "vSphere VM (OpenTelemetry)",
+  "pages": [
+    {
+      "name": "Overview",
+      "description": null,
+      "widgets": [
+        {
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "height": 3,
+            "width": 3
+          },
+          "title": "CPU utilization (%)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT average(vcenter.vm.cpu.utilization) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.vm.name",
+                "accountId": 0
+              }
+            ],
+            "units": {
+              "unit": "PERCENTAGE"
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "layout": {
+            "column": 4,
+            "row": 1,
+            "height": 3,
+            "width": 3
+          },
+          "title": "Memory utilization (%)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT average(vcenter.vm.memory.utilization) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.vm.name",
+                "accountId": 0
+              }
+            ],
+            "units": {
+              "unit": "PERCENTAGE"
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "layout": {
+            "column": 7,
+            "row": 1,
+            "height": 3,
+            "width": 3
+          },
+          "title": "Disk utilization (%)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT average(vcenter.vm.disk.utilization) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.vm.name",
+                "accountId": 0
+              }
+            ],
+            "units": {
+              "unit": "PERCENTAGE"
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "layout": {
+            "column": 10,
+            "row": 1,
+            "height": 3,
+            "width": 3
+          },
+          "title": "CPU readiness (%)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT average(vcenter.vm.cpu.readiness) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.vm.name",
+                "accountId": 0
+              }
+            ],
+            "units": {
+              "unit": "PERCENTAGE"
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.markdown"
+          },
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "height": 1,
+            "width": 12
+          },
+          "rawConfiguration": {
+            "text": "## CPU"
+          },
+          "title": ""
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 1,
+            "row": 5,
+            "height": 3,
+            "width": 4
+          },
+          "title": "CPU utilization (%)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT average(vcenter.vm.cpu.utilization) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.vm.name TIMESERIES AUTO",
+                "accountId": 0
+              }
+            ],
+            "units": {
+              "unit": "PERCENTAGE"
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 5,
+            "row": 5,
+            "height": 3,
+            "width": 4
+          },
+          "title": "CPU usage (MHz)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT average(vcenter.vm.cpu.usage) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.vm.name TIMESERIES AUTO",
+                "accountId": 0
+              }
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 9,
+            "row": 5,
+            "height": 3,
+            "width": 4
+          },
+          "title": "CPU readiness (%)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT average(vcenter.vm.cpu.readiness) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.vm.name TIMESERIES AUTO",
+                "accountId": 0
+              }
+            ],
+            "units": {
+              "unit": "PERCENTAGE"
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.markdown"
+          },
+          "layout": {
+            "column": 1,
+            "row": 8,
+            "height": 1,
+            "width": 12
+          },
+          "rawConfiguration": {
+            "text": "## Memory"
+          },
+          "title": ""
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 1,
+            "row": 9,
+            "height": 3,
+            "width": 3
+          },
+          "title": "Memory utilization (%)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT average(vcenter.vm.memory.utilization) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.vm.name TIMESERIES AUTO",
+                "accountId": 0
+              }
+            ],
+            "units": {
+              "unit": "PERCENTAGE"
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 4,
+            "row": 9,
+            "height": 3,
+            "width": 3
+          },
+          "title": "Memory usage (MiB)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT average(vcenter.vm.memory.usage) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.vm.name TIMESERIES AUTO",
+                "accountId": 0
+              }
+            ],
+            "units": {
+              "unit": "BYTES"
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 7,
+            "row": 9,
+            "height": 3,
+            "width": 3
+          },
+          "title": "Memory ballooned (MiB)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT average(vcenter.vm.memory.ballooned) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.vm.name TIMESERIES AUTO",
+                "accountId": 0
+              }
+            ],
+            "units": {
+              "unit": "BYTES"
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 10,
+            "row": 9,
+            "height": 3,
+            "width": 3
+          },
+          "title": "Memory swapped (MiB)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT average(vcenter.vm.memory.swapped) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.vm.name TIMESERIES AUTO",
+                "accountId": 0
+              }
+            ],
+            "units": {
+              "unit": "BYTES"
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.markdown"
+          },
+          "layout": {
+            "column": 1,
+            "row": 12,
+            "height": 1,
+            "width": 12
+          },
+          "rawConfiguration": {
+            "text": "## Network"
+          },
+          "title": ""
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 1,
+            "row": 13,
+            "height": 3,
+            "width": 4
+          },
+          "title": "Network throughput (By/s)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT average(vcenter.vm.network.throughput) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.vm.name, direction TIMESERIES AUTO",
+                "accountId": 0
+              }
+            ],
+            "units": {
+              "unit": "BYTES_PER_SECOND"
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 5,
+            "row": 13,
+            "height": 3,
+            "width": 4
+          },
+          "title": "Network packet rate (packets/s)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT average(vcenter.vm.network.packet.rate) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.vm.name, direction TIMESERIES AUTO",
+                "accountId": 0
+              }
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 9,
+            "row": 13,
+            "height": 3,
+            "width": 4
+          },
+          "title": "Network packet drops (packets/s)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT average(vcenter.vm.network.packet.drop.rate) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.vm.name, direction TIMESERIES AUTO",
+                "accountId": 0
+              }
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.markdown"
+          },
+          "layout": {
+            "column": 1,
+            "row": 16,
+            "height": 1,
+            "width": 12
+          },
+          "rawConfiguration": {
+            "text": "## Disk"
+          },
+          "title": ""
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 1,
+            "row": 17,
+            "height": 3,
+            "width": 3
+          },
+          "title": "Disk utilization (%)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT average(vcenter.vm.disk.utilization) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.vm.name TIMESERIES AUTO",
+                "accountId": 0
+              }
+            ],
+            "units": {
+              "unit": "PERCENTAGE"
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 4,
+            "row": 17,
+            "height": 3,
+            "width": 3
+          },
+          "title": "Disk latency avg (ms)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT average(vcenter.vm.disk.latency.avg) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.vm.name, direction TIMESERIES AUTO",
+                "accountId": 0
+              }
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 7,
+            "row": 17,
+            "height": 3,
+            "width": 3
+          },
+          "title": "Disk latency max (ms)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT max(vcenter.vm.disk.latency.max) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.vm.name TIMESERIES AUTO",
+                "accountId": 0
+              }
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 10,
+            "row": 17,
+            "height": 3,
+            "width": 3
+          },
+          "title": "Disk throughput (KiB/s)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT average(vcenter.vm.disk.throughput) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.vm.name, direction TIMESERIES AUTO",
+                "accountId": 0
+              }
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 1,
+            "row": 20,
+            "height": 3,
+            "width": 6
+          },
+          "title": "Disk usage - used (GiB)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT latest(vcenter.vm.disk.usage) / 1e9 WHERE instrumentation.provider = 'opentelemetry' AND disk_state = 'used' FACET vcenter.vm.name TIMESERIES AUTO",
+                "accountId": 0
+              }
+            ],
+            "units": {
+              "unit": "BYTES"
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 7,
+            "row": 20,
+            "height": 3,
+            "width": 6
+          },
+          "title": "Disk usage - available (GiB)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT latest(vcenter.vm.disk.usage) / 1e9 WHERE instrumentation.provider = 'opentelemetry' AND disk_state = 'available' FACET vcenter.vm.name TIMESERIES AUTO",
+                "accountId": 0
+              }
+            ],
+            "units": {
+              "unit": "BYTES"
+            }
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.markdown"
+          },
+          "layout": {
+            "column": 1,
+            "row": 23,
+            "height": 1,
+            "width": 12
+          },
+          "rawConfiguration": {
+            "text": "## vSAN"
+          },
+          "title": ""
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 1,
+            "row": 24,
+            "height": 3,
+            "width": 4
+          },
+          "title": "vSAN latency avg (\u00b5s)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT average(vcenter.vm.vsan.latency.avg) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.vm.name, type TIMESERIES AUTO",
+                "accountId": 0
+              }
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 5,
+            "row": 24,
+            "height": 3,
+            "width": 4
+          },
+          "title": "vSAN operations (ops/s)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT average(vcenter.vm.vsan.operations) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.vm.name, type TIMESERIES AUTO",
+                "accountId": 0
+              }
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 9,
+            "row": 24,
+            "height": 3,
+            "width": 4
+          },
+          "title": "vSAN throughput (By/s)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT average(vcenter.vm.vsan.throughput) WHERE instrumentation.provider = 'opentelemetry' FACET vcenter.vm.name, direction TIMESERIES AUTO",
+                "accountId": 0
+              }
+            ],
+            "units": {
+              "unit": "BYTES_PER_SECOND"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION

Add definition.stg.yml and opentelemetry_dashboard.json for:
- VSPHERECLUSTER
- VSPHEREDATACENTER
- VSPHEREDATASTORE
- VSPHEREHOST
- VSPHERERESOURCEPOOL
- VSPHEREVM

Each entity type includes:
- Two OTel synthesis rules (new/old collector library name formats) using vcenterreceiver resource attributes as identifiers
- OpenTelemetry dashboard with sectioned widgets covering CPU, Memory, Network, Disk, and vSAN metrics

### Relevant information

<!--
  Describe what you have done.
  Provide details that are relevant to the PR

  Always think that the person reviewing the PR doesn't have the context you have.

  Links to examples, documentation and similar resources make the process easier to review.
-->

<!--
  Contributions to this repository are reviewed at least twice a week

  There's no further action required once the PR has been created.
 -->

#### Api Review Board (ARB)

Any pull request with changes to this repository has to be linked with an ARB ticket, which has to be approved before merging.

If you are an external contributor please contact New Relic Support.

If you don't know about the ARB process check [this](https://newrelic.enterprise.slack.com/docs/T02D34WJD/F08AW240NSV)

ARB Jira ticket:
https://new-relic.atlassian.net/browse/NR-577516

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid.
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
* [ ] I've linked an ARB ticket & received approval from API Review Board in order to make these changes
