### PR TITLE
feat(nginx): update nginxserver to apm / ext service relationship synthesis rules

### DIFF
--- a/entity-types/infra-nginxserver/definition.stg.yml
+++ b/entity-types/infra-nginxserver/definition.stg.yml
@@ -1,0 +1,414 @@
+domain: INFRA
+type: NGINXSERVER
+
+goldenTags:
+- nginx.port
+- nginx.version
+- nginx.edition
+- nginx.hostname
+
+synthesis:
+  rules:
+
+  - ruleName: infra_nginxserver_composite
+    compositeIdentifier:
+      separator: ":"
+      attributes:
+        - nginx.deployment.name
+        - nginx.server.endpoint
+    name: nginx.display.name
+    encodeIdentifierInGUID: true
+    conditions:
+      - attribute: eventType
+        value: Metric
+      - attribute: nginx.deployment.name
+        present: true
+      - attribute: nginx.server.endpoint
+        present: true
+      - attribute: nginx.display.name
+        present: true
+      # All metrics from the receiver starts with the 'nginx.' prefix.
+      - attribute: metricName
+        prefix: nginx.
+      - attribute: instrumentation.provider
+        value: opentelemetry
+      # This filters only metrics coming from nginx receiver, given that metrics
+      # could differ between different runtime receivers.
+      - attribute: otel.library.name
+        value: "otelcol/nginxreceiver"
+    tags:
+      # Default resource attributes
+      nginx.server.endpoint:
+      nginx.deployment.name:
+      # OTel attributes
+      # The library name contains the name of the receiver that is used to identify the source
+      # and select the dashboard.
+      otel.library.name:
+        entityTagName: instrumentation.name
+  - ruleName: infra_nginxserver_composite_2
+    compositeIdentifier:
+      separator: ":"
+      attributes:
+        - nginx.deployment.name
+        - nginx.server.endpoint
+    name: nginx.display.name
+    encodeIdentifierInGUID: true
+    conditions:
+      - attribute: eventType
+        value: Metric
+      - attribute: nginx.deployment.name
+        present: true
+      - attribute: nginx.server.endpoint
+        present: true
+      - attribute: nginx.display.name
+        present: true
+      # All metrics from the receiver starts with the 'nginx.' prefix.
+      - attribute: metricName
+        prefix: nginx.
+      - attribute: instrumentation.provider
+        value: opentelemetry
+      # This filters only metrics coming from nginx receiver, given that metrics
+      # could differ between different runtime receivers.
+      - attribute: otel.library.name
+        value: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiver"
+    tags:
+      # Default resource attributes
+      nginx.server.endpoint:
+      nginx.deployment.name:
+      # OTel attributes
+      # The library name contains the name of the receiver that is used to identify the source
+      # and select the dashboard.
+      otel.library.name:
+        entityTagName: instrumentation.name
+  - ruleName: infra_nginxserver_composite_3
+    compositeIdentifier:
+      separator: ":"
+      attributes:
+        - nginx.deployment.name
+        - nginx.server.endpoint
+    name: nginx.display.name
+    encodeIdentifierInGUID: true
+    conditions:
+      - attribute: eventType
+        value: Metric
+      - attribute: nginx.deployment.name
+        present: true
+      - attribute: nginx.server.endpoint
+        present: true
+      - attribute: nginx.display.name
+        present: true
+      - attribute: metricName
+        prefix: nginxplus_
+      - attribute: instrumentation.provider
+        value: opentelemetry
+      - attribute: otel.library.name
+        value: "otelcol/prometheusreceiver"
+    tags:
+      nginx.server.endpoint:
+      nginx.deployment.name:
+      otel.library.name:
+        entityTagName: instrumentation.name
+  - ruleName: infra_nginxserver_composite_4
+    compositeIdentifier:
+      separator: ":"
+      attributes:
+        - nginx.deployment.name
+        - nginx.server.endpoint
+    name: nginx.display.name
+    encodeIdentifierInGUID: true
+    conditions:
+      - attribute: eventType
+        value: Metric
+      - attribute: nginx.deployment.name
+        present: true
+      - attribute: nginx.server.endpoint
+        present: true
+      - attribute: nginx.display.name
+        present: true
+      - attribute: metricName
+        prefix: nginxplus_
+      - attribute: instrumentation.provider
+        value: opentelemetry
+      - attribute: otel.library.name
+        value: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver"
+    tags:
+      nginx.server.endpoint:
+      # Deployment name — exposed as a tag for NGINXSERVER candidate (Path A) lookup.
+      nginx.deployment.name:
+      otel.library.name:
+        entityTagName: instrumentation.name
+  - ruleName: infra_nginxserver_composite_5
+    compositeIdentifier:
+      separator: ":"
+      attributes:
+        - nginx.deployment.name
+        - nginx.server.endpoint
+    name: nginx.display.name
+    encodeIdentifierInGUID: true
+    conditions:
+      - attribute: eventType
+        value: Log
+      - attribute: newrelic.source
+        value: 'api.logs.otlp'
+      - attribute: nginx.deployment.name
+        present: true
+      - attribute: nginx.server.endpoint
+        present: true
+      - attribute: nginx.display.name
+        present: true
+      - attribute: instrumentation.provider
+        value: opentelemetry
+    tags:
+      nginx.server.endpoint:
+      nginx.deployment.name:
+  - ruleName: infra_nginxserver_composite_6
+    compositeIdentifier:
+      separator: ":"
+      attributes:
+        - nginx.deployment.name
+        - nginx.server.endpoint
+    name: nginx.display.name
+    encodeIdentifierInGUID: true
+    conditions:
+      - attribute: eventType
+        value: Metric
+      - attribute: nginx.deployment.name
+        present: true
+      - attribute: nginx.server.endpoint
+        present: true
+      - attribute: nginx.display.name
+        present: true
+      - attribute: metricName
+        prefix: nginx.
+      - attribute: instrumentation.provider
+        value: opentelemetry
+      - attribute: otel.library.name
+        value: "otelcol/prometheusreceiver"
+    tags:
+      nginx.server.endpoint:
+      nginx.deployment.name:
+      otel.library.name:
+        entityTagName: instrumentation.name
+  - ruleName: infra_nginxserver_composite_7
+    compositeIdentifier:
+      separator: ":"
+      attributes:
+        - nginx.deployment.name
+        - nginx.server.endpoint
+    name: nginx.display.name
+    encodeIdentifierInGUID: true
+    conditions:
+      - attribute: eventType
+        value: Metric
+      - attribute: nginx.deployment.name
+        present: true
+      - attribute: nginx.server.endpoint
+        present: true
+      - attribute: nginx.display.name
+        present: true
+      - attribute: metricName
+        prefix: nginx.
+      - attribute: instrumentation.provider
+        value: opentelemetry
+      - attribute: otel.library.name
+        value: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver"
+    tags:
+      nginx.server.endpoint:
+      nginx.deployment.name:
+      otel.library.name:
+        entityTagName: instrumentation.name
+
+  - ruleName: infra_nginxserver_address_composite
+    compositeIdentifier:
+      separator: ":"
+      attributes:
+        - nginx.server.address
+        - nginx.server.port
+    name: nginx.server.address
+    encodeIdentifierInGUID: true
+    conditions:
+      - attribute: eventType
+        value: Metric
+      - attribute: nginx.deployment.name
+        present: false
+      - attribute: nginx.server.address
+        present: true
+      - attribute: nginx.server.port
+        present: true
+      - attribute: metricName
+        prefix: nginx.
+      - attribute: instrumentation.provider
+        value: opentelemetry
+      - attribute: otel.library.name
+        value: "otelcol/nginxreceiver"
+    tags:
+      nginx.server.address:
+      nginx.server.port:
+      otel.library.name:
+        entityTagName: instrumentation.name
+
+  - ruleName: infra_nginxserver_address_composite_2
+    compositeIdentifier:
+      separator: ":"
+      attributes:
+        - nginx.server.address
+        - nginx.server.port
+    name: nginx.server.address
+    encodeIdentifierInGUID: true
+    conditions:
+      - attribute: eventType
+        value: Metric
+      - attribute: nginx.deployment.name
+        present: false
+      - attribute: nginx.server.address
+        present: true
+      - attribute: nginx.server.port
+        present: true
+      - attribute: metricName
+        prefix: nginx.
+      - attribute: instrumentation.provider
+        value: opentelemetry
+      - attribute: otel.library.name
+        value: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiver"
+    tags:
+      nginx.server.address:
+      nginx.server.port:
+      otel.library.name:
+        entityTagName: instrumentation.name
+
+  - ruleName: infra_nginxserver_address_composite_3
+    compositeIdentifier:
+      separator: ":"
+      attributes:
+        - nginx.server.address
+        - nginx.server.port
+    name: nginx.server.address
+    encodeIdentifierInGUID: true
+    conditions:
+      - attribute: eventType
+        value: Metric
+      - attribute: nginx.deployment.name
+        present: false
+      - attribute: nginx.server.address
+        present: true
+      - attribute: nginx.server.port
+        present: true
+      - attribute: metricName
+        prefix: nginxplus_
+      - attribute: instrumentation.provider
+        value: opentelemetry
+      - attribute: otel.library.name
+        value: "otelcol/prometheusreceiver"
+    tags:
+      nginx.server.address:
+      nginx.server.port:
+      otel.library.name:
+        entityTagName: instrumentation.name
+
+  - ruleName: infra_nginxserver_address_composite_4
+    compositeIdentifier:
+      separator: ":"
+      attributes:
+        - nginx.server.address
+        - nginx.server.port
+    name: nginx.server.address
+    encodeIdentifierInGUID: true
+    conditions:
+      - attribute: eventType
+        value: Metric
+      - attribute: nginx.deployment.name
+        present: false
+      - attribute: nginx.server.address
+        present: true
+      - attribute: nginx.server.port
+        present: true
+      - attribute: metricName
+        prefix: nginxplus_
+      - attribute: instrumentation.provider
+        value: opentelemetry
+      - attribute: otel.library.name
+        value: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver"
+    tags:
+      nginx.server.address:
+      nginx.server.port:
+      otel.library.name:
+        entityTagName: instrumentation.name
+
+  - ruleName: infra_nginxserver_address_composite_5
+    compositeIdentifier:
+      separator: ":"
+      attributes:
+        - nginx.server.address
+        - nginx.server.port
+    name: nginx.server.address
+    encodeIdentifierInGUID: true
+    conditions:
+      - attribute: eventType
+        value: Metric
+      - attribute: nginx.deployment.name
+        present: false
+      - attribute: nginx.server.address
+        present: true
+      - attribute: nginx.server.port
+        present: true
+      - attribute: metricName
+        prefix: nginx.
+      - attribute: instrumentation.provider
+        value: opentelemetry
+      - attribute: otel.library.name
+        value: "otelcol/prometheusreceiver"
+    tags:
+      nginx.server.address:
+      nginx.server.port:
+      otel.library.name:
+        entityTagName: instrumentation.name
+
+  - ruleName: infra_nginxserver_address_composite_6
+    compositeIdentifier:
+      separator: ":"
+      attributes:
+        - nginx.server.address
+        - nginx.server.port
+    name: nginx.server.address
+    encodeIdentifierInGUID: true
+    conditions:
+      - attribute: eventType
+        value: Metric
+      - attribute: nginx.deployment.name
+        present: false
+      - attribute: nginx.server.address
+        present: true
+      - attribute: nginx.server.port
+        present: true
+      - attribute: metricName
+        prefix: nginx.
+      - attribute: instrumentation.provider
+        value: opentelemetry
+      - attribute: otel.library.name
+        value: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver"
+    tags:
+      nginx.server.address:
+      nginx.server.port:
+      otel.library.name:
+        entityTagName: instrumentation.name
+
+  tags:
+    # For OpenTelemetry
+    telemetry.sdk.name:
+      entityTagName: instrumentation.provider
+
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+
+dashboardTemplates:
+  # This should match the entity created from the ohi in the infra pipeline
+  newRelic:
+    template: newrelic_dashboard.json
+  # otel receiver
+  opentelemetry:
+    template: opentelemetry_dashboard.json
+
+ownership:
+  primaryOwner:
+    teamName: "OnHost Agent and Integrations"

--- a/entity-types/infra-nginxserver/tests/Metric.stg.json
+++ b/entity-types/infra-nginxserver/tests/Metric.stg.json
@@ -96,5 +96,141 @@
         "otel.library.version": "1.15.1",
         "state": "reading",
         "timestamp": 1779694506390
+    },
+    {
+        "description": "The current number of nginx connections by state",
+        "instrumentation.provider": "opentelemetry",
+        "metricName": "nginx.connections_current",
+        "newrelic.source": "api.metrics.otlp",
+        "nginx.connections_current": {
+            "type": "gauge",
+            "count": 1,
+            "sum": 1,
+            "min": 1,
+            "max": 1,
+            "latest": 1
+        },
+        "nginx.server.address": "10.10.49.147",
+        "nginx.server.port": "80",
+        "nginx.server.endpoint": "http://10.10.49.147/nginx_status",
+        "otel.library.name": "otelcol/nginxreceiver",
+        "otel.library.version": "0.82.0",
+        "state": "active",
+        "timestamp": 1780000000001
+    },
+    {
+        "description": "The current number of nginx connections by state",
+        "instrumentation.provider": "opentelemetry",
+        "metricName": "nginx.connections_current",
+        "newrelic.source": "api.metrics.otlp",
+        "nginx.connections_current": {
+            "type": "gauge",
+            "count": 1,
+            "sum": 1,
+            "min": 1,
+            "max": 1,
+            "latest": 1
+        },
+        "nginx.server.address": "10.10.49.147",
+        "nginx.server.port": "80",
+        "nginx.server.endpoint": "http://10.10.49.147/nginx_status",
+        "otel.library.name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiver",
+        "otel.library.version": "0.121.0",
+        "state": "active",
+        "timestamp": 1780000000002
+    },
+    {
+        "description": "Active client connections",
+        "http.scheme": "http",
+        "instrumentation.provider": "opentelemetry",
+        "metricName": "nginxplus_connections_active",
+        "net.host.port": "9113",
+        "newrelic.source": "api.metrics.otlp",
+        "nginxplus_connections_active": {
+            "type": "gauge",
+            "count": 1,
+            "sum": 1,
+            "min": 1,
+            "max": 1,
+            "latest": 1
+        },
+        "nginx.server.address": "10.10.49.147",
+        "nginx.server.port": "80",
+        "nginx.server.endpoint": "http://10.10.49.147/api/9",
+        "os.type": "linux",
+        "otel.library.name": "otelcol/prometheusreceiver",
+        "otel.library.version": "0.82.0",
+        "service.instance.id": "10.10.49.147:9113",
+        "service.name": "",
+        "timestamp": 1780000000003
+    },
+    {
+        "description": "Active client connections",
+        "http.scheme": "http",
+        "instrumentation.provider": "opentelemetry",
+        "metricName": "nginxplus_connections_active",
+        "net.host.port": "9113",
+        "newrelic.source": "api.metrics.otlp",
+        "nginxplus_connections_active": {
+            "type": "gauge",
+            "count": 1,
+            "sum": 1,
+            "min": 1,
+            "max": 1,
+            "latest": 1
+        },
+        "nginx.server.address": "10.10.49.147",
+        "nginx.server.port": "80",
+        "nginx.server.endpoint": "http://10.10.49.147/api/9",
+        "os.type": "linux",
+        "otel.library.name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel.library.version": "1.15.1",
+        "service.instance.id": "10.10.49.147:9113",
+        "service.name": "",
+        "timestamp": 1780000000004
+    },
+    {
+        "description": "The current number of nginx connections by state",
+        "instrumentation.provider": "opentelemetry",
+        "metricName": "nginx.connections_current",
+        "newrelic.source": "api.metrics.otlp",
+        "nginx.connections_current": {
+            "type": "gauge",
+            "count": 1,
+            "sum": 1,
+            "min": 1,
+            "max": 1,
+            "latest": 1
+        },
+        "nginx.server.address": "10.10.49.147",
+        "nginx.server.port": "80",
+        "nginx.server.endpoint": "http://10.10.49.147/nginx_status",
+        "os.type": "linux",
+        "otel.library.name": "otelcol/prometheusreceiver",
+        "otel.library.version": "0.82.0",
+        "state": "active",
+        "timestamp": 1780000000005
+    },
+    {
+        "description": "The current number of nginx connections by state",
+        "instrumentation.provider": "opentelemetry",
+        "metricName": "nginx.connections_current",
+        "newrelic.source": "api.metrics.otlp",
+        "nginx.connections_current": {
+            "type": "gauge",
+            "count": 1,
+            "sum": 1,
+            "min": 1,
+            "max": 1,
+            "latest": 1
+        },
+        "nginx.server.address": "10.10.49.147",
+        "nginx.server.port": "80",
+        "nginx.server.endpoint": "http://10.10.49.147/nginx_status",
+        "os.type": "linux",
+        "otel.library.name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel.library.version": "1.15.1",
+        "state": "active",
+        "timestamp": 1780000000006
     }
 ]

--- a/relationships/candidates/NGINXSERVER.stg.yml
+++ b/relationships/candidates/NGINXSERVER.stg.yml
@@ -1,66 +1,28 @@
 category: NGINXSERVER
 lookups:
-  # ── Outbound: NGINXSERVER → EXT SERVICE (backends) ────────────────────────
-  # Used by: INFRA-NGINXSERVER-to-EXT-SERVICE.stg.yml
+  # Path A — deployment-name lookup
   - entityTypes:
-      - domain: EXT
-        type: SERVICE
+      - domain: INFRA
+        type: NGINXSERVER
     tags:
       matchingMode: ALL
       predicates:
         - tagKeys: ["nginx.deployment.name"]
-          field: nginxDeploymentNameExtService
+          field: deploymentName
     onMatch:
       onMultipleMatches: RELATE_ALL
     onMiss:
       action: NO_OP
 
-  # ── Outbound: NGINXSERVER → APM APPLICATION (backends) ────────────────────
-  # Used by: INFRA-NGINXSERVER-to-APM-APPLICATION.stg.yml
+  # Path B — address-only lookup
   - entityTypes:
-      - domain: APM
-        type: APPLICATION
+      - domain: INFRA
+        type: NGINXSERVER
     tags:
       matchingMode: ALL
       predicates:
-        - tagKeys: ["nginx.deployment.name"]
-          field: nginxDeploymentNameApmApp
-    onMatch:
-      onMultipleMatches: RELATE_ALL
-    onMiss:
-      action: NO_OP
-
-  # ── Inbound: EXT SERVICE → NGINXSERVER (clients) ──────────────────────────
-  # Used by: EXT-SERVICE-to-INFRA-NGINXSERVER.stg.yml
-  # OTel client services set tags.nginx.upstream.deployment.name to identify
-  # which NGINXSERVER they call. Keyed separately from nginx.deployment.name
-  # to distinguish callers from callees.
-  - entityTypes:
-      - domain: EXT
-        type: SERVICE
-    tags:
-      matchingMode: ALL
-      predicates:
-        - tagKeys: ["nginx.upstream.deployment.name"]
-          field: nginxUpstreamDeploymentNameExtService
-    onMatch:
-      onMultipleMatches: RELATE_ALL
-    onMiss:
-      action: NO_OP
-
-  # ── Inbound: APM APPLICATION → NGINXSERVER (clients) ──────────────────────
-  # Used by: APM-APPLICATION-to-INFRA-NGINXSERVER.stg.yml
-  # NR APM client services set NEW_RELIC_LABELS=nginx.upstream.deployment.name:<value>,
-  # which becomes an entity tag. Keyed separately from nginx.deployment.name
-  # to distinguish callers from callees.
-  - entityTypes:
-      - domain: APM
-        type: APPLICATION
-    tags:
-      matchingMode: ALL
-      predicates:
-        - tagKeys: ["nginx.upstream.deployment.name"]
-          field: nginxUpstreamDeploymentNameApmApp
+        - tagKeys: ["nginx.server.address"]
+          field: serverAddress
     onMatch:
       onMultipleMatches: RELATE_ALL
     onMiss:

--- a/relationships/synthesis/APM-APPLICATION-to-INFRA-NGINXSERVER.stg.yml
+++ b/relationships/synthesis/APM-APPLICATION-to-INFRA-NGINXSERVER.stg.yml
@@ -1,68 +1,46 @@
 relationships:
-  - name: apmApplicationCallsOtelInfraNginxServer
+  - name: apmApplicationCallsNginxServerByUpstreamLabelStg
     version: "1"
     origins:
-      - OpenTelemetry
+      - Distributed Tracing
+      - APM Metrics
     conditions:
       - attribute: eventType
-        anyOf: [ "Metric" ]
-      - attribute: nginx.deployment.name
+        anyOf: [ "Span", "Transaction" ]
+      - attribute: newrelic.source
+        present: false
+      - attribute: tags.nginx.upstream.deployment.name
         present: true
-      - attribute: nginx.server.endpoint
-        present: true
-      - attribute: nginx.display.name
-        present: true
-      - attribute: metricName
-        startsWith: nginx.
-      - attribute: instrumentation.provider
-        anyOf: [ "opentelemetry" ]
-      - attribute: otel.library.name
-        anyOf: [ "otelcol/prometheusreceiver", "otelcol/nginxreceiver", "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiver", "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver" ]
     relationship:
       expires: PT75M
       relationshipType: CALLS
       source:
+        extractGuid:
+          attribute: entity.guid
+      target:
         lookupGuid:
           candidateCategory: NGINXSERVER
           fields:
-            - field: nginxUpstreamDeploymentNameApmApp
-              attribute: nginx.deployment.name
-      target:
-        extractGuid:
-          attribute: entity.guid
-          entityType:
-            value: NGINXSERVER
-
-  - name: apmApplicationCallsOtelInfraNginxPlusServer
+            - field: deploymentName
+              attribute: tags.nginx.upstream.deployment.name
+  - name: apmApplicationCallsNginxServerByAddressStg
     version: "1"
     origins:
-      - OpenTelemetry
+      - APM Metrics
     conditions:
-      - attribute: eventType
-        anyOf: [ "Metric" ]
-      - attribute: nginx.deployment.name
-        present: true
-      - attribute: nginx.server.endpoint
-        present: true
-      - attribute: nginx.display.name
-        present: true
       - attribute: metricName
-        startsWith: nginxplus_
-      - attribute: instrumentation.provider
-        anyOf: [ "opentelemetry" ]
-      - attribute: otel.library.name
-        anyOf: [ "otelcol/prometheusreceiver", "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver" ]
+        regex: "^External/[^/]+/.*"
     relationship:
       expires: PT75M
       relationshipType: CALLS
       source:
+        extractGuid:
+          attribute: entity.guid
+      target:
         lookupGuid:
           candidateCategory: NGINXSERVER
           fields:
-            - field: nginxUpstreamDeploymentNameApmApp
-              attribute: nginx.deployment.name
-      target:
-        extractGuid:
-          attribute: entity.guid
-          entityType:
-            value: NGINXSERVER
+            - field: serverAddress
+              capture:
+                attribute: metricName__2
+                regex: "^([^:/]+)"

--- a/relationships/synthesis/EXT-SERVICE-to-INFRA-NGINXSERVER.stg.yml
+++ b/relationships/synthesis/EXT-SERVICE-to-INFRA-NGINXSERVER.stg.yml
@@ -1,68 +1,55 @@
 relationships:
-  - name: otelExtServiceCallsOtelInfraNginxServer
+  - name: otelExtServiceCallsNginxServerByUpstreamLabelStg
     version: "1"
     origins:
       - OpenTelemetry
     conditions:
       - attribute: eventType
         anyOf: [ "Metric" ]
-      - attribute: nginx.deployment.name
+      - attribute: newrelic.source
+        anyOf: [ "api.metrics.otlp" ]
+      - attribute: entity.type
+        anyOf: [ "SERVICE" ]
+      - attribute: tags.nginx.upstream.deployment.name
         present: true
-      - attribute: nginx.server.endpoint
-        present: true
-      - attribute: nginx.display.name
-        present: true
-      - attribute: metricName
-        startsWith: nginx.
-      - attribute: instrumentation.provider
-        anyOf: [ "opentelemetry" ]
-      - attribute: otel.library.name
-        anyOf: [ "otelcol/prometheusreceiver", "otelcol/nginxreceiver", "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiver", "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver" ]
     relationship:
       expires: PT75M
       relationshipType: CALLS
       source:
+        extractGuid:
+          attribute: entity.guid
+      target:
         lookupGuid:
           candidateCategory: NGINXSERVER
           fields:
-            - field: nginxUpstreamDeploymentNameExtService
-              attribute: nginx.deployment.name
-      target:
-        extractGuid:
-          attribute: entity.guid
-          entityType:
-            value: NGINXSERVER
-
-  - name: otelExtServiceCallsOtelInfraNginxPlusServer
+            - field: deploymentName
+              attribute: tags.nginx.upstream.deployment.name
+  - name: otelExtServiceCallsNginxServerByAddressStg
     version: "1"
     origins:
       - OpenTelemetry
     conditions:
       - attribute: eventType
-        anyOf: [ "Metric" ]
-      - attribute: nginx.deployment.name
-        present: true
-      - attribute: nginx.server.endpoint
-        present: true
-      - attribute: nginx.display.name
+        anyOf: ["Metric"]
+      - attribute: newrelic.source
+        anyOf: ["api.metrics.otlp"]
+      - attribute: entity.type
+        anyOf: ["SERVICE"]
+      - attribute: tags.nginx.upstream.deployment.name
+        present: false
+      - attribute: server.address
         present: true
       - attribute: metricName
-        startsWith: nginxplus_
-      - attribute: instrumentation.provider
-        anyOf: [ "opentelemetry" ]
-      - attribute: otel.library.name
-        anyOf: [ "otelcol/prometheusreceiver", "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver" ]
+        startsWith: "http.client."
     relationship:
       expires: PT75M
       relationshipType: CALLS
       source:
+        extractGuid:
+          attribute: entity.guid
+      target:
         lookupGuid:
           candidateCategory: NGINXSERVER
           fields:
-            - field: nginxUpstreamDeploymentNameExtService
-              attribute: nginx.deployment.name
-      target:
-        extractGuid:
-          attribute: entity.guid
-          entityType:
-            value: NGINXSERVER
+            - field: serverAddress
+              attribute: server.address

--- a/relationships/synthesis/INFRA-NGINXSERVER-to-APM-APPLICATION.stg.yml
+++ b/relationships/synthesis/INFRA-NGINXSERVER-to-APM-APPLICATION.stg.yml
@@ -1,68 +1,26 @@
 relationships:
-  - name: otelInfraNginxServerCallsApmApplication
+  # NGINXSERVER → NR APM backend app (CALLS).
+  - name: nginxServerCallsApmApplicationByDeploymentLabelStg
     version: "1"
     origins:
-      - OpenTelemetry
+      - Distributed Tracing
+      - APM Metrics
     conditions:
       - attribute: eventType
-        anyOf: [ "Metric" ]
-      - attribute: nginx.deployment.name
+        anyOf: [ "Span", "Transaction" ]
+      - attribute: newrelic.source
+        present: false
+      - attribute: tags.nginx.deployment.name
         present: true
-      - attribute: nginx.server.endpoint
-        present: true
-      - attribute: nginx.display.name
-        present: true
-      - attribute: metricName
-        startsWith: nginx.
-      - attribute: instrumentation.provider
-        anyOf: [ "opentelemetry" ]
-      - attribute: otel.library.name
-        anyOf: [ "otelcol/prometheusreceiver", "otelcol/nginxreceiver", "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiver", "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver" ]
     relationship:
       expires: PT75M
       relationshipType: CALLS
       source:
-        extractGuid:
-          attribute: entity.guid
-          entityType:
-            value: NGINXSERVER
-      target:
         lookupGuid:
           candidateCategory: NGINXSERVER
           fields:
-            - field: nginxDeploymentNameApmApp
-              attribute: nginx.deployment.name
-
-  - name: otelInfraNginxPlusServerCallsApmApplication
-    version: "1"
-    origins:
-      - OpenTelemetry
-    conditions:
-      - attribute: eventType
-        anyOf: [ "Metric" ]
-      - attribute: nginx.deployment.name
-        present: true
-      - attribute: nginx.server.endpoint
-        present: true
-      - attribute: nginx.display.name
-        present: true
-      - attribute: metricName
-        startsWith: nginxplus_
-      - attribute: instrumentation.provider
-        anyOf: [ "opentelemetry" ]
-      - attribute: otel.library.name
-        anyOf: [ "otelcol/prometheusreceiver", "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver" ]
-    relationship:
-      expires: PT75M
-      relationshipType: CALLS
-      source:
+            - field: deploymentName
+              attribute: tags.nginx.deployment.name
+      target:
         extractGuid:
           attribute: entity.guid
-          entityType:
-            value: NGINXSERVER
-      target:
-        lookupGuid:
-          candidateCategory: NGINXSERVER
-          fields:
-            - field: nginxDeploymentNameApmApp
-              attribute: nginx.deployment.name

--- a/relationships/synthesis/INFRA-NGINXSERVER-to-EXT-SERVICE.stg.yml
+++ b/relationships/synthesis/INFRA-NGINXSERVER-to-EXT-SERVICE.stg.yml
@@ -1,68 +1,27 @@
 relationships:
-  - name: otelInfraNginxServerCallsOtelExtService
+  # NGINXSERVER → OTel backend service (CALLS).
+  - name: nginxServerCallsOtelExtServiceByDeploymentLabelStg
     version: "1"
     origins:
       - OpenTelemetry
     conditions:
       - attribute: eventType
         anyOf: [ "Metric" ]
-      - attribute: nginx.deployment.name
+      - attribute: newrelic.source
+        anyOf: [ "api.metrics.otlp" ]
+      - attribute: entity.type
+        anyOf: [ "SERVICE" ]
+      - attribute: tags.nginx.deployment.name
         present: true
-      - attribute: nginx.server.endpoint
-        present: true
-      - attribute: nginx.display.name
-        present: true
-      - attribute: metricName
-        startsWith: nginx.
-      - attribute: instrumentation.provider
-        anyOf: [ "opentelemetry" ]
-      - attribute: otel.library.name
-        anyOf: [ "otelcol/prometheusreceiver", "otelcol/nginxreceiver", "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiver", "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver" ]
     relationship:
       expires: PT75M
       relationshipType: CALLS
       source:
-        extractGuid:
-          attribute: entity.guid
-          entityType:
-            value: NGINXSERVER
-      target:
         lookupGuid:
           candidateCategory: NGINXSERVER
           fields:
-            - field: nginxDeploymentNameExtService
-              attribute: nginx.deployment.name
-
-  - name: otelInfraNginxPlusServerCallsOtelExtService
-    version: "1"
-    origins:
-      - OpenTelemetry
-    conditions:
-      - attribute: eventType
-        anyOf: [ "Metric" ]
-      - attribute: nginx.deployment.name
-        present: true
-      - attribute: nginx.server.endpoint
-        present: true
-      - attribute: nginx.display.name
-        present: true
-      - attribute: metricName
-        startsWith: nginxplus_
-      - attribute: instrumentation.provider
-        anyOf: [ "opentelemetry" ]
-      - attribute: otel.library.name
-        anyOf: [ "otelcol/prometheusreceiver", "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver" ]
-    relationship:
-      expires: PT75M
-      relationshipType: CALLS
-      source:
+            - field: deploymentName
+              attribute: tags.nginx.deployment.name
+      target:
         extractGuid:
           attribute: entity.guid
-          entityType:
-            value: NGINXSERVER
-      target:
-        lookupGuid:
-          candidateCategory: NGINXSERVER
-          fields:
-            - field: nginxDeploymentNameExtService
-              attribute: nginx.deployment.name


### PR DESCRIPTION
## What this does

Adds bidirectional `CALLS` relationship synthesis between `INFRA-NGINXSERVER` and both `APM-APPLICATION` and OpenTelemetry `EXT-SERVICE` entities, so NGINX shows up in service maps with traffic flowing through it in both directions.

## Approach

- **Emitter-driven:** the counterparty (APM app / OTel service) is always taken from `entity.guid`; **NGINXSERVER is the looked-up side** via candidate index
- **New candidate** `relationships/candidates/NGINXSERVER.stg.yml` indexing NGINXSERVER on two keys: `deploymentName` (Path A) and `serverAddress` (Path B, fallback).
- **Two resolution paths:**
  - **Path A (primary):** deployment labels — `nginx.deployment.name` (backends) / `nginx.upstream.deployment.name` (callers).
  - **Path B (fallback):** address matching when no label is present — APM `External/<host>` metric capture; OTel `http.client.* server.address`.
- **Bidirectional + dual-stack:** inbound (client → NGINX) and outbound (NGINX → backend), for both native NR APM and OpenTelemetry APM entites.
- **Entity definition** (`definition.stg.yml`): adds `nginx.server.address:nginx.server.port` composites for address-based synthesis, and exposes `nginx.deployment.name` as a tag on the deployment composites so Path A can resolve.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid.
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
* [ ] I've linked an ARB ticket & received approval from API Review Board in order to make these changes
