### PR TITLE
Update Object Storage entity identifier to oci.resourceId

### DIFF
--- a/entity-types/infra-ociobjectstoragebucket/definition.yml
+++ b/entity-types/infra-ociobjectstoragebucket/definition.yml
@@ -14,14 +14,14 @@ synthesis:
       entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
       multiValue: false
   rules:
-  - ruleName: infra_ociobjectstoragebucket_oci_resourceID
-    identifier: oci.resourceID
+  - ruleName: infra_ociobjectstoragebucket_oci_resourceId
+    identifier: oci.resourceId
     name: oci.resourceDisplayName
     legacyFeatures:
       overrideGuidType: true
     encodeIdentifierInGUID: true
     conditions:
-    - attribute: oci.resourceID
+    - attribute: oci.resourceId
       prefix: "ocid1.bucket"
     - attribute: oci.namespace
       value: "oci_objectstorage"

--- a/entity-types/infra-ociobjectstoragebucket/tests/Metric.json
+++ b/entity-types/infra-ociobjectstoragebucket/tests/Metric.json
@@ -3,7 +3,7 @@
     "oci.compartmentId": "ocid1.compartment.oc1..aaaaaaaabbbbbbccccccccdddddddeeeeeeefffffffgggggggghhhhhhhhiiiiiiiiijjjjjjjj",
     "oci.namespace": "oci_objectstorage",
     "oci.region": "ap-hyderabad-1",
-    "oci.resourceID": "ocid1.bucket.oc1.ap-hyderabad-1.aaaaaaaabbbbbbccccccccdddddddeeeeeeefffffffgggggggghhhhhhhhiiiiiiiiijjjjjjjj",
+    "oci.resourceId": "ocid1.bucket.oc1.ap-hyderabad-1.aaaaaaaabbbbbbccccccccdddddddeeeeeeefffffffgggggggghhhhhhhhiiiiiiiiijjjjjjjj",
     "oci.resourceDisplayName": "test",
     "oci.displayName": "test",
     "collector.name": "oci-monitor",


### PR DESCRIPTION
## Summary
- Updates `infra-ociobjectstoragebucket` entity definition to use `oci.resourceId` as the identifier and condition attribute instead of `oci.resourceID`
- OCI services send the `resourceId` dimension key with inconsistent casing (`resourceId`, `resourceID`, `ResourceId`, `ResourceID`). The metrics stream processor now normalizes all variants to `oci.resourceId`. This entity definition change aligns with that normalization.
ARB ticket: https://new-relic.atlassian.net/browse/NR-581543
Ticket: https://new-relic.atlassian.net/browse/NR-579120
## Test plan
- [x] Metrics stream processor deployed to staging with normalization logic (PR beyond/beyond-oci-metrics-stream-processor#115)
- [ ] Validate Object Storage entities synthesize correctly with `oci.resourceId` after entity-definitions deployment
- [ ] Verify entity GUIDs remain unchanged (GUID uses identifier value, not attribute name)

🤖 Generated with [Claude Code](https://claude.com/claude-code)