### PR TITLE
feat: Add AZUREPOWERPLATFORMMONITORINGHUBPOWERAPPS entity definition

### DIFF
--- a/entity-types/infra-azurepowerplatformmonitoringhubpowerapps/definition.yml
+++ b/entity-types/infra-azurepowerplatformmonitoringhubpowerapps/definition.yml
@@ -1,0 +1,31 @@
+domain: INFRA
+type: AZUREPOWERPLATFORMMONITORINGHUBPOWERAPPS
+goldenTags:
+  - azure.regionName
+  - azure.subscriptionId
+  - azure.resourceGroupName
+  - azure.type
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+synthesis:
+  rules:
+    - ruleName: infra_azurepowerplatformmonitoringhubpowerapps_azure_resourceId
+      identifier: azure.resourceId
+      name: displayName
+      tags:
+        newrelic.cloudIntegrations.providerAccountName:
+          entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
+        azure.resourceGroupName:
+        azure.regionName:
+        azure.subscriptionId:
+      legacyFeatures:
+        overrideGuidType: true
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: azure.resourceType
+          value: microsoft.powerplatformmonitoringhub/powerapps
+
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-azurepowerplatformmonitoringhubpowerapps/golden_metrics.yml
+++ b/entity-types/infra-azurepowerplatformmonitoringhubpowerapps/golden_metrics.yml
@@ -1,0 +1,27 @@
+appLaunchCount:
+  title: App Launch Count
+  unit: COUNT
+  queries:
+    azure:
+      select: sum(azure.powerplatformmonitoringhub.powerapps.powerapps.app_launch_count)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+dataRequests:
+  title: Data Requests
+  unit: COUNT
+  queries:
+    azure:
+      select: sum(azure.powerplatformmonitoringhub.powerapps.powerapps.data_requests)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+timeToInteractive:
+  title: Time To Interactive
+  unit: MS
+  queries:
+    azure:
+      select: average(azure.powerplatformmonitoringhub.powerapps.powerapps.time_to_interactive)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-azurepowerplatformmonitoringhubpowerapps/summary_metrics.yml
+++ b/entity-types/infra-azurepowerplatformmonitoringhubpowerapps/summary_metrics.yml
@@ -1,0 +1,17 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: Azure account
+  unit: STRING
+appLaunchCount:
+  goldenMetric: appLaunchCount
+  unit: COUNT
+  title: App Launch Count
+dataRequests:
+  goldenMetric: dataRequests
+  unit: COUNT
+  title: Data Requests
+timeToInteractive:
+  goldenMetric: timeToInteractive
+  unit: MS
+  title: Time To Interactive


### PR DESCRIPTION
## Summary
Adds the **Azure Power Platform Monitoring Hub – Power Apps** infrastructure entity (`microsoft.powerplatformmonitoringhub/powerapps`).

ARB - https://new-relic.atlassian.net/browse/NR-551510

## Files
- `entity-types/infra-azurepowerplatformmonitoringhubpowerapps/definition.yml` — synthesis on `azure.resourceType = microsoft.powerplatformmonitoringhub/powerapps`, 4 golden tags
- `entity-types/infra-azurepowerplatformmonitoringhubpowerapps/golden_metrics.yml` — App Launch Count, Data Requests, Time To Interactive
- `entity-types/infra-azurepowerplatformmonitoringhubpowerapps/summary_metrics.yml`

## Metric verification
Metric names taken verbatim from the [Azure Monitor supported-metrics docs](https://learn.microsoft.com/en-us/azure/azure-monitor/reference/supported-metrics/microsoft-powerplatformmonitoringhub-powerapps-metrics) and formatted as `azure.{namespace}.{resourcetype}.{RESTAPIName}` per existing conventions (e.g. `infra-azurecontainerapps`, `infra-azurepowerbidedicatedcapacity`).

> Note: this is a brand-new resource type with no telemetry ingested in NR yet, so the `azure.*` metric names could not be cross-checked against live data and were derived from the docs + naming convention. Please confirm the ingested metric prefix once data flows.

## Test
Selected golden metrics reference only metric names present in the verified docs list.
