### PR TITLE
feat: Add AZUREPOWERPLATFORMMONITORINGHUBPOWERAUTOMATE entity definition

### DIFF
--- a/entity-types/infra-azurepowerplatformmonitoringhubpowerautomate/definition.yml
+++ b/entity-types/infra-azurepowerplatformmonitoringhubpowerautomate/definition.yml
@@ -1,0 +1,31 @@
+domain: INFRA
+type: AZUREPOWERPLATFORMMONITORINGHUBPOWERAUTOMATE
+goldenTags:
+  - azure.regionName
+  - azure.subscriptionId
+  - azure.resourceGroupName
+  - azure.type
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+synthesis:
+  rules:
+    - ruleName: infra_azurepowerplatformmonitoringhubpowerautomate_azure_resourceId
+      identifier: azure.resourceId
+      name: displayName
+      tags:
+        newrelic.cloudIntegrations.providerAccountName:
+          entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
+        azure.resourceGroupName:
+        azure.regionName:
+        azure.subscriptionId:
+      legacyFeatures:
+        overrideGuidType: true
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: azure.resourceType
+          value: microsoft.powerplatformmonitoringhub/powerautomate
+
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-azurepowerplatformmonitoringhubpowerautomate/golden_metrics.yml
+++ b/entity-types/infra-azurepowerplatformmonitoringhubpowerautomate/golden_metrics.yml
@@ -1,0 +1,27 @@
+cloudFlowRuns:
+  title: Cloud Flow Runs
+  unit: COUNT
+  queries:
+    azure:
+      select: sum(azure.powerplatformmonitoringhub.powerautomate.cloudflow.run)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+desktopFlowRuns:
+  title: Desktop Flow Runs
+  unit: COUNT
+  queries:
+    azure:
+      select: sum(azure.powerplatformmonitoringhub.powerautomate.desktopflow.run)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+workqueueOutOfSla:
+  title: Workqueue Out of SLA
+  unit: COUNT
+  queries:
+    azure:
+      select: sum(azure.powerplatformmonitoringhub.powerautomate.workqueue.out_of_sla)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-azurepowerplatformmonitoringhubpowerautomate/summary_metrics.yml
+++ b/entity-types/infra-azurepowerplatformmonitoringhubpowerautomate/summary_metrics.yml
@@ -1,0 +1,17 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: Azure account
+  unit: STRING
+cloudFlowRuns:
+  goldenMetric: cloudFlowRuns
+  unit: COUNT
+  title: Cloud Flow Runs
+desktopFlowRuns:
+  goldenMetric: desktopFlowRuns
+  unit: COUNT
+  title: Desktop Flow Runs
+workqueueOutOfSla:
+  goldenMetric: workqueueOutOfSla
+  unit: COUNT
+  title: Workqueue Out of SLA


### PR DESCRIPTION
## Summary
Adds the **Azure Power Platform Monitoring Hub – Power Automate** infrastructure entity (`microsoft.powerplatformmonitoringhub/powerautomate`).

ARB - https://new-relic.atlassian.net/browse/NR-551510

## Files
- `entity-types/infra-azurepowerplatformmonitoringhubpowerautomate/definition.yml` — synthesis on `azure.resourceType = microsoft.powerplatformmonitoringhub/powerautomate`, 4 golden tags
- `entity-types/infra-azurepowerplatformmonitoringhubpowerautomate/golden_metrics.yml` — Cloud Flow Runs, Desktop Flow Runs, Workqueue Out of SLA
- `entity-types/infra-azurepowerplatformmonitoringhubpowerautomate/summary_metrics.yml`

## Metric verification
Metric names taken verbatim from the [Azure Monitor supported-metrics docs](https://learn.microsoft.com/en-us/azure/azure-monitor/reference/supported-metrics/microsoft-powerplatformmonitoringhub-powerautomate-metrics) and formatted as `azure.{namespace}.{resourcetype}.{RESTAPIName}` per existing conventions (e.g. `infra-azurecontainerapps`, `infra-azurepowerbidedicatedcapacity`).

> Note: this is a brand-new resource type with no telemetry ingested in NR yet, so the `azure.*` metric names could not be cross-checked against live data and were derived from the docs + naming convention. Please confirm the ingested metric prefix once data flows.

## Test
Selected golden metrics reference only metric names present in the verified docs list.
