### PR TITLE
feat: Add GCPCLOUDSQLINSTANCEDATABASE entity definition

### DIFF
--- a/entity-types/infra-gcpcloudsqlinstancedatabase/dashboard.json
+++ b/entity-types/infra-gcpcloudsqlinstancedatabase/dashboard.json
@@ -1,0 +1,186 @@
+{
+  "name": "GCP Cloud SQL Instance Database",
+  "description": null,
+  "pages": [
+    {
+      "name": "Summary",
+      "description": null,
+      "widgets": [
+        {
+          "title": "Client Connections",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`gcp.cloudsql.per_database.conn_pool.client_connections`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.status` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Server Connections",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`gcp.cloudsql.per_database.conn_pool.server_connections`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.status` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Connection Errors",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.cloudsql.per_database.conn_pool.client_connections_error_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Client Connection Attempts",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.cloudsql.per_database.conn_pool.client_connections_attempts_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Average Client Wait Time (µs)",
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.cloudsql.per_database.conn_pool.client_connections_avg_wait_time`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Number of Connection Pools",
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`gcp.cloudsql.per_database.conn_pool.num_pools`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpcloudsqlinstancedatabase/definition.yml
+++ b/entity-types/infra-gcpcloudsqlinstancedatabase/definition.yml
@@ -1,0 +1,11 @@
+domain: INFRA
+type: GCPCLOUDSQLINSTANCEDATABASE
+goldenTags:
+- gcp.projectId
+- gcp.region
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-gcpcloudsqlinstancedatabase/golden_metrics.yml
+++ b/entity-types/infra-gcpcloudsqlinstancedatabase/golden_metrics.yml
@@ -1,0 +1,27 @@
+clientConnections:
+  title: Client connections
+  unit: COUNT
+  queries:
+    gcp:
+      select: latest(`gcp.cloudsql.per_database.conn_pool.client_connections`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+serverConnections:
+  title: Server connections
+  unit: COUNT
+  queries:
+    gcp:
+      select: latest(`gcp.cloudsql.per_database.conn_pool.server_connections`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+connectionErrors:
+  title: Connection errors
+  unit: COUNT
+  queries:
+    gcp:
+      select: sum(`gcp.cloudsql.per_database.conn_pool.client_connections_error_count`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-gcpcloudsqlinstancedatabase/summary_metrics.yml
+++ b/entity-types/infra-gcpcloudsqlinstancedatabase/summary_metrics.yml
@@ -1,0 +1,22 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: GCP account
+  unit: STRING
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
+clientConnections:
+  goldenMetric: clientConnections
+  unit: COUNT
+  title: Client connections
+serverConnections:
+  goldenMetric: serverConnections
+  unit: COUNT
+  title: Server connections
+connectionErrors:
+  goldenMetric: connectionErrors
+  unit: COUNT
+  title: Connection errors


### PR DESCRIPTION
### Relevant information

Adding GCPCLOUDSQLINSTANCEDATABASE entity definition for GCP Cloud SQL Instance Database (backs the GCP `cloudsql_instance_database` monitored resource — a logical database on a Cloud SQL instance).

This PR adds:
- `definition.yml` with entity type, goldenTags (gcp.projectId, gcp.region), and alertable configuration
- `golden_metrics.yml` with 3 key performance metrics (clientConnections, serverConnections, connectionErrors)
- `summary_metrics.yml` with providerAccountName, gcp.projectId, and the golden metrics
- `dashboard.json` with 6 widgets covering connection pool health and connection attempts

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid.
* [x] I've confirmed that my entity type wasn't already defined.

> ⚠️ **Validation note**: No live `gcp.cloudsql.*` v2 metric data available in the checked NR accounts (10876283, 686923, 12208939, 10018487). Metric names verified against official GCP Cloud SQL documentation. NRQL syntax validated (queries execute without error).