### PR TITLE
feat: add GCPAPPENGINEGCEINSTANCE entity for App Engine Flex VMs

### DIFF
--- a/entity-types/infra-gcpappenginegceinstance/dashboard.json
+++ b/entity-types/infra-gcpappenginegceinstance/dashboard.json
@@ -1,0 +1,162 @@
+{
+  "name": "GCP App Engine Flex VM",
+  "description": null,
+  "pages": [
+    {
+      "name": "GCP App Engine Flex VM",
+      "description": null,
+      "widgets": [
+        {
+          "title": "Connections (current)",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT max(`gcp.appengine.flex.autoscaler.connections.current`) AS 'Connections' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES AUTO",
+                "offset": 300000
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Request count",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.appengine.flex.autoscaler.server.request_count`) AS 'Requests' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES AUTO",
+                "offset": 300000
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Connections by state",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT max(`gcp.appengine.flex.autoscaler.connections.current`) AS 'Connections' FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.state` TIMESERIES AUTO",
+                "offset": 300000
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Requests by version",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.appengine.flex.autoscaler.server.request_count`) AS 'Requests' FROM Metric WHERE entity.guid = '{{entity.id}}' FACET version_id TIMESERIES AUTO",
+                "offset": 300000
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Connections by version",
+          "layout": {
+            "column": 7,
+            "row": 4,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT max(`gcp.appengine.flex.autoscaler.connections.current`) AS 'Connections' FROM Metric WHERE entity.guid = '{{entity.id}}' FACET version_id TIMESERIES AUTO",
+                "offset": 300000
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpappenginegceinstance/definition.yml
+++ b/entity-types/infra-gcpappenginegceinstance/definition.yml
@@ -1,0 +1,12 @@
+domain: INFRA
+type: GCPAPPENGINEGCEINSTANCE
+goldenTags:
+  - gcp.projectId
+  - gcp.region
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-gcpappenginegceinstance/golden_metrics.yml
+++ b/entity-types/infra-gcpappenginegceinstance/golden_metrics.yml
@@ -1,0 +1,18 @@
+Connections:
+  title: Connections
+  unit: COUNT
+  queries:
+    gcp:
+      select: max(gcp.appengine.flex.autoscaler.connections.current)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+RequestCount:
+  title: Request Count
+  unit: COUNT
+  queries:
+    gcp:
+      select: sum(gcp.appengine.flex.autoscaler.server.request_count)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-gcpappenginegceinstance/summary_metrics.yml
+++ b/entity-types/infra-gcpappenginegceinstance/summary_metrics.yml
@@ -1,0 +1,18 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: GCP account
+  unit: STRING
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
+Connections:
+  goldenMetric: Connections
+  unit: COUNT
+  title: Connections
+RequestCount:
+  goldenMetric: RequestCount
+  unit: COUNT
+  title: Request Count


### PR DESCRIPTION
## Summary

Adds **GCPAPPENGINEGCEINSTANCE**, a new INFRA entity for App Engine Flexible-environment VMs.

GCP reports a small set of Flex autoscaler metrics under the `gce_instance` monitored resource type (e.g. `flex/autoscaler/connections/current`, `flex/autoscaler/server/request_count`). These currently land on `GCPVIRTUALMACHINE` along with regular Compute Engine VM metrics, which is incorrect.

## Design notes

- **Monitored resource type:** `gce_instance` (per GCP — same type as plain GCE VMs).
- **Synthetic asset type:** `appengine.googleapis.com/FlexInstance`. No CAI asset type exists specifically for Flex VMs, so discovery uses the Monitoring API. This follows the same pattern as `container.googleapis.com/Pod` / `k8s_pod`.
- **Disambiguation from `GCPVIRTUALMACHINE`:** the synthesizer's `resolveDefinitionKey` uses the trigger's `resource_type` to disambiguate when a `monitored_resource_type` is shared. The `gcp_appengine` datasource owns the FlexInstance trigger, so its metrics route to `GCPAPPENGINEGCEINSTANCE` rather than the (also-`gce_instance`) `GCPVIRTUALMACHINE` rule.
- **Identifying labels:** `[service_id, version_id, instance_name, project_id]` — taken from the Flex autoscaler metric labels.
- **Golden metrics:** `flex/autoscaler/connections/current` (BETA, GAUGE), `flex/autoscaler/server/request_count` (BETA, DELTA). ALPHA metrics excluded per skill guidance.

## ⚠️ Telemetry caveat

These metrics are **not currently flowing** in NR (verified in account 10876283 — zero `gcp.appengine.flex.autoscaler.*` samples in the last 7 days). The Flex VMs in the test project are minimal/idle and the polling integration doesn't enumerate this metric prefix yet. The metric names and labels in this PR come from the GCP metrics reference (https://cloud.google.com/monitoring/api/metrics_gcp_a_b#gcp-appengine).

A follow-up validation pass against a project running Flex autoscaling under load is recommended before this entity is considered fully verified.

## Companion PRs (must merge together)

| Repo | PR | What |
|---|---|---|
| `newrelic/entity-definitions` | — | Entity definition + golden/summary metrics + dashboard |
| `entity-platform/entity-type-ui-definitions-service` | — | UI definition |
| `beyond/gcp-polling-v2` | — | Synthesis rule + datasource mapping |
| `Pegasus/infra-summary` | — | Entity overview + metrics templates |
| `Pegasus/infrastructure` | — | Cloud UI dimensional-metrics template |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
