### PR TITLE
Add staging APM-to-MSSQLINSTANCE relationship by server.address and server.port

### DIFF
--- a/relationships/synthesis/APM-APPLICATION-to-INFRA-MSSQLINSTANCE.stg.yml
+++ b/relationships/synthesis/APM-APPLICATION-to-INFRA-MSSQLINSTANCE.stg.yml
@@ -1,0 +1,34 @@
+relationships:
+  # STAGING ONLY.
+  # APM native agent to INFRA MSSQLINSTANCE, resolved by database host + port.
+  # Native-agent datastore spans emit server.address and server.port describing the
+  # database connection target (DatastoreParameters.getHost()/getPort()), so the
+  # host+port candidate lookup resolves to a single MSSQL instance. This avoids the
+  # host.name-only fan-out where one host running multiple instances relates to all
+  # of them. Mirrors OTEL-APPLICATION-to-INFRA-MSSQLINSTANCE.yml, minus the
+  # OTLP-specific newrelic.source filter, since this targets native APM spans.
+  - name: apmApplicationCallsMssqlInstanceByHostPortStaging
+    version: "1"
+    origins:
+      - Distributed Tracing
+    conditions:
+      - attribute: db.system
+        anyOf: ["mssql"]
+      - attribute: server.address
+        present: true
+      - attribute: server.port
+        present: true
+    relationship:
+      expires: PT75M
+      relationshipType: CALLS
+      source:
+        extractGuid:
+          attribute: entity.guid
+      target:
+        lookupGuid:
+          candidateCategory: MSSQLINSTANCE
+          fields:
+            - field: serverAddress
+              attribute: server.address
+            - field: serverPort
+              attribute: server.port


### PR DESCRIPTION
## What

Adds a **staging-only** relationship synthesis rule that resolves the APM application → MSSQL instance relationship using the datastore connection's `server.address` + `server.port`, instead of `host.name` alone.

New file: `relationships/synthesis/APM-APPLICATION-to-INFRA-MSSQLINSTANCE.stg.yml`

## Why

The existing native-APM rule (`APM-APPLICATION-to-OTELMSSQLDATABASE.yml`) matches on `host.name` only. When one host runs multiple SQL Server instances, the candidate lookup (`onMultipleMatches: RELATE_ALL`) relates the application to **every** instance on that host, not just the one it actually talks to.

Native APM datastore spans emit `server.address` and `server.port` describing the database connection target (from `DatastoreParameters.getHost()/getPort()` — "the host where the datastore is located"). Keying the lookup on host + port resolves to a **single** instance via the existing `MSSQLINSTANCE` candidate's `matchingMode: ALL` branch.

This mirrors `OTEL-APPLICATION-to-INFRA-MSSQLINSTANCE.yml`, minus the OTLP-specific `newrelic.source` filter, since this targets native APM spans.

## Staging-first

Shipped as `.stg.yml` so it is evaluated in staging only. The `conditions` block (`db.system: mssql`) needs validation against real native-APM span data before a production `.yml` rule is added. The existing production rule is left unchanged.

## Validation

- `ajv` schema validation against `relationship-synthesis-schema-v1.json`: **valid**
- `validate_relationship_synthesis_rules.js`: **pass** (exit 0)