### PR TITLE
fix(mysqlnode): remove dead otel.library.name synthesis check

### DIFF
--- a/entity-types/infra-mysqlnode/definition.yml
+++ b/entity-types/infra-mysqlnode/definition.yml
@@ -15,10 +15,6 @@ synthesis:
           prefix: mysql.
         - attribute: instrumentation.provider
           value: opentelemetry
-        # This filters only metrics coming from mysqlreceiver , given that metrics
-        # could differ between different runtime receivers.
-        - attribute: otel.library.name
-          value: otelcol/mysqlreceiver
       tags:
         # Environment resource attributes
         host.type:
@@ -74,4 +70,4 @@ dashboardTemplates:
 
 ownership:
   primaryOwner:
-    teamName: "no owner"
+    teamName: "Database Integrations"


### PR DESCRIPTION
Bug fix: Similar to #2953 (for `infra-postgresqlinstance`) we need to remove the **broken** check on the otel.library.name value that is no longer emitted from modern OTel Collectors.

I'm using the opportunity to also set the owner.