### PR TITLE
feat(haproxy): Add HAProxy OTel entity synthesis for prometheus and logs mapping

### DIFF
--- a/entity-types/infra-haproxyinstance/definition.stg.yml
+++ b/entity-types/infra-haproxyinstance/definition.stg.yml
@@ -108,6 +108,134 @@ synthesis:
       otel.library.name:
         entityTagName: instrumentation.name
 
+  # Prometheus receiver synthesis rule
+  # For metrics collected via the OTel Collector's prometheusreceiver scraping HAProxy's
+  # built-in /metrics endpoint. The metricstransform processor renames metrics to haproxy.*
+  # and adds haproxy.addr as a resource attribute.
+  - ruleName: infra_haproxyinstance_otel_prometheus
+    compositeIdentifier:
+      separator: ":"
+      attributes:
+        - host.id
+        - haproxy.addr
+    name: host.name
+    encodeIdentifierInGUID: true
+    conditions:
+      - attribute: eventType
+        value: Metric
+      - attribute: metricName
+        prefix: haproxy.
+      - attribute: instrumentation.provider
+        value: opentelemetry
+      - attribute: host.id
+        present: true
+      - attribute: haproxy.addr
+        present: true
+      - attribute: otel.library.name
+        value: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver"
+    tags:
+      host.name:
+        ttl: P1D
+      haproxy.addr:
+      haproxy.proxy_name:
+      haproxy.service_name:
+      os.type:
+      host.id:
+        ttl: P1D
+      host.type:
+      cloud.provider:
+      cloud.account.id:
+      cloud.region:
+      k8s.cluster.name:
+        ttl: P1D
+      k8s.namespace.name:
+        ttl: P1D
+      k8s.pod.name:
+        ttl: P1D
+      k8s.node.name:
+        ttl: P1D
+      otel.library.name:
+        entityTagName: instrumentation.name
+
+  # Prometheus receiver with old otel.library.name format
+  - ruleName: infra_haproxyinstance_otel_prometheus_old
+    compositeIdentifier:
+      separator: ":"
+      attributes:
+        - host.id
+        - haproxy.addr
+    name: host.name
+    encodeIdentifierInGUID: true
+    conditions:
+      - attribute: eventType
+        value: Metric
+      - attribute: metricName
+        prefix: haproxy.
+      - attribute: instrumentation.provider
+        value: opentelemetry
+      - attribute: host.id
+        present: true
+      - attribute: haproxy.addr
+        present: true
+      - attribute: otel.library.name
+        value: "otelcol/prometheusreceiver"
+    tags:
+      host.name:
+        ttl: P1D
+      haproxy.addr:
+      haproxy.proxy_name:
+      haproxy.service_name:
+      os.type:
+      host.id:
+        ttl: P1D
+      host.type:
+      cloud.provider:
+      cloud.account.id:
+      cloud.region:
+      k8s.cluster.name:
+        ttl: P1D
+      k8s.namespace.name:
+        ttl: P1D
+      k8s.pod.name:
+        ttl: P1D
+      k8s.node.name:
+        ttl: P1D
+      otel.library.name:
+        entityTagName: instrumentation.name
+
+  # OpenTelemetry Log synthesis rule
+  # Allows logs forwarded via the OTel Collector's filelog receiver to be associated with
+  # the HAProxy entity. Without this rule, logs only appear on the HOST entity's Logs page.
+  # Requires: resourcedetection processor (adds host.id) + resource processor (adds haproxy.addr)
+  - ruleName: infra_haproxyinstance_otel_logs
+    compositeIdentifier:
+      separator: ":"
+      attributes:
+        - host.id
+        - haproxy.addr
+    name: host.name
+    encodeIdentifierInGUID: true
+    conditions:
+      - attribute: eventType
+        value: Log
+      - attribute: newrelic.source
+        value: 'api.logs.otlp'
+      - attribute: instrumentation.provider
+        value: opentelemetry
+      - attribute: host.id
+        present: true
+      - attribute: haproxy.addr
+        present: true
+    tags:
+      host.name:
+        ttl: P1D
+      haproxy.addr:
+      host.id:
+        ttl: P1D
+      os.type:
+      otel.library.name:
+        entityTagName: instrumentation.name
+
   # Fallback: haproxy.instance.id pattern (new collector format)
   # For users who explicitly set haproxy.instance.id via a resource processor when host.id is unavailable.
   # This is a customer-chosen, stable identifier (e.g., "prod-haproxy-east-1").

--- a/entity-types/infra-haproxyinstance/tests/Metric.stg.json
+++ b/entity-types/infra-haproxyinstance/tests/Metric.stg.json
@@ -78,6 +78,29 @@
   },
   {
     "eventType": "Metric",
+    "host.name": "ip-172-31-3-206.ap-southeast-2.compute.internal",
+    "host.id": "ec25749b118fcc80c9c69b6c22f314a7",
+    "os.type": "linux",
+    "haproxy.addr": "http://localhost:8404/stats",
+    "haproxy.proxy_name": "web_servers",
+    "haproxy.service_name": "BACKEND",
+    "instrumentation.provider": "opentelemetry",
+    "metricName": "haproxy.sessions.count",
+    "newrelic.source": "api.metrics.otlp",
+    "otel.library.name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+    "otel.library.version": "0.154.0",
+    "haproxy.sessions.count": {
+      "type": "gauge",
+      "count": 1,
+      "sum": 3,
+      "min": 3,
+      "max": 3,
+      "latest": 3
+    },
+    "timestamp": 1781912376000
+  },
+  {
+    "eventType": "Metric",
     "haproxy.instance.id": "prod-haproxy-east-1",
     "host.name": "lb-server-01",
     "haproxy.addr": "http://127.0.0.1:8404/stats",

--- a/relationships/synthesis/INFRA-CONTAINER-to-INFRA-HAPROXYINSTANCE.stg.yml
+++ b/relationships/synthesis/INFRA-CONTAINER-to-INFRA-HAPROXYINSTANCE.stg.yml
@@ -1,0 +1,173 @@
+relationships:
+  # Rule 1: OTel HAProxy in Docker (non-K8s) → OTel Container (dockerstats receiver)
+  # When HAProxy runs in Docker and the collector has container.id from Docker resource detection.
+  - name: OtelHaproxyInstanceToOtelDockerContainerStg
+    version: "1"
+    origins:
+      - OpenTelemetry
+    conditions:
+      - attribute: eventType
+        anyOf: ["Metric", "Log"]
+      - attribute: instrumentation.provider
+        anyOf: ["opentelemetry"]
+      - attribute: entity.type
+        anyOf: ["HAPROXYINSTANCE"]
+      - attribute: container.id
+        present: true
+      - attribute: k8s.pod.name
+        present: false
+    relationship:
+      expires: PT75M
+      relationshipType: IS
+      source:
+        buildGuid:
+          account:
+            attribute: accountId
+          domain:
+            value: INFRA
+          type:
+            value: CONTAINER
+          identifier:
+            fragments:
+              - attribute: container.id
+            hashAlgorithm: FARM_HASH
+      target:
+        extractGuid:
+          attribute: entity.guid
+          entityType:
+            attribute: entity.type
+
+  # Rule 2: OTel HAProxy in Docker (non-K8s) → NR native Docker Container (ContainerSample)
+  - name: OtelHaproxyInstanceToNrDockerContainerStg
+    version: "1"
+    origins:
+      - OpenTelemetry
+    conditions:
+      - attribute: eventType
+        anyOf: ["Metric", "Log"]
+      - attribute: instrumentation.provider
+        anyOf: ["opentelemetry"]
+      - attribute: entity.type
+        anyOf: ["HAPROXYINSTANCE"]
+      - attribute: container.id
+        present: true
+      - attribute: k8s.pod.name
+        present: false
+    relationship:
+      expires: PT75M
+      relationshipType: IS
+      source:
+        buildGuid:
+          account:
+            attribute: accountId
+          domain:
+            value: INFRA
+          type:
+            value: CONTAINER
+            valueInGuid: NA
+          identifier:
+            fragments:
+              - value: "docker:"
+              - attribute: container.id
+            hashAlgorithm: FARM_HASH
+      target:
+        extractGuid:
+          attribute: entity.guid
+          entityType:
+            attribute: entity.type
+
+  # Rule 3: OTel HAProxy in K8s → OTel K8s Container (kube-state-metrics / cAdvisor / kubeletstats)
+  - name: OtelHaproxyInstanceToOtelK8sContainerStg
+    version: "1"
+    origins:
+      - OpenTelemetry
+    conditions:
+      - attribute: eventType
+        anyOf: ["Metric", "Log"]
+      - attribute: instrumentation.provider
+        anyOf: ["opentelemetry"]
+      - attribute: entity.type
+        anyOf: ["HAPROXYINSTANCE"]
+      - attribute: k8s.cluster.name
+        present: true
+      - attribute: k8s.namespace.name
+        present: true
+      - attribute: k8s.pod.name
+        present: true
+      - attribute: k8s.container.name
+        present: true
+    relationship:
+      expires: PT75M
+      relationshipType: IS
+      source:
+        buildGuid:
+          account:
+            attribute: accountId
+          domain:
+            value: INFRA
+          type:
+            value: CONTAINER
+          identifier:
+            fragments:
+              - attribute: k8s.cluster.name
+              - value: ":"
+              - attribute: k8s.namespace.name
+              - value: ":"
+              - attribute: k8s.pod.name
+              - value: ":"
+              - attribute: k8s.container.name
+            hashAlgorithm: FARM_HASH
+      target:
+        extractGuid:
+          attribute: entity.guid
+          entityType:
+            attribute: entity.type
+
+  # Rule 4: OTel HAProxy in K8s → NR native K8s Container (K8sContainerSample)
+  - name: OtelHaproxyInstanceToNrK8sContainerStg
+    version: "1"
+    origins:
+      - OpenTelemetry
+    conditions:
+      - attribute: eventType
+        anyOf: ["Metric", "Log"]
+      - attribute: instrumentation.provider
+        anyOf: ["opentelemetry"]
+      - attribute: entity.type
+        anyOf: ["HAPROXYINSTANCE"]
+      - attribute: k8s.cluster.name
+        present: true
+      - attribute: k8s.namespace.name
+        present: true
+      - attribute: k8s.pod.name
+        present: true
+      - attribute: k8s.container.name
+        present: true
+    relationship:
+      expires: PT75M
+      relationshipType: IS
+      source:
+        buildGuid:
+          account:
+            attribute: accountId
+          domain:
+            value: INFRA
+          type:
+            value: CONTAINER
+            valueInGuid: NA
+          identifier:
+            fragments:
+              - value: "k8s:"
+              - attribute: k8s.cluster.name
+              - value: ":"
+              - attribute: k8s.namespace.name
+              - value: ":"
+              - attribute: k8s.pod.name
+              - value: ":container:"
+              - attribute: k8s.container.name
+            hashAlgorithm: FARM_HASH
+      target:
+        extractGuid:
+          attribute: entity.guid
+          entityType:
+            attribute: entity.type

--- a/relationships/synthesis/INFRA-HOST-to-INFRA-HAPROXYINSTANCE.stg.yml
+++ b/relationships/synthesis/INFRA-HOST-to-INFRA-HAPROXYINSTANCE.stg.yml
@@ -16,6 +16,8 @@ relationships:
         anyOf: ["opentelemetry"]
       - attribute: host.id
         present: true
+      - attribute: k8s.pod.name
+        present: false
     relationship:
       expires: PT75M
       relationshipType: HOSTS

--- a/relationships/synthesis/INFRA-HOST-to-INFRA-HAPROXYINSTANCE.stg.yml
+++ b/relationships/synthesis/INFRA-HOST-to-INFRA-HAPROXYINSTANCE.stg.yml
@@ -16,8 +16,6 @@ relationships:
         anyOf: ["opentelemetry"]
       - attribute: host.id
         present: true
-      - attribute: k8s.pod.name
-        present: false
     relationship:
       expires: PT75M
       relationshipType: HOSTS


### PR DESCRIPTION
### Relevant information

Adds complete entity definitions for HAProxy monitoring via OpenTelemetry, including:
                                                                                                                                                                      
                                                                        
  - Entity synthesis rules for Prometheus receiver (new + old format)                                                                                                 
  - Log synthesis rule (associates filelog-forwarded HAProxy logs with the entity)   

#### Api Review Board (ARB)

Any pull request with changes to this repository has to be linked with an ARB ticket, which has to be approved before merging.

If you are an external contributor please contact New Relic Support.

If you don't know about the ARB process check [this](https://newrelic.enterprise.slack.com/docs/T02D34WJD/F08AW240NSV)

ARB Jira ticket:
https://new-relic.atlassian.net/browse/NR-567749

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid.
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
* [ ] I've linked an ARB ticket & received approval from API Review Board in order to make these changes
