### PR TITLE
feat: Add GCPVIRTUALMACHINEDISK entity definition

### DIFF
--- a/entity-types/infra-gcpvirtualmachinedisk/dashboard.json
+++ b/entity-types/infra-gcpvirtualmachinedisk/dashboard.json
@@ -1,0 +1,163 @@
+{
+  "name": "GCP Virtual Machine Disk",
+  "description": null,
+  "pages": [
+    {
+      "name": "GCP Virtual Machine Disk",
+      "description": null,
+      "widgets": [
+        {
+          "title": "Disk Read/Write Bytes",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT sum(`gcp.compute.instance.disk.read_bytes_count`) AS 'Read', sum(`gcp.compute.instance.disk.write_bytes_count`) AS 'Write' WHERE entity.guid IN ({{entity.guid}}) TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Disk Read/Write Operations",
+          "layout": {
+            "column": 7,
+            "row": 1,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT sum(`gcp.compute.instance.disk.read_ops_count`) AS 'Read ops', sum(`gcp.compute.instance.disk.write_ops_count`) AS 'Write ops' WHERE entity.guid IN ({{entity.guid}}) TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Average I/O Latency (ms)",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT average(`gcp.compute.instance.disk.average_io_latency`) / 1000 AS 'Avg I/O latency (ms)' WHERE entity.guid IN ({{entity.guid}}) TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Average I/O Queue Depth",
+          "layout": {
+            "column": 7,
+            "row": 4,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT average(`gcp.compute.instance.disk.average_io_queue_depth`) AS 'Queue depth' WHERE entity.guid IN ({{entity.guid}}) TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Throttled Operations",
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT sum(`gcp.compute.instance.disk.throttled_read_ops_count`) AS 'Throttled reads', sum(`gcp.compute.instance.disk.throttled_write_ops_count`) AS 'Throttled writes' WHERE entity.guid IN ({{entity.guid}}) TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Provisioned Size (GiB)",
+          "layout": {
+            "column": 7,
+            "row": 7,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT latest(`gcp.compute.instance.disk.provisioning.size`) / 1073741824 AS 'Size (GiB)' WHERE entity.guid IN ({{entity.guid}})"
+              }
+            ],
+            "thresholds": []
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpvirtualmachinedisk/definition.yml
+++ b/entity-types/infra-gcpvirtualmachinedisk/definition.yml
@@ -4,6 +4,11 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 
+goldenTags:
+  - gcp.projectId
+  - gcp.region
+  - gcp.zone
+
 ownership:
   primaryOwner:
     teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-gcpvirtualmachinedisk/golden_metrics.yml
+++ b/entity-types/infra-gcpvirtualmachinedisk/golden_metrics.yml
@@ -1,0 +1,45 @@
+readBytes:
+  title: Disk Read Bytes
+  unit: BYTES
+  queries:
+    gcp:
+      select: sum(`gcp.compute.instance.disk.read_bytes_count`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+writeBytes:
+  title: Disk Write Bytes
+  unit: BYTES
+  queries:
+    gcp:
+      select: sum(`gcp.compute.instance.disk.write_bytes_count`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+avgIoLatency:
+  title: Average I/O Latency
+  unit: MS
+  queries:
+    gcp:
+      select: average(`gcp.compute.instance.disk.average_io_latency`) / 1000
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+throttledReadOps:
+  title: Throttled Read Operations
+  unit: COUNT
+  queries:
+    gcp:
+      select: sum(`gcp.compute.instance.disk.throttled_read_ops_count`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+throttledWriteOps:
+  title: Throttled Write Operations
+  unit: COUNT
+  queries:
+    gcp:
+      select: sum(`gcp.compute.instance.disk.throttled_write_ops_count`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-gcpvirtualmachinedisk/summary_metrics.yml
+++ b/entity-types/infra-gcpvirtualmachinedisk/summary_metrics.yml
@@ -1,0 +1,30 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: GCP account
+  unit: STRING
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
+readBytes:
+  goldenMetric: readBytes
+  unit: BYTES
+  title: Disk Read Bytes
+writeBytes:
+  goldenMetric: writeBytes
+  unit: BYTES
+  title: Disk Write Bytes
+avgIoLatency:
+  goldenMetric: avgIoLatency
+  unit: MS
+  title: Average I/O Latency
+throttledReadOps:
+  goldenMetric: throttledReadOps
+  unit: COUNT
+  title: Throttled Read Operations
+throttledWriteOps:
+  goldenMetric: throttledWriteOps
+  unit: COUNT
+  title: Throttled Write Operations


### PR DESCRIPTION
### Relevant information

Adding entity definition files for GCPVIRTUALMACHINEDISK (GCP Virtual Machine Disk).

This PR adds:
- `golden_metrics.yml` — 5 golden metrics: readBytes, writeBytes, avgIoLatency, throttledReadOps, throttledWriteOps
- `summary_metrics.yml` — providerAccountName (GCP account), gcp.projectId (GCP project), and all golden metrics
- `dashboard.json` — 6-widget entity dashboard (read/write bytes, read/write ops, latency, queue depth, throttled ops, provisioned size)
- Updates existing `definition.yml` to add `goldenTags` (`gcp.projectId`, `gcp.region`, `gcp.zone`)

### Design notes

Golden metrics use `gcp.compute.instance.disk.*` attributes (native GCP Compute per-instance disk metrics) — aligning with the v1 approach that exposed per-disk throttled metrics via `gce_instance`'s per-device view.

**Requires companion PR to beyond/gcp-polling-v2** to change entity synthesis from `gce_disk` (limited to 5 replication metrics, no live data) to `gce_instance` with `metric_prefix: compute.googleapis.com/instance/disk/`. Without that change, the metrics in this PR won't attach to synthesized entities.

### Validation

All queries validated via NR MCP against account 10876283:
- Non-throttled I/O metrics: 2.58 TB read / 12.16 TB write, 4.47ms avg latency over 30 days
- Throttled metrics: 0 (metric names valid — only emit when actual throttling occurs, GCP-expected behavior)
- FACET queries with `metric.device_name`, `metric.storage_type`, `metric.instance_name` return real per-disk data

Ran `npm --prefix validator run check` — all 8 validator checks pass.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid.
* [x] I've confirmed that my entity type wasn't already defined.