### PR TITLE
feat: add missing dashboards and summary_metrics for BigQuery/Bigtable entities

### DIFF
--- a/entity-types/infra-gcpbigquerydataset/dashboard.json
+++ b/entity-types/infra-gcpbigquerydataset/dashboard.json
@@ -1,0 +1,93 @@
+{
+  "name": "GCP BigQuery Dataset",
+  "description": null,
+  "pages": [
+    {
+      "name": "GCP BigQuery Dataset",
+      "description": null,
+      "widgets": [
+        {
+          "title": "Stored bytes",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.bigquery.storage.stored_bytes`) AS 'Stored bytes' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Number of tables",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.bigquery.storage.table_count`) AS 'Tables' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Stored bytes (current)",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`gcp.bigquery.storage.stored_bytes`) AS 'Stored bytes' FROM Metric WHERE entity.guid = '{{entity.id}}'"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpbigqueryproject/dashboard.json
+++ b/entity-types/infra-gcpbigqueryproject/dashboard.json
@@ -1,0 +1,157 @@
+{
+  "name": "GCP BigQuery Project",
+  "description": null,
+  "pages": [
+    {
+      "name": "GCP BigQuery Project",
+      "description": null,
+      "widgets": [
+        {
+          "title": "Queries",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.bigquery.query.count`) AS 'Queries' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Query execution time (avg)",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.bigquery.query.execution_times`) AS 'Avg duration (s)' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Query execution time percentiles",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.bigquery.query.execution_times.p50`) AS 'p50', average(`gcp.bigquery.query.execution_times.p95`) AS 'p95', average(`gcp.bigquery.query.execution_times.p99`) AS 'p99' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Slots allocated",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.bigquery.slots.allocated`) AS 'Allocated' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Queries by priority",
+          "layout": {
+            "column": 7,
+            "row": 4,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.bigquery.query.count`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `gcp.bigquery.priority` TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpbigtablecluster/dashboard.json
+++ b/entity-types/infra-gcpbigtablecluster/dashboard.json
@@ -1,0 +1,151 @@
+{
+  "name": "GCP Bigtable Cluster",
+  "description": null,
+  "pages": [
+    {
+      "name": "GCP Bigtable Cluster",
+      "description": null,
+      "widgets": [
+        {
+          "title": "CPU load (%)",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.bigtable.cluster.cpuLoad`) AS 'CPU load' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "CPU load of busiest node (%)",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.bigtable.cluster.cpuLoadHottestNode`) AS 'CPU load (busiest)' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Utilization of HDD disks (%)",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.bigtable.cluster.diskLoad`) AS 'HDD utilization' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Storage used (%)",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.bigtable.cluster.storageUtilization`) AS 'Storage used' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Storage used (current)",
+          "layout": {
+            "column": 7,
+            "row": 4,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`gcp.bigtable.cluster.storageUtilization`) AS 'Storage utilization' FROM Metric WHERE entity.guid = '{{entity.id}}'"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpbigtablecluster/summary_metrics.yml
+++ b/entity-types/infra-gcpbigtablecluster/summary_metrics.yml
@@ -1,0 +1,26 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: GCP account
+  unit: STRING
+zone:
+  tag:
+    key: zone
+  title: Zone
+  unit: STRING
+cpuLoad:
+  goldenMetric: cpuLoad
+  unit: PERCENTAGE
+  title: CPU load
+cpuLoadOfBusiestNode:
+  goldenMetric: cpuLoadOfBusiestNode
+  unit: PERCENTAGE
+  title: CPU load of busiest node
+utilizationOfHddDisks:
+  goldenMetric: utilizationOfHddDisks
+  unit: PERCENTAGE
+  title: Utilization of HDD disks
+storageUsed:
+  goldenMetric: storageUsed
+  unit: PERCENTAGE
+  title: Storage used

--- a/entity-types/infra-gcpbigtabletable/dashboard.json
+++ b/entity-types/infra-gcpbigtabletable/dashboard.json
@@ -1,0 +1,157 @@
+{
+  "name": "GCP Bigtable Table",
+  "description": null,
+  "pages": [
+    {
+      "name": "GCP Bigtable Table",
+      "description": null,
+      "widgets": [
+        {
+          "title": "Server requests",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.bigtable.table.server.requestCount`) AS 'Requests' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Server requests failed",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.bigtable.table.server.errorCount`) AS 'Errors' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Replication latency (ms)",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.bigtable.table.replication.latency`) AS 'Replication latency' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Uncompressed bytes of response data",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.bigtable.table.server.sentBytesCount`) AS 'Response bytes' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Error rate (%)",
+          "layout": {
+            "column": 7,
+            "row": 4,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.bigtable.table.server.errorCount`) * 100 / average(`gcp.bigtable.table.server.requestCount`) AS 'Error rate (%)' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpbigtabletable/summary_metrics.yml
+++ b/entity-types/infra-gcpbigtabletable/summary_metrics.yml
@@ -1,0 +1,26 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: GCP account
+  unit: STRING
+zone:
+  tag:
+    key: zone
+  title: Zone
+  unit: STRING
+serverRequests:
+  goldenMetric: serverRequests
+  unit: COUNT
+  title: Server requests
+serverRequestsFailed:
+  goldenMetric: serverRequestsFailed
+  unit: COUNT
+  title: Server requests failed
+replicationRequestLatenciesMs:
+  goldenMetric: replicationRequestLatenciesMs
+  unit: MS
+  title: Replication request latencies
+uncompressedBytesOfResponseData:
+  goldenMetric: uncompressedBytesOfResponseData
+  unit: BYTES
+  title: Uncompressed response bytes


### PR DESCRIPTION
## Summary

Fills in missing files for four pre-existing INFRA entities — BigQuery (project, dataset) and Bigtable (cluster, table). Synthesis rules, UI definitions, and infra-summary templates already exist; this PR adds what was missing for parity with newer entities.

## What's added

**entity-definitions:**
- `dashboard.json` for all four entities (none existed before)
- `summary_metrics.yml` for `GCPBIGTABLECLUSTER` and `GCPBIGTABLETABLE` (BigQuery entities already had theirs)

**infrastructure (Cloud UI):**
- `gcp_bigquery_dimensional_metrics.json` — replaces sample-based `gcp_bigquery.json` with a dimensional-Metric version (project/dataset)
- `gcp_bigtable_dimensional_metrics.json` — dimensional-Metric version for cluster/table

## Resource types (unchanged — existing rules)

| Entity | `monitored_resource_type` | `identifying_labels` |
|---|---|---|
| `GCPBIGQUERYPROJECT` | `bigquery_project` | `[project_id]` |
| `GCPBIGQUERYDATASET` | `bigquery_dataset` | `[dataset_id, project_id]` |
| `GCPBIGTABLECLUSTER` | `bigtable_cluster` | `[cluster, instance, zone, project_id]` |
| `GCPBIGTABLETABLE` | `bigtable_table` | `[table, cluster, instance, zone, project_id]` |

## Telemetry verification (account 10876283)

- ✅ BigQuery: dimensional `gcp.bigquery.query.*` and `gcp.bigquery.slots.*` metrics are flowing (1,229+ samples/day). `GcpBigQueryProjectSample` (5,965/day) and `GcpBigQueryDataSetSample` (1,921/day) also active.
- ⚠️ Bigtable: **zero metrics in this account** — no Bigtable instances are running in 10876283. Metric names and labels come from existing `golden_metrics.yml` (already validated in production by prior PRs that added those entities). Recommend smoke-testing the dashboard against an account with active Bigtable clusters before final merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
