### PR TITLE
feat(gcpbigquerydataset): add dashboard.json and extend goldenTags

### DIFF
--- a/entity-types/infra-gcpbigquerydataset/dashboard.json
+++ b/entity-types/infra-gcpbigquerydataset/dashboard.json
@@ -1,0 +1,194 @@
+{
+  "name": "GCP BigQuery Dataset",
+  "description": null,
+  "pages": [
+    {
+      "name": "GCP BigQuery Dataset",
+      "description": null,
+      "widgets": [
+        {
+          "title": "Stored Bytes",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT sum(`gcp.bigquery.storage.stored_bytes`) AS 'Stored Bytes' WHERE entity.guid IN ({{entity.guid}}) TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Number of Tables",
+          "layout": {
+            "column": 7,
+            "row": 1,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT sum(`gcp.bigquery.storage.table_count`) AS 'Tables' WHERE entity.guid IN ({{entity.guid}}) TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Uploaded Bytes",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT sum(`gcp.bigquery.storage.uploaded_bytes`) AS 'Uploaded Bytes' WHERE entity.guid IN ({{entity.guid}}) TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Uploaded Bytes Billed",
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT sum(`gcp.bigquery.storage.uploaded_bytes_billed`) AS 'Uploaded Bytes Billed' WHERE entity.guid IN ({{entity.guid}}) TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Uploaded Rows",
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT sum(`gcp.bigquery.storage.uploaded_row_count`) AS 'Uploaded Rows' WHERE entity.guid IN ({{entity.guid}}) TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Uploaded Bytes by API",
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.bar"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT sum(`gcp.bigquery.storage.uploaded_bytes`) AS 'Uploaded Bytes' WHERE entity.guid IN ({{entity.guid}}) FACET `metric.api`"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Stored Bytes by Table (Top 10)",
+          "layout": {
+            "column": 7,
+            "row": 7,
+            "width": 6,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.bar"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT latest(`gcp.bigquery.storage.stored_bytes`) AS 'Stored Bytes' WHERE entity.guid IN ({{entity.guid}}) FACET `metric.table` LIMIT 10"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpbigquerydataset/definition.yml
+++ b/entity-types/infra-gcpbigquerydataset/definition.yml
@@ -3,6 +3,8 @@ type: GCPBIGQUERYDATASET
 goldenTags:
 - gcp.projectId
 - gcp.zone
+- gcp.region
+- gcp.datasetId
 configuration:
   entityExpirationTime: DAILY
   alertable: true


### PR DESCRIPTION
## Summary

Fills gaps in the existing `GCPBIGQUERYDATASET` entity definition:

- **`dashboard.json` (NEW)** — 7 widgets covering the full set of dataset-scoped metrics:
  - Stored Bytes (line)
  - Number of Tables (line)
  - Uploaded Bytes / Uploaded Bytes Billed / Uploaded Rows (line)
  - Uploaded Bytes by API (`metric.api` facet, bar)
  - Stored Bytes by Table, top 10 (`metric.table` facet, bar)
- **`definition.yml`** — extend `goldenTags` with `gcp.region` and `gcp.datasetId` alongside existing `gcp.projectId` and `gcp.zone`. `dataset_id` is one of the two identifying labels for the `bigquery_dataset` monitored resource per GCP docs.
- Existing `golden_metrics.yml` and `summary_metrics.yml` are unchanged (both `Metric` and legacy `GcpBigQueryDataSetSample` entries preserved).

Metric names sourced from https://cloud.google.com/monitoring/api/metrics_gcp_a_b#gcp-bigquery — all metrics are GA and scoped to the `bigquery_dataset` monitored resource type.

Companion PRs:
- infra-summary: `feat/gcp-bigquerydataset-dashboard`
- infrastructure: `feat/gcp-bigquerydataset-infra-metrics`

## Validation

- `npm run check` in `validator/` passes (schemas + rules + relationship-synthesis).
- `sanitize-dashboards` produced no changes.
- NR MCP NRQL validation was not executed in this session (tool unavailable); metric names are sourced directly from the official GCP metrics reference. Recommend a manual NRQL spot-check post-merge.

## Test plan

- [ ] Confirm CI (validator + linting) passes
- [ ] After merge, verify entity type appears with dashboard in a NR account with GCP BigQuery integration
- [ ] Spot-check that new golden tags (`gcp.region`, `gcp.datasetId`) appear on synthesized entities

🤖 Generated with [Claude Code](https://claude.com/claude-code)