### PR TITLE
feat: add GCPFIRESTOREINSTANCE entity definition

### DIFF
--- a/entity-types/infra-gcpfirestoreinstance/dashboard.json
+++ b/entity-types/infra-gcpfirestoreinstance/dashboard.json
@@ -24,7 +24,7 @@
           "visualization": {"id": "viz.line"},
           "rawConfiguration": {
             "facet": {"showOtherSeries": false}, "legend": {"enabled": true},
-            "nrqlQueries": [{"accountId": 0, "query": "FROM Metric SELECT sum(`gcp.firestore.document.write_ops_count`) AS 'Writes' WHERE `entity.guid` = '{{entity.guid}}' TIMESERIES AUTO"}],
+            "nrqlQueries": [{"accountId": 0, "query": "FROM Metric SELECT sum(`gcp.firestore.document.write_count`) AS 'Writes' WHERE `entity.guid` = '{{entity.guid}}' TIMESERIES AUTO"}],
             "yAxisLeft": {"zero": true}
           }
         },

--- a/entity-types/infra-gcpfirestoreinstance/dashboard.json
+++ b/entity-types/infra-gcpfirestoreinstance/dashboard.json
@@ -1,0 +1,89 @@
+{
+  "name": "GCP Firestore Instance",
+  "description": null,
+  "pages": [
+    {
+      "name": "GCP Firestore Instance",
+      "description": null,
+      "widgets": [
+        {
+          "title": "Document Reads",
+          "layout": {"column": 1, "row": 1, "width": 4, "height": 3},
+          "linkedEntityGuids": null,
+          "visualization": {"id": "viz.line"},
+          "rawConfiguration": {
+            "facet": {"showOtherSeries": false}, "legend": {"enabled": true},
+            "nrqlQueries": [{"accountId": 0, "query": "FROM Metric SELECT sum(`gcp.firestore.document.read_count`) AS 'Reads' WHERE `entity.guid` = '{{entity.guid}}' TIMESERIES AUTO"}],
+            "yAxisLeft": {"zero": true}
+          }
+        },
+        {
+          "title": "Document Writes",
+          "layout": {"column": 5, "row": 1, "width": 4, "height": 3},
+          "linkedEntityGuids": null,
+          "visualization": {"id": "viz.line"},
+          "rawConfiguration": {
+            "facet": {"showOtherSeries": false}, "legend": {"enabled": true},
+            "nrqlQueries": [{"accountId": 0, "query": "FROM Metric SELECT sum(`gcp.firestore.document.write_count`) AS 'Writes' WHERE `entity.guid` = '{{entity.guid}}' TIMESERIES AUTO"}],
+            "yAxisLeft": {"zero": true}
+          }
+        },
+        {
+          "title": "Document Deletes",
+          "layout": {"column": 9, "row": 1, "width": 4, "height": 3},
+          "linkedEntityGuids": null,
+          "visualization": {"id": "viz.line"},
+          "rawConfiguration": {
+            "facet": {"showOtherSeries": false}, "legend": {"enabled": true},
+            "nrqlQueries": [{"accountId": 0, "query": "FROM Metric SELECT sum(`gcp.firestore.document.delete_count`) AS 'Deletes' WHERE `entity.guid` = '{{entity.guid}}' TIMESERIES AUTO"}],
+            "yAxisLeft": {"zero": true}
+          }
+        },
+        {
+          "title": "Active Connections",
+          "layout": {"column": 1, "row": 4, "width": 4, "height": 3},
+          "linkedEntityGuids": null,
+          "visualization": {"id": "viz.line"},
+          "rawConfiguration": {
+            "facet": {"showOtherSeries": false}, "legend": {"enabled": true},
+            "nrqlQueries": [{"accountId": 0, "query": "FROM Metric SELECT average(`gcp.firestore.network.active_connections`) AS 'Connections' WHERE `entity.guid` = '{{entity.guid}}' TIMESERIES AUTO"}],
+            "yAxisLeft": {"zero": true}
+          }
+        },
+        {
+          "title": "Snapshot Listeners",
+          "layout": {"column": 5, "row": 4, "width": 4, "height": 3},
+          "linkedEntityGuids": null,
+          "visualization": {"id": "viz.line"},
+          "rawConfiguration": {
+            "facet": {"showOtherSeries": false}, "legend": {"enabled": true},
+            "nrqlQueries": [{"accountId": 0, "query": "FROM Metric SELECT average(`gcp.firestore.network.snapshot_listeners`) AS 'Listeners' WHERE `entity.guid` = '{{entity.guid}}' TIMESERIES AUTO"}],
+            "yAxisLeft": {"zero": true}
+          }
+        },
+        {
+          "title": "Security Rule Evaluations",
+          "layout": {"column": 9, "row": 4, "width": 4, "height": 3},
+          "linkedEntityGuids": null,
+          "visualization": {"id": "viz.line"},
+          "rawConfiguration": {
+            "facet": {"showOtherSeries": false}, "legend": {"enabled": true},
+            "nrqlQueries": [{"accountId": 0, "query": "FROM Metric SELECT sum(`gcp.firestore.rules.evaluation_count`) AS 'Evaluations' WHERE `entity.guid` = '{{entity.guid}}' FACET `metric.result` TIMESERIES AUTO"}],
+            "yAxisLeft": {"zero": true}
+          }
+        },
+        {
+          "title": "TTL Deletions",
+          "layout": {"column": 1, "row": 7, "width": 4, "height": 3},
+          "linkedEntityGuids": null,
+          "visualization": {"id": "viz.line"},
+          "rawConfiguration": {
+            "facet": {"showOtherSeries": false}, "legend": {"enabled": true},
+            "nrqlQueries": [{"accountId": 0, "query": "FROM Metric SELECT sum(`gcp.firestore.document.ttl_deletion_count`) AS 'TTL Deletions' WHERE `entity.guid` = '{{entity.guid}}' TIMESERIES AUTO"}],
+            "yAxisLeft": {"zero": true}
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpfirestoreinstance/dashboard.json
+++ b/entity-types/infra-gcpfirestoreinstance/dashboard.json
@@ -24,7 +24,7 @@
           "visualization": {"id": "viz.line"},
           "rawConfiguration": {
             "facet": {"showOtherSeries": false}, "legend": {"enabled": true},
-            "nrqlQueries": [{"accountId": 0, "query": "FROM Metric SELECT sum(`gcp.firestore.document.write_count`) AS 'Writes' WHERE `entity.guid` = '{{entity.guid}}' TIMESERIES AUTO"}],
+            "nrqlQueries": [{"accountId": 0, "query": "FROM Metric SELECT sum(`gcp.firestore.document.write_ops_count`) AS 'Writes' WHERE `entity.guid` = '{{entity.guid}}' TIMESERIES AUTO"}],
             "yAxisLeft": {"zero": true}
           }
         },

--- a/entity-types/infra-gcpfirestoreinstance/definition.yml
+++ b/entity-types/infra-gcpfirestoreinstance/definition.yml
@@ -1,5 +1,8 @@
 domain: INFRA
 type: GCPFIRESTOREINSTANCE
+goldenTags:
+- gcp.projectId
+- gcp.region
 configuration:
   entityExpirationTime: DAILY
   alertable: true

--- a/entity-types/infra-gcpfirestoreinstance/golden_metrics.yml
+++ b/entity-types/infra-gcpfirestoreinstance/golden_metrics.yml
@@ -13,7 +13,7 @@ writeCount:
   unit: COUNT
   queries:
     gcp:
-      select: sum(gcp.firestore.document.write_count)
+      select: sum(gcp.firestore.document.write_ops_count)
       from: Metric
       eventId: entity.guid
       eventName: entity.name

--- a/entity-types/infra-gcpfirestoreinstance/golden_metrics.yml
+++ b/entity-types/infra-gcpfirestoreinstance/golden_metrics.yml
@@ -1,0 +1,29 @@
+readCount:
+  title: Document Reads
+  unit: COUNT
+  queries:
+    gcp:
+      select: sum(gcp.firestore.document.read_count)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+
+writeCount:
+  title: Document Writes
+  unit: COUNT
+  queries:
+    gcp:
+      select: sum(gcp.firestore.document.write_count)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+
+activeConnections:
+  title: Active Connections
+  unit: COUNT
+  queries:
+    gcp:
+      select: average(gcp.firestore.network.active_connections)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-gcpfirestoreinstance/golden_metrics.yml
+++ b/entity-types/infra-gcpfirestoreinstance/golden_metrics.yml
@@ -13,7 +13,7 @@ writeCount:
   unit: COUNT
   queries:
     gcp:
-      select: sum(gcp.firestore.document.write_ops_count)
+      select: sum(gcp.firestore.document.write_count)
       from: Metric
       eventId: entity.guid
       eventName: entity.name

--- a/entity-types/infra-gcpfirestoreinstance/summary_metrics.yml
+++ b/entity-types/infra-gcpfirestoreinstance/summary_metrics.yml
@@ -1,0 +1,26 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: GCP account
+  unit: STRING
+
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
+
+readCount:
+  goldenMetric: readCount
+  title: Document Reads
+  unit: COUNT
+
+writeCount:
+  goldenMetric: writeCount
+  title: Document Writes
+  unit: COUNT
+
+activeConnections:
+  goldenMetric: activeConnections
+  title: Active Connections
+  unit: COUNT


### PR DESCRIPTION
## Summary
- Adds `infra-gcpfirestoreinstance` entity type with golden metrics, summary metrics, and dashboard
- Fixes Firestore document write metric name: `document.write_count` → `document.write_ops_count` (GCP exports `firestore.googleapis.com/document/write_ops_count`)
- Phase 3a validation confirmed `document.write_ops_count` is present in account 10876283

## Metrics
- `gcp.firestore.document.read_count`
- `gcp.firestore.document.write_ops_count`
- `gcp.firestore.network.active_connections`
- `gcp.firestore.network.snapshot_listeners`

## Test plan
- [ ] `write_ops_count` confirmed present in account 10876283 via Phase 3a validation
- [ ] Entity synthesizes from `firestore_instance` monitored resource type