### PR TITLE
fix(postgresqlinstance): per-second OTel bgwriter golden metrics (staging)

### DIFF
--- a/entity-types/infra-postgresqlinstance/golden_metrics.stg.yml
+++ b/entity-types/infra-postgresqlinstance/golden_metrics.stg.yml
@@ -8,7 +8,7 @@ scheduledCheckpoints:
       eventId: entityGuid
       eventName: entityName
     opentelemetry:
-      select: average(postgresql.bgwriter.checkpoint.count)
+      select: sum(postgresql.bgwriter.checkpoint.count) / sum((endTimestamp - timestamp) / 1000)
       from: Metric
       where: type = 'scheduled'
 
@@ -22,7 +22,7 @@ requestedCheckpoints:
       eventId: entityGuid
       eventName: entityName
     opentelemetry:
-      select: average(postgresql.bgwriter.checkpoint.count)
+      select: sum(postgresql.bgwriter.checkpoint.count) / sum((endTimestamp - timestamp) / 1000)
       from: Metric
       where: type = 'requested'
 
@@ -36,5 +36,5 @@ buffersAllocated:
       eventId: entityGuid
       eventName: entityName
     opentelemetry:
-      select: average(postgresql.bgwriter.buffers.allocated)
+      select: sum(postgresql.bgwriter.buffers.allocated) / sum((endTimestamp - timestamp) / 1000)
       from: Metric


### PR DESCRIPTION
Staging-only (`.stg`) fix to the three OpenTelemetry PostgreSQL golden metrics

Many thanks to the nr:review-api-skill to point out to me that the golden metrics had a mismatch (cumulative counter versus per-second rate).