### PR TITLE
fix(redis-otel): Use NO_OP instead of CREATE_UNINSTRUMENTED for clust…

### DIFF
--- a/relationships/candidates/REDISCLUSTER.stg.yml
+++ b/relationships/candidates/REDISCLUSTER.stg.yml
@@ -11,6 +11,4 @@ lookups:
     onMatch:
       onMultipleMatches: RELATE_ALL
     onMiss:
-      action: CREATE_UNINSTRUMENTED
-      uninstrumented:
-        type: REDISCLUSTER
+      action: NO_OP


### PR DESCRIPTION
## Summary

Fixes CI failure introduced by the Redis OTel cluster candidate relationship file. Changes `onMiss` action from `CREATE_UNINSTRUMENTED` to `NO_OP` for the `REDISCLUSTER` candidate category.

## Problem

The `REDISCLUSTER.stg.yml` candidate relationship used `CREATE_UNINSTRUMENTED` which requires a corresponding `uninstrumented-rediscluster/definition.stg.yml` file to exist. This file was missing, causing the `validate_uninstrumented_definitions_exists` CI check to fail for all PRs.

## Fix

Changed to `action: NO_OP` — when an APM service references a Redis cluster that doesn't have an instrumented entity, do nothing instead of creating a placeholder. This matches the approach used by Kafka topics (PR #2994).

## Why NO_OP over CREATE_UNINSTRUMENTED

- Avoids creating potentially confusing placeholder entities for customers
- Simpler — no additional uninstrumented entity definition file needed
- Consistent with the Kafka OTel pattern (`KAFKATOPIC.stg.yml`)
- Relationships still work correctly when both entities are instrumented