### PR TITLE
feat: Add GCPCLOUDSQLDATABASE entity definition

### DIFF
--- a/entity-types/infra-gcpcloudsqldatabase/dashboard.json
+++ b/entity-types/infra-gcpcloudsqldatabase/dashboard.json
@@ -1,0 +1,186 @@
+{
+  "name": "GCP Cloud SQL Database",
+  "description": null,
+  "pages": [
+    {
+      "name": "Summary",
+      "description": null,
+      "widgets": [
+        {
+          "title": "CPU Utilization (%)",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT max(`gcp.cloudsql.database.cpu.utilization`) * 100 FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Memory Utilization (%)",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT max(`gcp.cloudsql.database.memory.utilization`) * 100 FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Disk Utilization (%)",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT max(`gcp.cloudsql.database.disk.utilization`) * 100 FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Disk Bytes Used",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT max(`gcp.cloudsql.database.disk.bytes_used`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Network Bytes Received",
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.cloudsql.database.network.received_bytes_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Network Bytes Sent",
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.cloudsql.database.network.sent_bytes_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpcloudsqldatabase/definition.yml
+++ b/entity-types/infra-gcpcloudsqldatabase/definition.yml
@@ -1,0 +1,11 @@
+domain: INFRA
+type: GCPCLOUDSQLDATABASE
+goldenTags:
+- gcp.projectId
+- gcp.region
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-gcpcloudsqldatabase/golden_metrics.yml
+++ b/entity-types/infra-gcpcloudsqldatabase/golden_metrics.yml
@@ -1,0 +1,27 @@
+cpuUtilization:
+  title: CPU utilization
+  unit: PERCENTAGE
+  queries:
+    gcp:
+      select: max(`gcp.cloudsql.database.cpu.utilization`) * 100
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+memoryUtilization:
+  title: Memory utilization
+  unit: PERCENTAGE
+  queries:
+    gcp:
+      select: max(`gcp.cloudsql.database.memory.utilization`) * 100
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+diskUtilization:
+  title: Disk utilization
+  unit: PERCENTAGE
+  queries:
+    gcp:
+      select: max(`gcp.cloudsql.database.disk.utilization`) * 100
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-gcpcloudsqldatabase/summary_metrics.yml
+++ b/entity-types/infra-gcpcloudsqldatabase/summary_metrics.yml
@@ -1,0 +1,22 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: GCP account
+  unit: STRING
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
+cpuUtilization:
+  goldenMetric: cpuUtilization
+  unit: PERCENTAGE
+  title: CPU utilization
+memoryUtilization:
+  goldenMetric: memoryUtilization
+  unit: PERCENTAGE
+  title: Memory utilization
+diskUtilization:
+  goldenMetric: diskUtilization
+  unit: PERCENTAGE
+  title: Disk utilization


### PR DESCRIPTION
### Relevant information

Adding GCPCLOUDSQLDATABASE entity definition for GCP Cloud SQL Database (backs the GCP `cloudsql_database` monitored resource).

This PR adds:
- `definition.yml` with entity type, goldenTags (gcp.projectId, gcp.region), and alertable configuration
- `golden_metrics.yml` with 3 key performance metrics (cpuUtilization, memoryUtilization, diskUtilization)
- `summary_metrics.yml` with providerAccountName, gcp.projectId, and the golden metrics
- `dashboard.json` with 6 widgets covering CPU/Memory/Disk utilization and network I/O

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid.
* [x] I've confirmed that my entity type wasn't already defined.

> ⚠️ **Validation note**: No live `gcp.cloudsql.*` v2 metric data available in the checked NR accounts (10876283, 686923, 12208939, 10018487). Metric names verified against official GCP Cloud SQL documentation. NRQL syntax validated (queries execute without error).