### PR TITLE
feat: Add entity definitions for GCP Cloud Composer (GCPCOMPOSERENVIRONMENT, GCPCOMPOSERWORKFLOW, GCPCOMPOSERWORKLOAD)

### DIFF
--- a/entity-types/infra-gcpcomposerenvironment/dashboard.json
+++ b/entity-types/infra-gcpcomposerenvironment/dashboard.json
@@ -1,0 +1,144 @@
+{
+  "name": "Cloud Composer Environment",
+  "description": null,
+  "pages": [
+    {
+      "name": "Cloud Composer Environment",
+      "description": null,
+      "widgets": [
+        {
+          "title": "Environment Healthy",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountIds": "{{accountIds}}",
+                "query": "SELECT latest(`gcp.composer.environment.healthy`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Active Celery Workers",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountIds": "{{accountIds}}",
+                "query": "SELECT latest(`gcp.composer.environment.num_celery_workers`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Active Schedulers",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountIds": "{{accountIds}}",
+                "query": "SELECT latest(`gcp.composer.environment.active_schedulers`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "DAG Total Parse Time (s)",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountIds": "{{accountIds}}",
+                "query": "SELECT average(`gcp.composer.environment.dag_processing.total_parse_time`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpcomposerenvironment/dashboard.json
+++ b/entity-types/infra-gcpcomposerenvironment/dashboard.json
@@ -137,6 +137,69 @@
               "zero": true
             }
           }
+        },
+        {
+          "title": "Active Triggerers",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountIds": "{{accountIds}}",
+                "query": "SELECT latest(`gcp.composer.environment.active_triggerers`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Active Webservers",
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountIds": "{{accountIds}}",
+                "query": "SELECT latest(`gcp.composer.environment.active_webservers`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Database Healthy",
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountIds": "{{accountIds}}",
+                "query": "SELECT latest(`gcp.composer.environment.database_health`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ]
+          }
         }
       ]
     }

--- a/entity-types/infra-gcpcomposerenvironment/golden_metrics.yml
+++ b/entity-types/infra-gcpcomposerenvironment/golden_metrics.yml
@@ -1,0 +1,56 @@
+environmentHealthy:
+  title: Environment healthy
+  unit: COUNT
+  queries:
+    gcp:
+      select: latest(gcp.composer.environment.healthy)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    gcpSample:
+      select: latest(environment.HealthStatus)
+      from: GcpComposerEnvironmentSample
+      eventId: entityGuid
+      eventName: entityName
+activeCeleryWorkers:
+  title: Active Celery workers
+  unit: COUNT
+  queries:
+    gcp:
+      select: latest(gcp.composer.environment.num_celery_workers)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    gcpSample:
+      select: latest(environment.NumCeleryWorkers)
+      from: GcpComposerEnvironmentSample
+      eventId: entityGuid
+      eventName: entityName
+activeSchedulers:
+  title: Active schedulers
+  unit: COUNT
+  queries:
+    gcp:
+      select: latest(gcp.composer.environment.active_schedulers)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    gcpSample:
+      select: latest(environment.ActiveSchedulers)
+      from: GcpComposerEnvironmentSample
+      eventId: entityGuid
+      eventName: entityName
+dagParseTime:
+  title: DAG total parse time (s)
+  unit: SECONDS
+  queries:
+    gcp:
+      select: average(gcp.composer.environment.dag_processing.total_parse_time)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    gcpSample:
+      select: average(environment.DagProcessingTotalParseTime)
+      from: GcpComposerEnvironmentSample
+      eventId: entityGuid
+      eventName: entityName

--- a/entity-types/infra-gcpcomposerenvironment/golden_metrics.yml
+++ b/entity-types/infra-gcpcomposerenvironment/golden_metrics.yml
@@ -54,3 +54,45 @@ dagParseTime:
       from: GcpComposerEnvironmentSample
       eventId: entityGuid
       eventName: entityName
+activeTriggerers:
+  title: Active triggerers
+  unit: COUNT
+  queries:
+    gcp:
+      select: latest(gcp.composer.environment.active_triggerers)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    gcpSample:
+      select: latest(environment.ActiveTriggerers)
+      from: GcpComposerEnvironmentSample
+      eventId: entityGuid
+      eventName: entityName
+activeWebservers:
+  title: Active webservers
+  unit: COUNT
+  queries:
+    gcp:
+      select: latest(gcp.composer.environment.active_webservers)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    gcpSample:
+      select: latest(environment.ActiveWebservers)
+      from: GcpComposerEnvironmentSample
+      eventId: entityGuid
+      eventName: entityName
+databaseHealth:
+  title: Database healthy
+  unit: COUNT
+  queries:
+    gcp:
+      select: latest(gcp.composer.environment.database_health)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    gcpSample:
+      select: latest(environment.DatabaseHealth)
+      from: GcpComposerEnvironmentSample
+      eventId: entityGuid
+      eventName: entityName

--- a/entity-types/infra-gcpcomposerenvironment/summary_metrics.yml
+++ b/entity-types/infra-gcpcomposerenvironment/summary_metrics.yml
@@ -29,3 +29,15 @@ dagParseTime:
   goldenMetric: dagParseTime
   unit: SECONDS
   title: DAG total parse time (s)
+activeTriggerers:
+  goldenMetric: activeTriggerers
+  unit: COUNT
+  title: Active triggerers
+activeWebservers:
+  goldenMetric: activeWebservers
+  unit: COUNT
+  title: Active webservers
+databaseHealth:
+  goldenMetric: databaseHealth
+  unit: COUNT
+  title: Database healthy

--- a/entity-types/infra-gcpcomposerenvironment/summary_metrics.yml
+++ b/entity-types/infra-gcpcomposerenvironment/summary_metrics.yml
@@ -1,0 +1,31 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: GCP account
+  unit: STRING
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
+gcpRegion:
+  tag:
+    key: gcp.region
+  title: GCP Region
+  unit: STRING
+environmentHealthy:
+  goldenMetric: environmentHealthy
+  unit: COUNT
+  title: Environment healthy
+activeCeleryWorkers:
+  goldenMetric: activeCeleryWorkers
+  unit: COUNT
+  title: Active Celery workers
+activeSchedulers:
+  goldenMetric: activeSchedulers
+  unit: COUNT
+  title: Active schedulers
+dagParseTime:
+  goldenMetric: dagParseTime
+  unit: SECONDS
+  title: DAG total parse time (s)

--- a/entity-types/infra-gcpcomposerworkflow/dashboard.json
+++ b/entity-types/infra-gcpcomposerworkflow/dashboard.json
@@ -1,0 +1,78 @@
+{
+  "name": "Cloud Composer Workflow",
+  "description": null,
+  "pages": [
+    {
+      "name": "Cloud Composer Workflow",
+      "description": null,
+      "widgets": [
+        {
+          "title": "Workflow Run Count",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountIds": "{{accountIds}}",
+                "query": "SELECT sum(`gcp.composer.workflow.run_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.state` TIMESERIES AUTO"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "DAG Run Schedule Delay (ms)",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountIds": "{{accountIds}}",
+                "query": "SELECT average(`gcp.composer.workflow.schedule_delay`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpcomposerworkflow/definition.yml
+++ b/entity-types/infra-gcpcomposerworkflow/definition.yml
@@ -3,7 +3,9 @@ type: GCPCOMPOSERWORKFLOW
 configuration:
   entityExpirationTime: DAILY
   alertable: true
-
+goldenTags:
+  - gcp.projectId
+  - gcp.region
 ownership:
   primaryOwner:
     teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-gcpcomposerworkflow/golden_metrics.yml
+++ b/entity-types/infra-gcpcomposerworkflow/golden_metrics.yml
@@ -1,0 +1,28 @@
+workflowRunCount:
+  title: Workflow run count
+  unit: COUNT
+  queries:
+    gcp:
+      select: sum(gcp.composer.workflow.run_count)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    gcpSample:
+      select: sum(workflow.RunCount)
+      from: GcpComposerWorkflowSample
+      eventId: entityGuid
+      eventName: entityName
+scheduleDelay:
+  title: DAG run schedule delay (ms)
+  unit: MS
+  queries:
+    gcp:
+      select: average(gcp.composer.workflow.schedule_delay)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    gcpSample:
+      select: average(workflow.ScheduleDelay)
+      from: GcpComposerWorkflowSample
+      eventId: entityGuid
+      eventName: entityName

--- a/entity-types/infra-gcpcomposerworkflow/summary_metrics.yml
+++ b/entity-types/infra-gcpcomposerworkflow/summary_metrics.yml
@@ -1,0 +1,23 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: GCP account
+  unit: STRING
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
+gcpRegion:
+  tag:
+    key: gcp.region
+  title: GCP Region
+  unit: STRING
+workflowRunCount:
+  goldenMetric: workflowRunCount
+  unit: COUNT
+  title: Workflow run count
+scheduleDelay:
+  goldenMetric: scheduleDelay
+  unit: MS
+  title: DAG run schedule delay (ms)

--- a/entity-types/infra-gcpcomposerworkload/dashboard.json
+++ b/entity-types/infra-gcpcomposerworkload/dashboard.json
@@ -104,6 +104,48 @@
               "zero": true
             }
           }
+        },
+        {
+          "title": "Disk Used (bytes)",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountIds": "{{accountIds}}",
+                "query": "SELECT average(`gcp.composer.workload.disk.bytes_used`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Workload Uptime (s)",
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountIds": "{{accountIds}}",
+                "query": "SELECT latest(`gcp.composer.workload.uptime`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ]
+          }
         }
       ]
     }

--- a/entity-types/infra-gcpcomposerworkload/dashboard.json
+++ b/entity-types/infra-gcpcomposerworkload/dashboard.json
@@ -1,0 +1,111 @@
+{
+  "name": "Cloud Composer Workload",
+  "description": null,
+  "pages": [
+    {
+      "name": "Cloud Composer Workload",
+      "description": null,
+      "widgets": [
+        {
+          "title": "CPU Usage Time (s)",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountIds": "{{accountIds}}",
+                "query": "SELECT sum(`gcp.composer.workload.cpu.usage_time`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Memory Used (bytes)",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountIds": "{{accountIds}}",
+                "query": "SELECT average(`gcp.composer.workload.memory.bytes_used`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES AUTO"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Workload Restart Count",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountIds": "{{accountIds}}",
+                "query": "SELECT sum(`gcp.composer.workload.restart_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.type` TIMESERIES AUTO"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpcomposerworkload/definition.yml
+++ b/entity-types/infra-gcpcomposerworkload/definition.yml
@@ -1,5 +1,5 @@
 domain: INFRA
-type: GCPCOMPOSERENVIRONMENT
+type: GCPCOMPOSERWORKLOAD
 configuration:
   entityExpirationTime: DAILY
   alertable: true

--- a/entity-types/infra-gcpcomposerworkload/golden_metrics.yml
+++ b/entity-types/infra-gcpcomposerworkload/golden_metrics.yml
@@ -25,3 +25,21 @@ restartCount:
       from: Metric
       eventId: entity.guid
       eventName: entity.name
+diskBytesUsed:
+  title: Disk used (bytes)
+  unit: BYTES
+  queries:
+    gcp:
+      select: average(gcp.composer.workload.disk.bytes_used)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+workloadUptime:
+  title: Workload uptime (s)
+  unit: SECONDS
+  queries:
+    gcp:
+      select: latest(gcp.composer.workload.uptime)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-gcpcomposerworkload/golden_metrics.yml
+++ b/entity-types/infra-gcpcomposerworkload/golden_metrics.yml
@@ -1,0 +1,27 @@
+cpuUsageTime:
+  title: CPU usage time (s)
+  unit: SECONDS
+  queries:
+    gcp:
+      select: sum(gcp.composer.workload.cpu.usage_time)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+memoryBytesUsed:
+  title: Memory used (bytes)
+  unit: BYTES
+  queries:
+    gcp:
+      select: average(gcp.composer.workload.memory.bytes_used)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+restartCount:
+  title: Workload restart count
+  unit: COUNT
+  queries:
+    gcp:
+      select: sum(gcp.composer.workload.restart_count)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-gcpcomposerworkload/summary_metrics.yml
+++ b/entity-types/infra-gcpcomposerworkload/summary_metrics.yml
@@ -1,0 +1,27 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: GCP account
+  unit: STRING
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
+gcpRegion:
+  tag:
+    key: gcp.region
+  title: GCP Region
+  unit: STRING
+cpuUsageTime:
+  goldenMetric: cpuUsageTime
+  unit: SECONDS
+  title: CPU usage time (s)
+memoryBytesUsed:
+  goldenMetric: memoryBytesUsed
+  unit: BYTES
+  title: Memory used (bytes)
+restartCount:
+  goldenMetric: restartCount
+  unit: COUNT
+  title: Workload restart count

--- a/entity-types/infra-gcpcomposerworkload/summary_metrics.yml
+++ b/entity-types/infra-gcpcomposerworkload/summary_metrics.yml
@@ -25,3 +25,11 @@ restartCount:
   goldenMetric: restartCount
   unit: COUNT
   title: Workload restart count
+diskBytesUsed:
+  goldenMetric: diskBytesUsed
+  unit: BYTES
+  title: Disk used (bytes)
+workloadUptime:
+  goldenMetric: workloadUptime
+  unit: SECONDS
+  title: Workload uptime (s)


### PR DESCRIPTION
## ARB / CDD
- **Jira (ARB):** https://new-relic.atlassian.net/browse/NR-567584
- **CDD:** https://newrelic.atlassian.net/wiki/spaces/INST/pages/5590026838

## Summary

Adds `definition.yml`, `golden_metrics.yml`, `summary_metrics.yml`, and `dashboard.json` for 3 GCP Cloud Composer entities.

| Entity Type | Display Name | Type | Files |
|---|---|---|---|
| `GCPCOMPOSERENVIRONMENT` | Cloud Composer Environment | Update (adds metrics) | definition, golden_metrics, summary_metrics, dashboard |
| `GCPCOMPOSERWORKFLOW` | Cloud Composer Workflow | Update (adds metrics) | definition, golden_metrics, summary_metrics, dashboard |
| `GCPCOMPOSERWORKLOAD` | Cloud Composer Workload | **New entity** | definition, golden_metrics, summary_metrics, dashboard |

## Golden Metrics Validation
**Metrics source:** `composer.googleapis.com` (BETA) — GCP Cloud Monitoring docs: https://cloud.google.com/monitoring/api/metrics_gcp_c#gcp-composer  
**Account:** 10876283 (30-day lookback)

| Entity | Metric Key | NR Attribute | Aggregation | GCP Kind | Status |
|---|---|---|---|---|---|
| GCPCOMPOSERENVIRONMENT | environmentHealthy | `gcp.composer.environment.healthy` | `latest()` | GAUGE | ⚠️ Doc-confirmed (BETA) |
| GCPCOMPOSERENVIRONMENT | activeCeleryWorkers | `gcp.composer.environment.num_celery_workers` | `latest()` | GAUGE | ⚠️ Doc-confirmed (BETA) |
| GCPCOMPOSERENVIRONMENT | activeSchedulers | `gcp.composer.environment.active_schedulers` | `latest()` | GAUGE | ⚠️ Doc-confirmed (BETA) |
| GCPCOMPOSERENVIRONMENT | dagParseTime | `gcp.composer.environment.dag_processing.total_parse_time` | `average()` | GAUGE | ⚠️ Doc-confirmed (BETA) |
| GCPCOMPOSERWORKFLOW | workflowRunCount | `gcp.composer.workflow.run_count` | `sum()` | DELTA | ⚠️ Doc-confirmed (BETA) |
| GCPCOMPOSERWORKFLOW | scheduleDelay | `gcp.composer.workflow.schedule_delay` | `average()` | GAUGE | ⚠️ Doc-confirmed (BETA) |
| GCPCOMPOSERWORKLOAD | cpuUsageTime | `gcp.composer.workload.cpu.usage_time` | `sum()` | DELTA | ⚠️ Doc-confirmed (BETA) |
| GCPCOMPOSERWORKLOAD | memoryBytesUsed | `gcp.composer.workload.memory.bytes_used` | `average()` | GAUGE | ⚠️ Doc-confirmed (BETA) |
| GCPCOMPOSERWORKLOAD | restartCount | `gcp.composer.workload.restart_count` | `sum()` | DELTA | ⚠️ Doc-confirmed (BETA) |