### PR TITLE
feat: Update SQL Server OTel dashboard layout and queries

### DIFF
--- a/entity-types/infra-mssqlinstance/newrelic_otel_sql_dashboard.stg.json
+++ b/entity-types/infra-mssqlinstance/newrelic_otel_sql_dashboard.stg.json
@@ -25,7 +25,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT latest(sqlserver.stats.connections or sqlserver.user.connection.count) AS 'Connections' FROM Metric WHERE metricName IN ('sqlserver.stats.connections', 'sqlserver.user.connection.count')"
+                "query": "SELECT latest(sqlserver.stats.connections OR sqlserver.user.connection.count) AS 'Connections' FROM Metric WHERE metricName IN ('sqlserver.stats.connections', 'sqlserver.user.connection.count')"
               }
             ],
             "platformOptions": {
@@ -66,7 +66,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT average(sqlserver.stats.connections or sqlserver.user.connection.count) AS 'User Connections' FROM Metric WHERE metricName IN ('sqlserver.stats.connections', 'sqlserver.user.connection.count') TIMESERIES AUTO"
+                "query": "SELECT average(sqlserver.stats.connections OR sqlserver.user.connection.count) AS 'User Connections' FROM Metric WHERE metricName IN ('sqlserver.stats.connections', 'sqlserver.user.connection.count') TIMESERIES AUTO"
               }
             ],
             "platformOptions": {
@@ -81,10 +81,57 @@
           }
         },
         {
-          "title": "Buffer Cache Hit Ratio Over Time",
+          "title": "Batch Requests / sec",
           "layout": {
             "column": 9,
             "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.area"
+          },
+          "rawConfiguration": {
+            "chartStyles": {
+              "gradient": {
+                "enabled": false
+              },
+              "lineInterpolation": "linear",
+              "stacked": {
+                "enabled": true
+              }
+            },
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "markers": {
+              "displayedTypes": {
+                "annotations": true,
+                "criticalViolations": false,
+                "deployments": true,
+                "relatedDeployments": true,
+                "warningViolations": false
+              }
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT derivative(sqlserver.batch.request.rate, 1 second) AS 'Batch req/sec' FROM Metric TIMESERIES AUTO"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "Buffer Cache Hit Ratio Over Time",
+          "layout": {
+            "column": 1,
+            "row": 4,
             "width": 4,
             "height": 3
           },
@@ -113,7 +160,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT average(sqlserver.instance.buffer_pool_hit_percent or sqlserver.page.buffer_cache.hit_ratio) AS 'Buffer Cache Hit %' FROM Metric WHERE metricName IN ('sqlserver.instance.buffer_pool_hit_percent', 'sqlserver.page.buffer_cache.hit_ratio') TIMESERIES AUTO"
+                "query": "SELECT average(sqlserver.instance.buffer_pool_hit_percent OR sqlserver.page.buffer_cache.hit_ratio) AS 'Buffer Cache Hit %' FROM Metric WHERE metricName IN ('sqlserver.instance.buffer_pool_hit_percent', 'sqlserver.page.buffer_cache.hit_ratio') TIMESERIES AUTO"
               }
             ],
             "platformOptions": {
@@ -130,9 +177,9 @@
         {
           "title": "Page Life Expectancy",
           "layout": {
-            "column": 1,
+            "column": 5,
             "row": 4,
-            "width": 6,
+            "width": 4,
             "height": 3
           },
           "visualization": {
@@ -160,7 +207,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT average(sqlserver.buffer.page_life_expectancy or sqlserver.page.life_expectancy) AS 'Page Life Expectancy (sec)' FROM Metric WHERE metricName IN ('sqlserver.buffer.page_life_expectancy', 'sqlserver.page.life_expectancy') TIMESERIES AUTO"
+                "query": "SELECT average(sqlserver.buffer.page_life_expectancy OR sqlserver.page.life_expectancy) AS 'Page Life Expectancy (sec)' FROM Metric WHERE metricName IN ('sqlserver.buffer.page_life_expectancy', 'sqlserver.page.life_expectancy') TIMESERIES AUTO"
               }
             ],
             "platformOptions": {
@@ -171,6 +218,499 @@
             },
             "yAxisRight": {
               "zero": true
+            }
+          }
+        },
+        {
+          "title": "Memory Grants Pending",
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.area"
+          },
+          "rawConfiguration": {
+            "chartStyles": {
+              "lineInterpolation": "linear"
+            },
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(sqlserver.memory.grants.pending.count) AS 'Pending Grants' FROM Metric TIMESERIES AUTO"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Memory Acquired vs Target (%)",
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.area"
+          },
+          "rawConfiguration": {
+            "chartStyles": {
+              "gradient": {
+                "enabled": false
+              },
+              "lineInterpolation": "linear",
+              "stacked": {
+                "enabled": true
+              }
+            },
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "markers": {
+              "displayedTypes": {
+                "annotations": true,
+                "criticalViolations": false,
+                "deployments": true,
+                "relatedDeployments": true,
+                "warningViolations": false
+              }
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT filter(latest(sqlserver.memory.area), WHERE memory.pool = 'total') / filter(latest(sqlserver.memory.area), WHERE memory.pool = 'target') * 100 AS 'Memory %' FROM Metric TIMESERIES AUTO"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "Memory Area by Pool",
+          "layout": {
+            "column": 7,
+            "row": 7,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.area"
+          },
+          "rawConfiguration": {
+            "chartStyles": {
+              "gradient": {
+                "enabled": false
+              },
+              "lineInterpolation": "linear",
+              "stacked": {
+                "enabled": true
+              }
+            },
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "markers": {
+              "displayedTypes": {
+                "annotations": true,
+                "criticalViolations": false,
+                "deployments": true,
+                "relatedDeployments": true,
+                "warningViolations": false
+              }
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(sqlserver.memory.area) FROM Metric FACET memory.pool TIMESERIES AUTO"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "Database Write Throughput (MB/s)",
+          "layout": {
+            "column": 1,
+            "row": 10,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.area"
+          },
+          "rawConfiguration": {
+            "chartStyles": {
+              "lineInterpolation": "linear"
+            },
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(sum(sqlserver.database.io), 1 second) / (1024*1024) AS 'Write MB/s' FROM Metric WHERE direction = 'write' FACET sqlserver.database.name TIMESERIES AUTO"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Database Read Throughput (MB/s)",
+          "layout": {
+            "column": 5,
+            "row": 10,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.area"
+          },
+          "rawConfiguration": {
+            "chartStyles": {
+              "lineInterpolation": "linear"
+            },
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT rate(sum(sqlserver.database.io), 1 second) / (1024*1024) AS 'Read MB/s' FROM Metric WHERE direction = 'read' FACET sqlserver.database.name TIMESERIES AUTO"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Database I/O Latency (avg ms per I/O)",
+          "layout": {
+            "column": 9,
+            "row": 10,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "chartStyles": {
+              "lineInterpolation": "linear"
+            },
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "markers": {
+              "displayedTypes": {
+                "annotations": true,
+                "criticalViolations": false,
+                "deployments": true,
+                "relatedDeployments": true,
+                "warningViolations": false
+              }
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT (sum(sqlserver.database.latency) / sum(sqlserver.database.operations)) * 1000 AS 'Avg I/O wait (ms per op)' FROM Metric FACET direction TIMESERIES AUTO"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            },
+            "yAxisRight": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Database Count by Status",
+          "layout": {
+            "column": 1,
+            "row": 13,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.bar"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(sqlserver.database.count) FROM Metric FACET database.status TIMESERIES AUTO"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "Database File Size",
+          "layout": {
+            "column": 7,
+            "row": 13,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.pie"
+          },
+          "rawConfiguration": {
+            "chartStyles": {
+              "gradient": {
+                "enabled": false
+              }
+            },
+            "facet": {
+              "showOtherSeries": true
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(sqlserver.database.file.size) / (1024*1024) AS 'Size (MB)' FROM Metric FACET sqlserver.database.name, file_type TIMESERIES AUTO"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "tempdb Space by State",
+          "layout": {
+            "column": 1,
+            "row": 16,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.area"
+          },
+          "rawConfiguration": {
+            "chartStyles": {
+              "lineInterpolation": "linear"
+            },
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(sqlserver.database.tempdb.space) / 1024 AS 'MB' FROM Metric FACET tempdb.state TIMESERIES AUTO"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "tempdb Version Store Size",
+          "layout": {
+            "column": 7,
+            "row": 16,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.area"
+          },
+          "rawConfiguration": {
+            "chartStyles": {
+              "lineInterpolation": "linear"
+            },
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(sqlserver.database.tempdb.version_store.size) / 1024 AS 'current MB', max(sqlserver.database.tempdb.version_store.size) / 1024 AS 'peak MB' FROM Metric TIMESERIES AUTO"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Blocked Processes",
+          "layout": {
+            "column": 1,
+            "row": 19,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.area"
+          },
+          "rawConfiguration": {
+            "chartStyles": {
+              "lineInterpolation": "linear"
+            },
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(sqlserver.processes.blocked) AS 'Blocked Processes' FROM Metric TIMESERIES AUTO"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Lock Wait Time",
+          "layout": {
+            "column": 5,
+            "row": 19,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.area"
+          },
+          "rawConfiguration": {
+            "chartStyles": {
+              "lineInterpolation": "linear"
+            },
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(sqlserver.os.wait.duration) AS 'Lock wait (s)' FROM Metric WHERE wait.category = 'Lock' TIMESERIES AUTO"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Deadlocks",
+          "layout": {
+            "column": 9,
+            "row": 19,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.area"
+          },
+          "rawConfiguration": {
+            "chartStyles": {
+              "gradient": {
+                "enabled": false
+              },
+              "lineInterpolation": "linear",
+              "stacked": {
+                "enabled": true
+              }
+            },
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "markers": {
+              "displayedTypes": {
+                "annotations": true,
+                "criticalViolations": false,
+                "deployments": true,
+                "relatedDeployments": true,
+                "warningViolations": false
+              }
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT derivative(sqlserver.deadlock.rate, 1 second) AS 'Total Deadlocks/sec' FROM Metric TIMESERIES AUTO"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
             }
           }
         }


### PR DESCRIPTION
  ## Summary

  Expands the OTel staging dashboard for `INFRA / MSSQLINSTANCE` entities from 4 to 18 widgets, adding visibility into batch throughput,
  memory pressure, per-database I/O, database state & storage, contention, and tempdb pressure.

  ## Metrics added

  | Widget | Visualization | Metric(s) |
  |---|---|---|
  | Batch Requests / sec | area | `sqlserver.batch.request.rate` |
  | Memory Grants Pending | area | `sqlserver.memory.grants.pending.count` |
  | Memory Acquired vs Target (%) | area | `sqlserver.memory.area` (filtered by `memory.pool`) |
  | Memory Area by Pool | area | `sqlserver.memory.area` (faceted by `memory.pool`) |
  | Database Write Throughput (MB/s) | area | `sqlserver.database.io` (`direction='write'`) |
  | Database Read Throughput (MB/s) | area | `sqlserver.database.io` (`direction='read'`) |
  | Database I/O Latency (avg ms per I/O) | line | `sqlserver.database.latency` / `sqlserver.database.operations` |
  | Database Count by Status | bar | `sqlserver.database.count` |
  | Database File Size | pie | `sqlserver.database.file.size` |
  | tempdb Space by State | area | `sqlserver.database.tempdb.space` |
  | tempdb Version Store Size | area | `sqlserver.database.tempdb.version_store.size` |
  | Blocked Processes | area | `sqlserver.processes.blocked` |
  | Lock Wait Time | area | `sqlserver.os.wait.duration` (`wait.category='Lock'`) |
  | Deadlocks | area | `sqlserver.deadlock.rate` |

ARB Jira ticket:
https://new-relic.atlassian.net/browse/NR-578964


  ## Notes

  - Staging dashboard only — production (`newrelic_otel_sql_dashboard.json`) is unchanged.
  - All queries use OTel-receiver metric names. Where the receiver renamed metrics across versions, both names are accepted via `OR` +
  `WHERE metricName IN (…)` for backward compatibility.
  - All widgets respect the dashboard's global time picker (no hardcoded `SINCE` clauses).

  ## Test plan

  - [x] `npm --prefix validator run check` — schema validation passes
  - [x] `npm --prefix validator run sanitize-dashboards` — sanitizer makes no changes
  - [x] Manual import of dashboard against a real OTel SQL Server entity in staging account — values render correctly across all 18
  widgets

  ## Related

  ARB doc: https://newrelic.atlassian.net/wiki/x/xYF8VQE