### PR TITLE
feat: Add entity definition for GCPCOMPOSERENVIRONMENT (Cloud Composer)

### DIFF
--- a/entity-types/infra-gcpcomposerenvironment/dashboard.json
+++ b/entity-types/infra-gcpcomposerenvironment/dashboard.json
@@ -1,0 +1,273 @@
+{
+  "name": "GCP Cloud Composer Environment",
+  "description": null,
+  "pages": [
+    {
+      "name": "Summary",
+      "description": null,
+      "widgets": [
+        {
+          "title": "Running Tasks",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.composer.environment.executor.running_tasks`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Queued Tasks",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.composer.environment.executor.queued_tasks`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Database CPU Utilization",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.composer.environment.database.cpu.utilization`) * 100 FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Open Executor Slots",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.composer.environment.executor.open_slots`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Finished Task Instances",
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.composer.environment.finished_task_instance_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "DAG Bag Size",
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.composer.environment.dagbag_size`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Database Memory Utilization",
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.composer.environment.database.memory.utilization`) * 100 FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "API Request Count",
+          "layout": {
+            "column": 5,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.composer.environment.api.request_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "API Request Latency",
+          "layout": {
+            "column": 9,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.composer.environment.api.request_latencies`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpcomposerenvironment/definition.yml
+++ b/entity-types/infra-gcpcomposerenvironment/definition.yml
@@ -1,5 +1,8 @@
 domain: INFRA
 type: GCPCOMPOSERENVIRONMENT
+goldenTags:
+- gcp.projectId
+- gcp.region
 configuration:
   entityExpirationTime: DAILY
   alertable: true

--- a/entity-types/infra-gcpcomposerenvironment/golden_metrics.yml
+++ b/entity-types/infra-gcpcomposerenvironment/golden_metrics.yml
@@ -1,0 +1,27 @@
+runningTasks:
+  title: Running Tasks
+  unit: COUNT
+  queries:
+    gcp:
+      select: average(`gcp.composer.environment.executor.running_tasks`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+queuedTasks:
+  title: Queued Tasks
+  unit: COUNT
+  queries:
+    gcp:
+      select: average(`gcp.composer.environment.executor.queued_tasks`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+dbCpuUtilization:
+  title: Database CPU Utilization
+  unit: PERCENTAGE
+  queries:
+    gcp:
+      select: average(`gcp.composer.environment.database.cpu.utilization`) * 100
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-gcpcomposerenvironment/summary_metrics.yml
+++ b/entity-types/infra-gcpcomposerenvironment/summary_metrics.yml
@@ -1,0 +1,23 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: GCP account
+  unit: STRING
+
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
+runningTasks:
+  goldenMetric: runningTasks
+  unit: COUNT
+  title: Running Tasks
+queuedTasks:
+  goldenMetric: queuedTasks
+  unit: COUNT
+  title: Queued Tasks
+dbCpuUtilization:
+  goldenMetric: dbCpuUtilization
+  unit: PERCENTAGE
+  title: Database CPU Utilization


### PR DESCRIPTION
## Summary

Adds full entity definitions for the existing **GCPCOMPOSERENVIRONMENT** stub, enabling golden metrics, summary metrics, and an entity dashboard for GCP Cloud Composer Environments.

## Changes

- **definition.yml** — adds `goldenTags: [gcp.projectId, gcp.region]`
- **golden_metrics.yml** — 3 metrics selected from GCP Cloud Monitoring BETA metrics:
  - `runningTasks` — `average(gcp.composer.environment.executor.running_tasks)`
  - `queuedTasks` — `average(gcp.composer.environment.executor.queued_tasks)`
  - `dbCpuUtilization` — `average(gcp.composer.environment.database.cpu.utilization) * 100`
- **summary_metrics.yml** — GCP account, project ID, and the three golden metrics
- **dashboard.json** — 9-widget entity dashboard covering executor state, DAG bag, DB utilization, and API request activity

All metric names were sourced from the official GCP Cloud Monitoring metrics reference for `composer.googleapis.com`. Only BETA/GA metrics were used (no ALPHA).

## Validation

- ✅ `npm --prefix validator run check` passes
- ✅ Dashboard sanitizer ran cleanly (no changes)
- ⚠️ NR MCP queries for `gcp.composer.*` return 0 rows in account 10876283 — expected, since GCPCOMPOSERENVIRONMENT synthesis isn't live yet (that mapping is added in the [`gcp-polling-v2` companion PR](#)). Metric names verified against GCP official documentation.

## Companion PRs

- **entity-type-ui-definitions-service** — UI enrichment
- **gcp-polling-v2** — synthesis mapping (`composer.googleapis.com/Environment` → `GCPCOMPOSERENVIRONMENT`)
- **infra-summary** — dashboard templates for generic-metrics/generic-overview nerdlets
- **infrastructure** — dimensional-metrics cloud dashboard

## Test plan

- [ ] CI validator green
- [ ] Cross-team review from Cloud Monitoring Platform
- [ ] Verify entity dashboard renders once companion `gcp-polling-v2` PR is merged and Composer env is polled