### PR TITLE
feat(gcpappengineservice): add gcp.region golden tag and gcp.projectId summary metric

### DIFF
--- a/entity-types/infra-gcpappengineservice/definition.yml
+++ b/entity-types/infra-gcpappengineservice/definition.yml
@@ -2,6 +2,7 @@ domain: INFRA
 type: GCPAPPENGINESERVICE
 goldenTags:
 - gcp.projectId
+- gcp.region
 - gcp.zone
 configuration:
   entityExpirationTime: DAILY

--- a/entity-types/infra-gcpappengineservice/summary_metrics.yml
+++ b/entity-types/infra-gcpappengineservice/summary_metrics.yml
@@ -3,6 +3,11 @@ providerAccountName:
     key: providerAccountName
   title: GCP account
   unit: STRING
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
 Instances:
   goldenMetric: Instances
   unit: COUNT


### PR DESCRIPTION
## Summary

Two small parity fixes to `infra-gcpappengineservice`:

1. **Add `gcp.region` to `goldenTags`** — matches the New Relic entity-definition standard that all GCP entities should expose `gcp.projectId` and `gcp.region`. Existing `gcp.zone` retained for backward compatibility.
2. **Add `gcp.projectId` as a tag-based summary metric** — surfaces the GCP project in the entity summary column, matching what newer GCP entities (e.g., `GCPAIPLATFORMLOCATION`) already do.

## Verification (account 10876283)

- ✅ `gcp.projectId` is populated on real `GCPAPPENGINESERVICE` entities (values: `beyond-181918`)
- ⚠️ `gcp.region` is **not currently emitted** on `gae_app` metrics or entity tags in this account. Adding it here is forward-looking: once `gcp-polling-v2` starts attaching region to App Engine entities, the golden tag will resolve automatically. The tag being unresolved today is not a regression — it was already the case for `gcp.zone`.

ARB Ticket - https://new-relic.atlassian.net/browse/NR-567584
🤖 Generated with [Claude Code](https://claude.com/claude-code)
