### PR TITLE
feat: Add golden_metrics, summary_metrics, and dashboard for GCPCOMPOSERWORKFLOW

### DIFF
--- a/entity-types/infra-gcpcomposerworkflow/dashboard.json
+++ b/entity-types/infra-gcpcomposerworkflow/dashboard.json
@@ -1,0 +1,186 @@
+{
+  "name": "GCP Composer Workflow",
+  "description": null,
+  "pages": [
+    {
+      "name": "Summary",
+      "description": null,
+      "widgets": [
+        {
+          "title": "Workflow Runs by State",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.composer.workflow.run_count`) AS 'Runs' FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.state` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Workflow Run Duration (avg)",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.composer.workflow.run_duration`) AS 'Avg Duration (s)' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Failed Run Rate",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT filter(sum(`gcp.composer.workflow.run_count`), WHERE `metric.state` = 'failed') * 100 / sum(`gcp.composer.workflow.run_count`) AS 'Failed %' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Schedule Delay (avg)",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.composer.workflow.schedule_delay`) AS 'Avg Delay (ms)' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Task Runs by State",
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.composer.workflow.task.run_count`) AS 'Task Runs' FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.state` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Task Run Duration (avg)",
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.composer.workflow.task.run_duration`) AS 'Avg Task Duration (s)' FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpcomposerworkflow/definition.yml
+++ b/entity-types/infra-gcpcomposerworkflow/definition.yml
@@ -4,6 +4,11 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 
+goldenTags:
+  - gcp.projectId
+  - gcp.location
+  - gcp.environmentName
+
 ownership:
   primaryOwner:
     teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-gcpcomposerworkflow/golden_metrics.yml
+++ b/entity-types/infra-gcpcomposerworkflow/golden_metrics.yml
@@ -1,0 +1,27 @@
+runCount:
+  title: Workflow Runs
+  unit: COUNT
+  queries:
+    gcp:
+      select: sum(`gcp.composer.workflow.run_count`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+runDuration:
+  title: Workflow Run Duration
+  unit: SECONDS
+  queries:
+    gcp:
+      select: average(`gcp.composer.workflow.run_duration`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+failedRunRate:
+  title: Failed Run Rate
+  unit: PERCENTAGE
+  queries:
+    gcp:
+      select: filter(sum(`gcp.composer.workflow.run_count`), WHERE `metric.state` = 'failed') * 100 / sum(`gcp.composer.workflow.run_count`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-gcpcomposerworkflow/summary_metrics.yml
+++ b/entity-types/infra-gcpcomposerworkflow/summary_metrics.yml
@@ -1,0 +1,22 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: GCP account
+  unit: STRING
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
+runCount:
+  goldenMetric: runCount
+  unit: COUNT
+  title: Workflow Runs
+runDuration:
+  goldenMetric: runDuration
+  unit: SECONDS
+  title: Workflow Run Duration
+failedRunRate:
+  goldenMetric: failedRunRate
+  unit: PERCENTAGE
+  title: Failed Run Rate


### PR DESCRIPTION
## Summary
- Adds `golden_metrics.yml`, `summary_metrics.yml`, `dashboard.json` for `GCPCOMPOSERWORKFLOW` entity
- Adds `goldenTags` block to existing stub `definition.yml` (projectId, location, environmentName)

## Golden metrics
- `runCount` — sum(`gcp.composer.workflow.run_count`)
- `runDuration` — average(`gcp.composer.workflow.run_duration`)
- `failedRunRate` — % of failed workflow runs (derived from run_count faceted by state)

Metrics sourced from official GCP Cloud Monitoring docs (BETA/GA only).

## Related PRs
This is one of 5 PRs adding GCP Cloud Composer Workflow support end-to-end:
- entity-type-ui-definitions-service — UI definition
- gcp-polling-v2 — entity synthesis + datasource mapping
- infra-summary — dashboard templates
- infrastructure — dimensional metrics dashboard

## Test plan
- [ ] CI validator passes (schema check + dashboard sanitizer)
- [ ] After gcp-polling-v2 merge, entity gets synthesized in test account
- [ ] Golden metric queries return data for a real workflow

## Notes
- Phase 3a NR MCP validation was skipped (auth unavailable at time of authoring). NRQL queries follow the pattern used by neighboring GCP v2 entities but are not verified against live data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)