### PR TITLE
feat: Add OCINOTIFICATION entity definition

### DIFF
--- a/entity-types/infra-ocinotification/definition.stg.yml
+++ b/entity-types/infra-ocinotification/definition.stg.yml
@@ -1,0 +1,26 @@
+domain: INFRA
+type: OCINOTIFICATION
+goldenTags:
+- oci.compartmentId
+- oci.regionName
+- oci.namespace
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
+      multiValue: false
+  rules:
+  - ruleName: infra_ocinotification_oci_resourceId
+    identifier: oci.resourceId
+    name: oci.resourceDisplayName
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: oci.namespace
+      value: "oci_notification"
+
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-ocinotification/golden_metrics.stg.yml
+++ b/entity-types/infra-ocinotification/golden_metrics.stg.yml
@@ -1,0 +1,29 @@
+# Golden metrics for OCI Notification
+# Source: https://docs.oracle.com/en-us/iaas/Content/Notification/Reference/notificationmetrics-reference.htm
+publishedMessagesCount:
+  title: Published Messages Count
+  unit: COUNT
+  queries:
+    oci:
+      select: sum(oci.notification.PublishedMessagesCount)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+deliveredMessagesCount:
+  title: Delivered Messages Count
+  unit: COUNT
+  queries:
+    oci:
+      select: sum(oci.notification.DeliveredMessagesCount)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+failedMessagesCount:
+  title: Failed Messages Count
+  unit: COUNT
+  queries:
+    oci:
+      select: sum(oci.notification.FailedMessagesCount)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-ocinotification/summary_metrics.stg.yml
+++ b/entity-types/infra-ocinotification/summary_metrics.stg.yml
@@ -1,0 +1,19 @@
+# Summary metrics for OCI Notification
+# Source: https://docs.oracle.com/en-us/iaas/Content/Notification/Reference/notificationmetrics-reference.htm
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: OCI account
+  unit: STRING
+publishedMessagesCount:
+  goldenMetric: publishedMessagesCount
+  unit: COUNT
+  title: Published Messages Count
+deliveredMessagesCount:
+  goldenMetric: deliveredMessagesCount
+  unit: COUNT
+  title: Delivered Messages Count
+failedMessagesCount:
+  goldenMetric: failedMessagesCount
+  unit: COUNT
+  title: Failed Messages Count


### PR DESCRIPTION
Add OCI Notification entity definition with synthesis rules, golden metrics, and summary metrics.

## Entity Type
- Type: `INFRA-OCINOTIFICATION`
- Provider: OCI (Oracle Cloud Infrastructure)
- Namespace: `oci_notification`

## Golden Metrics
- PublishedMessagesCount — Count of messages received from the service or customer
- DeliveredMessagesCount — Count of messages successfully transmitted to endpoints
- FailedMessagesCount — Count of messages that could not be transmitted to endpoints

## Metric Source
https://docs.oracle.com/en-us/iaas/Content/Notification/Reference/notificationmetrics-reference.htm

## Notes
- Using `.stg.yml` suffix (staging only)