### PR TITLE
docs(readme): drop stale stg rule-rename requirement; rename mislabeled prod MSSQL rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ It is also possible to test new definitions by adding `.stg` suffix to its files
 
 Required validation steps:
 1. Ensure no file references are broken by override
-2. Verify override rule identifiers are different from originals (e.g. mySuperRule -> mySuperRuleStgOverride)
+2. New rules require new names, but existing rule identifiers can now stay the same as in the originals that they replace. (`.stg` file name uniqueness is no longer required against its own original.)
 3. If override changes file enough, you might need to consider adding a new definition / rule
 
 > [!NOTE]  

--- a/relationships/synthesis/APM-APPLICATION-to-INFRA-MSSQLINSTANCE.yml
+++ b/relationships/synthesis/APM-APPLICATION-to-INFRA-MSSQLINSTANCE.yml
@@ -33,7 +33,7 @@ relationships:
                   - operation: toLowerCase
             hashAlgorithm: FARM_HASH
 
-  - name: apmApplicationCallsInfraMSSQLInstanceTimesliceStaging
+  - name: apmApplicationCallsInfraMSSQLInstanceTimeslice
     version: "1"
     origins:
       - APM Metrics


### PR DESCRIPTION
Follow-up to #2942.

1. **README** — remove the staging-override step that previously told contributors to give override rules a *different* identifier (e.g. `mySuperRule -> mySuperRuleStgOverride`).

2. fix one production rule, where the Staging name had slipped out.
