### PR TITLE
feat(infra-host): add gcp dimensional queries for cpuUsage and network golden metrics

### DIFF
--- a/entity-types/infra-host/golden_metrics.yml
+++ b/entity-types/infra-host/golden_metrics.yml
@@ -44,7 +44,12 @@ cpuUsage:
       select: average(instance.cpu.Utilization)
       from: GcpVirtualMachineSample
       eventId: entityGuid
-      eventName: entityName          
+      eventName: entityName
+    gcp:
+      select: average(gcp.compute.instance.cpu.utilization) * 100
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
     oci:
       select: average(`oci.computeagent.cpu.utilization`)
       from: Metric
@@ -144,7 +149,12 @@ networkTrafficTx:
       select: average(instance.network.SentBytes)
       from: GcpVirtualMachineSample
       eventId: entityGuid
-      eventName: entityName        
+      eventName: entityName
+    gcp:
+      select: sum(gcp.compute.instance.network.sent_bytes_count)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
     oci:
       select: average(`oci.computeagent.network.bytes.out`)
       from: Metric
@@ -197,7 +207,12 @@ networkTrafficRx:
       select: average(instance.network.ReceivedBytes)
       from: GcpVirtualMachineSample
       eventId: entityGuid
-      eventName: entityName      
+      eventName: entityName
+    gcp:
+      select: sum(gcp.compute.instance.network.received_bytes_count)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
     oci:
       select: average(`oci.computeagent.network.bytes.in`)
       from: Metric


### PR DESCRIPTION
## Summary

Follow-up to `beyond/gcp-polling-v2` PR #136 which routes `gce_instance` metrics to the `HOST` entity type. This PR adds the corresponding dimensional Metric queries/widgets so HOST entities from the polling-agent path show meaningful data.

## What's added

**entity-definitions (`infra-host/golden_metrics.yml`):** dimensional `gcp:` queries alongside existing `gcpSample:` queries for
- `cpuUsage` — `average(gcp.compute.instance.cpu.utilization) * 100`
- Network sent — `sum(gcp.compute.instance.network.sent_bytes_count)`
- Network received — `sum(gcp.compute.instance.network.received_bytes_count)`

**infra-summary (`HOST_GCP-VM.json`):** existing 11 widgets → 17. Added dimensional Metric widgets for CPU, network sent/received, disk read/write, CPU reserved cores, uptime.

**infrastructure (new `gcp_vms_dimensional_metrics.json`):** 9-widget dimensional companion to existing sample-based `gcp_vms.json`.

## Related PRs

- `beyond/gcp-polling-v2#136` — the actual `entity_type: HOST` change (this PR is a no-op without that)

## Telemetry (account 10876283)

All `gcp.compute.*` metrics referenced here are flowing today (7.3M metrics/day currently on `GCPVIRTUALMACHINE` — after #136 lands they'll flow to `HOST`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
