### PR TITLE
feat(nginx): add candidate synthesis and relationship synthesis rules for NGINXSERVER

### DIFF
--- a/relationships/candidates/NGINXSERVER.stg.yml
+++ b/relationships/candidates/NGINXSERVER.stg.yml
@@ -1,0 +1,67 @@
+category: NGINXSERVER
+lookups:
+  # ── Outbound: NGINXSERVER → EXT SERVICE (backends) ────────────────────────
+  # Used by: INFRA-NGINXSERVER-to-EXT-SERVICE.stg.yml
+  - entityTypes:
+      - domain: EXT
+        type: SERVICE
+    tags:
+      matchingMode: ALL
+      predicates:
+        - tagKeys: ["nginx.deployment.name"]
+          field: nginxDeploymentNameExtService
+    onMatch:
+      onMultipleMatches: RELATE_ALL
+    onMiss:
+      action: NO_OP
+
+  # ── Outbound: NGINXSERVER → APM APPLICATION (backends) ────────────────────
+  # Used by: INFRA-NGINXSERVER-to-APM-APPLICATION.stg.yml
+  - entityTypes:
+      - domain: APM
+        type: APPLICATION
+    tags:
+      matchingMode: ALL
+      predicates:
+        - tagKeys: ["nginx.deployment.name"]
+          field: nginxDeploymentNameApmApp
+    onMatch:
+      onMultipleMatches: RELATE_ALL
+    onMiss:
+      action: NO_OP
+
+  # ── Inbound: EXT SERVICE → NGINXSERVER (clients) ──────────────────────────
+  # Used by: EXT-SERVICE-to-INFRA-NGINXSERVER.stg.yml
+  # OTel client services set tags.nginx.upstream.deployment.name to identify
+  # which NGINXSERVER they call. Keyed separately from nginx.deployment.name
+  # to distinguish callers from callees.
+  - entityTypes:
+      - domain: EXT
+        type: SERVICE
+    tags:
+      matchingMode: ALL
+      predicates:
+        - tagKeys: ["nginx.upstream.deployment.name"]
+          field: nginxUpstreamDeploymentNameExtService
+    onMatch:
+      onMultipleMatches: RELATE_ALL
+    onMiss:
+      action: NO_OP
+
+  # ── Inbound: APM APPLICATION → NGINXSERVER (clients) ──────────────────────
+  # Used by: APM-APPLICATION-to-INFRA-NGINXSERVER.stg.yml
+  # NR APM client services set NEW_RELIC_LABELS=nginx.upstream.deployment.name:<value>,
+  # which becomes an entity tag. Keyed separately from nginx.deployment.name
+  # to distinguish callers from callees.
+  - entityTypes:
+      - domain: APM
+        type: APPLICATION
+    tags:
+      matchingMode: ALL
+      predicates:
+        - tagKeys: ["nginx.upstream.deployment.name"]
+          field: nginxUpstreamDeploymentNameApmApp
+    onMatch:
+      onMultipleMatches: RELATE_ALL
+    onMiss:
+      action: NO_OP

--- a/relationships/synthesis/APM-APPLICATION-to-INFRA-NGINXSERVER.stg.yml
+++ b/relationships/synthesis/APM-APPLICATION-to-INFRA-NGINXSERVER.stg.yml
@@ -1,5 +1,5 @@
 relationships:
-  - name: otelExtServiceCallsOtelInfraNginxServer
+  - name: apmApplicationCallsOtelInfraNginxServer
     version: "1"
     origins:
       - OpenTelemetry
@@ -25,7 +25,7 @@ relationships:
         lookupGuid:
           candidateCategory: NGINXSERVER
           fields:
-            - field: nginxUpstreamDeploymentNameExtService
+            - field: nginxUpstreamDeploymentNameApmApp
               attribute: nginx.deployment.name
       target:
         extractGuid:
@@ -33,7 +33,7 @@ relationships:
           entityType:
             value: NGINXSERVER
 
-  - name: otelExtServiceCallsOtelInfraNginxPlusServer
+  - name: apmApplicationCallsOtelInfraNginxPlusServer
     version: "1"
     origins:
       - OpenTelemetry
@@ -59,7 +59,7 @@ relationships:
         lookupGuid:
           candidateCategory: NGINXSERVER
           fields:
-            - field: nginxUpstreamDeploymentNameExtService
+            - field: nginxUpstreamDeploymentNameApmApp
               attribute: nginx.deployment.name
       target:
         extractGuid:

--- a/relationships/synthesis/INFRA-NGINXSERVER-to-APM-APPLICATION.stg.yml
+++ b/relationships/synthesis/INFRA-NGINXSERVER-to-APM-APPLICATION.stg.yml
@@ -1,5 +1,5 @@
 relationships:
-  - name: otelExtServiceCallsOtelInfraNginxServer
+  - name: otelInfraNginxServerCallsApmApplication
     version: "1"
     origins:
       - OpenTelemetry
@@ -22,18 +22,18 @@ relationships:
       expires: PT75M
       relationshipType: CALLS
       source:
-        lookupGuid:
-          candidateCategory: NGINXSERVER
-          fields:
-            - field: nginxUpstreamDeploymentNameExtService
-              attribute: nginx.deployment.name
-      target:
         extractGuid:
           attribute: entity.guid
           entityType:
             value: NGINXSERVER
+      target:
+        lookupGuid:
+          candidateCategory: NGINXSERVER
+          fields:
+            - field: nginxDeploymentNameApmApp
+              attribute: nginx.deployment.name
 
-  - name: otelExtServiceCallsOtelInfraNginxPlusServer
+  - name: otelInfraNginxPlusServerCallsApmApplication
     version: "1"
     origins:
       - OpenTelemetry
@@ -56,13 +56,13 @@ relationships:
       expires: PT75M
       relationshipType: CALLS
       source:
-        lookupGuid:
-          candidateCategory: NGINXSERVER
-          fields:
-            - field: nginxUpstreamDeploymentNameExtService
-              attribute: nginx.deployment.name
-      target:
         extractGuid:
           attribute: entity.guid
           entityType:
             value: NGINXSERVER
+      target:
+        lookupGuid:
+          candidateCategory: NGINXSERVER
+          fields:
+            - field: nginxDeploymentNameApmApp
+              attribute: nginx.deployment.name

--- a/relationships/synthesis/INFRA-NGINXSERVER-to-EXT-SERVICE.stg.yml
+++ b/relationships/synthesis/INFRA-NGINXSERVER-to-EXT-SERVICE.stg.yml
@@ -1,5 +1,5 @@
 relationships:
-  - name: otelExtServiceCallsOtelInfraNginxServer
+  - name: otelInfraNginxServerCallsOtelExtService
     version: "1"
     origins:
       - OpenTelemetry
@@ -22,18 +22,18 @@ relationships:
       expires: PT75M
       relationshipType: CALLS
       source:
-        lookupGuid:
-          candidateCategory: NGINXSERVER
-          fields:
-            - field: nginxUpstreamDeploymentNameExtService
-              attribute: nginx.deployment.name
-      target:
         extractGuid:
           attribute: entity.guid
           entityType:
             value: NGINXSERVER
+      target:
+        lookupGuid:
+          candidateCategory: NGINXSERVER
+          fields:
+            - field: nginxDeploymentNameExtService
+              attribute: nginx.deployment.name
 
-  - name: otelExtServiceCallsOtelInfraNginxPlusServer
+  - name: otelInfraNginxPlusServerCallsOtelExtService
     version: "1"
     origins:
       - OpenTelemetry
@@ -56,13 +56,13 @@ relationships:
       expires: PT75M
       relationshipType: CALLS
       source:
-        lookupGuid:
-          candidateCategory: NGINXSERVER
-          fields:
-            - field: nginxUpstreamDeploymentNameExtService
-              attribute: nginx.deployment.name
-      target:
         extractGuid:
           attribute: entity.guid
           entityType:
             value: NGINXSERVER
+      target:
+        lookupGuid:
+          candidateCategory: NGINXSERVER
+          fields:
+            - field: nginxDeploymentNameExtService
+              attribute: nginx.deployment.name


### PR DESCRIPTION
#### NGINXSERVER ↔ APM / EXT bidirectional relationship synthesis

This PR adds bidirectional CALLS relationship synthesis between INFRA-NGINXSERVER entities and both APM-APPLICATION and EXT-SERVICE entities, using OpenTelemetry NGINX metrics. It also introduces a candidate lookup file so relationships resolve via GUID lookup instead of building a synthetic GUID.

#### What changed

New candidate file — relationships/candidates/NGINXSERVER.yml
- Defines four lookup categories under category: NGINXSERVER:
  - Outbound (NGINXSERVER → backend): matches EXT-SERVICE / APM-APPLICATION on nginx.deployment.name.
  - Inbound (client → NGINXSERVER): matches EXT-SERVICE / APM-APPLICATION on nginx.upstream.deployment.name.
- The caller (nginx.upstream.deployment.name) and callee (nginx.deployment.name) tag keys are deliberately kept separate so we can distinguish clients from backends.
- All lookups use onMultipleMatches: RELATE_ALL and onMiss: NO_OP.

New synthesis files
- APM-APPLICATION-to-INFRA-NGINXSERVER.stg.yml
- INFRA-NGINXSERVER-to-APM-APPLICATION.stg.yml
- INFRA-NGINXSERVER-to-EXT-SERVICE.stg.yml

Each file defines two rules — one for NGINX OSS (metricName startsWith nginx.) and one for NGINX Plus (metricName startsWith nginxplus_). All are scoped to instrumentation.provider: opentelemetry, require nginx.deployment.name, and expire after PT75M.

Refactored — EXT-SERVICE-to-INFRA-NGINXSERVER.stg.yml
- Replaced the legacy buildGuid approach (which hashed nginx.deployment.name:nginx.server.endpoint via FARM_HASH) with lookupGuid against the new NGINXSERVER candidate category.
- Renamed apmCallsOtelNginxServer → otelExtServiceCallsOtelInfraNginxServer for clarity and consistency.
- Added the matching NGINX Plus variant.
- Dropped now-unnecessary conditions (entity.type, nginx.server.endpoint, nginx.display.name).

▎ Note: These are all .stg.yml (staging-scoped) files for validation before promoting to production.

#### Api Review Board (ARB)

ARB Jira ticket:
https://new-relic.atlassian.net/browse/NR-580731

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid.
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
* [ ] I've linked an ARB ticket & received approval from API Review Board in order to make these changes
