### PR TITLE
fix(ext-snmp_appliance, ext-hardware_security_module): remove duplicate AS alias in Summary widget query

### DIFF
--- a/entity-types/ext-hardware_security_module/luna-hsm-dashboard.json
+++ b/entity-types/ext-hardware_security_module/luna-hsm-dashboard.json
@@ -25,7 +25,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "FROM Metric SELECT latest(device_name) AS 'Device Name'\n, latest(src_addr) AS 'Device IP'\n, latest(kentik.snmp.Uptime)/8640000 AS 'Uptime (Days)'\n, latest(SysObjectID) AS 'SysObjectID'\n, latest(entity.type) AS 'Entity Type'\n, latest(instrumentation.name) AS 'Ktranslate Profile'\n, latest(timestamp) AS 'Last Update'\n, latest(PollingHealth) AS 'Polling Health'\n, if(latest(PollingHealth) = 'GOOD', '', latest(PollingHealthReason)) AS 'Health Reason'AS 'Last Health Problem'\n, filter(latest(timestamp), where PollingHealth = 'BAD') AS 'Last Health Problem Timestamp'  WHERE instrumentation.name = 'luna-hsm'"
+                "query": "FROM Metric SELECT latest(device_name) AS 'Device Name'\n, latest(src_addr) AS 'Device IP'\n, latest(kentik.snmp.Uptime)/8640000 AS 'Uptime (Days)'\n, latest(SysObjectID) AS 'SysObjectID'\n, latest(entity.type) AS 'Entity Type'\n, latest(instrumentation.name) AS 'Ktranslate Profile'\n, latest(timestamp) AS 'Last Update'\n, latest(PollingHealth) AS 'Polling Health'\n, if(latest(PollingHealth) = 'GOOD', '', latest(PollingHealthReason)) AS 'Health Reason'\n, filter(latest(timestamp), where PollingHealth = 'BAD') AS 'Last Health Problem Timestamp'  WHERE instrumentation.name = 'luna-hsm'"
               }
             ],
             "platformOptions": {

--- a/entity-types/ext-snmp_appliance/aruba-clearpass-dashboard.json
+++ b/entity-types/ext-snmp_appliance/aruba-clearpass-dashboard.json
@@ -35,7 +35,7 @@
               "nrqlQueries": [
                 {
                   "accountId": 0,
-                  "query": "FROM Metric SELECT latest(device_name) AS 'Device Name', latest(src_addr) AS 'Device IP', latest(kentik.snmp.Uptime)/8640000 AS 'Uptime (Days)', latest(SysObjectID) AS 'SysObjectID', latest(entity.type) AS 'Entity Type', latest(instrumentation.name) AS 'Ktranslate Profile', latest(timestamp) AS 'Last Update', latest(PollingHealth) AS 'Polling Health', if(latest(PollingHealth) = 'GOOD', '', latest(PollingHealthReason)) AS 'Health Reason'AS 'Last Health Problem', filter(latest(timestamp), where PollingHealth = 'BAD') AS 'Last Health Problem Timestamp'  WHERE instrumentation.name = 'aruba-clearpass' "
+                  "query": "FROM Metric SELECT latest(device_name) AS 'Device Name', latest(src_addr) AS 'Device IP', latest(kentik.snmp.Uptime)/8640000 AS 'Uptime (Days)', latest(SysObjectID) AS 'SysObjectID', latest(entity.type) AS 'Entity Type', latest(instrumentation.name) AS 'Ktranslate Profile', latest(timestamp) AS 'Last Update', latest(PollingHealth) AS 'Polling Health', if(latest(PollingHealth) = 'GOOD', '', latest(PollingHealthReason)) AS 'Health Reason', filter(latest(timestamp), where PollingHealth = 'BAD') AS 'Last Health Problem Timestamp'  WHERE instrumentation.name = 'aruba-clearpass' "
                 }
               ],
               "platformOptions": {


### PR DESCRIPTION
### Relevant information

The Summary widget query in two device-overview dashboards has two `AS` aliases on the same `SELECT` expression, which is invalid NRQL:

```sql
... if(latest(PollingHealth) = 'GOOD', '', latest(PollingHealthReason)) AS 'Health Reason'AS 'Last Health Problem', ...
```

NRQL rejects this with `Error at line 1 position 441, unexpected 'AS'`, so the Summary widget on the device overview page renders **"We couldn't fetch your data"** for any customer with an Aruba ClearPass or Luna HSM device monitored via SNMP.

#### Affected files

- `entity-types/ext-snmp_appliance/aruba-clearpass-dashboard.json`
- `entity-types/ext-hardware_security_module/luna-hsm-dashboard.json`

#### Fix

Drop the stray ` AS 'Last Health Problem'`. The `dataFormatters` block in both dashboards only declares `Last Health Problem Timestamp` and `Last Update` — `Last Health Problem` was never an intended column, just a copy-paste leftover. The remaining single alias (`AS 'Health Reason'`) matches the pattern used by every other Summary widget in this repo, e.g. `entity-types/ext-firewall/palo-alto-dashboard.json`.

#### Verification

- Both JSON files still parse (validated locally with `python3 -m json.tool`).
- Diff is a single-character change per file (removal of the duplicate `AS '…'` substring); no schema, identifier, or entity-type semantics changed.

#### Jira

Reported in [NR-581683](https://new-relic.atlassian.net/browse/NR-581683) (GTSE escalation from a customer hitting this on Aruba ClearPass).

#### ARB

No ARB ticket — this PR only repairs an invalid NRQL string in two existing widgets. It does not change identifiers, entity-type definitions, golden metrics, or any API surface. Happy to attach one if the reviewer disagrees.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. *(N/A — no identifier changes)*
* [x] I've confirmed that my entity type wasn't already defined. *(N/A — no new entity type)*
* [ ] I've linked an ARB ticket & received approval from API Review Board in order to make these changes *(see note above)*

[NR-581683]: https://new-relic.atlassian.net/browse/NR-581683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ