### PR TITLE
docs(infra-container): mark Sample-based synthesis active (reverse #2126)

### DIFF
--- a/entity-types/infra-container/definition.yml
+++ b/entity-types/infra-container/definition.yml
@@ -473,7 +473,7 @@ synthesis:
       tags.:
         ttl: P1D
 
-  # Docker Container from Samples - NOT in use yet - see FF EntitySynthesis/ExtractEntityFromInfraTelemetry
+  # Docker Container from Samples - active (FF EntitySynthesis/ExtractEntityFromInfraTelemetry enabled for INFRA-CONTAINER, 2026-04)
   - ruleName: infra_container_entityId
     identifier: entityId
     name: name
@@ -535,7 +535,7 @@ synthesis:
         entityTagName: aws.region
     prefixedTags:
       label.:
-  # K8s Container from Samples - NOT in use yet - see FF EntitySynthesis/ExtractEntityFromInfraTelemetry
+  # K8s Container from Samples - active (FF EntitySynthesis/ExtractEntityFromInfraTelemetry enabled for INFRA-CONTAINER, 2026-04)
   - ruleName: infra_container_entityId_2
     identifier: entityId
     name: containerName


### PR DESCRIPTION
Pure comment clarification on infra-container based on Infra Samples from "NOT in use yet" to "active".
