### PR TITLE
feat: Promote GCP Managed Kafka additions from stg to prod (KAFKACLUSTER + KAFKATOPIC)

### DIFF
--- a/entity-types/infra-kafkacluster/definition.yml
+++ b/entity-types/infra-kafkacluster/definition.yml
@@ -224,10 +224,15 @@ dashboardTemplates:
   # otel receiver
   opentelemetry:
     template: opentelemetry_dashboard.json
+  # GCP Managed Kafka
+  gcp:
+    template: gcp_dashboard.json
 
 goldenTags:
 - clusterName
 - kafka.cluster.name
+- gcp.projectId
+- gcp.region
 
 ownership:
   primaryOwner:

--- a/entity-types/infra-kafkacluster/gcp_dashboard.json
+++ b/entity-types/infra-kafkacluster/gcp_dashboard.json
@@ -47,7 +47,7 @@
           }
         },
         {
-          "title": "Request Latency p99 (ms)",
+          "title": "Request Latency (ms)",
           "layout": {
             "column": 9,
             "row": 1,
@@ -61,7 +61,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "FROM Metric SELECT average(`gcp.managedkafka.request_latencies`) AS 'p99 (ms)' AND `metric.percentile` = '99' TIMESERIES AUTO"
+                "query": "FROM Metric SELECT average(`gcp.managedkafka.request_latencies`) AS 'Latency (ms)' TIMESERIES AUTO"
               }
             ]
           }

--- a/entity-types/infra-kafkacluster/golden_metrics.yml
+++ b/entity-types/infra-kafkacluster/golden_metrics.yml
@@ -42,6 +42,11 @@ partitionCount:
       from: Metric
       where: metricName='kafka.cluster.partition.count' and getField(kafka.cluster.partition.count , 'latest') > 0
       eventId: entity.guid
+    gcp:
+      select: latest(gcp.managedkafka.partitions)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
 
 offlinePartitions:
   title: Offline partitions
@@ -57,3 +62,8 @@ offlinePartitions:
       from: Metric
       where: metricName='kafka.partition.offline'
       eventId: entity.guid
+    gcp:
+      select: max(gcp.managedkafka.offline_partitions)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-kafkatopic/definition.yml
+++ b/entity-types/infra-kafkatopic/definition.yml
@@ -147,6 +147,8 @@ goldenTags:
 - clusterName
 - topic
 - kafka.cluster.name
+- gcp.projectId
+- gcp.region
 
 dashboardTemplates:
   # This should match the entity created from the ohi
@@ -155,6 +157,9 @@ dashboardTemplates:
   # otel receiver
   opentelemetry:
     template: opentelemetry_dashboard.json
+  # GCP Managed Kafka
+  gcp:
+    template: gcp_dashboard.json
 
 ownership:
   primaryOwner:

--- a/entity-types/infra-kafkatopic/golden_metrics.yml
+++ b/entity-types/infra-kafkatopic/golden_metrics.yml
@@ -1,5 +1,5 @@
 bytesInPerSecond:
-  title: "OTel: Bytes in per second"
+  title: Bytes in per second
   unit: BYTES_PER_SECOND
   queries:
     opentelemetry:
@@ -7,9 +7,14 @@ bytesInPerSecond:
       from: Metric
       where: metricName = 'kafka.topic.io' AND (state = 'in' OR direction = 'in')
       eventId: entity.guid
+    gcp:
+      select: rate(sum(gcp.managedkafka.byte_in_count), 1 second)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
 
 bytesOutPerSecond:
-  title: "OTel: Bytes out per second"
+  title: Bytes out per second
   unit: BYTES_PER_SECOND
   queries:
     opentelemetry:
@@ -17,9 +22,14 @@ bytesOutPerSecond:
       from: Metric
       where: metricName = 'kafka.topic.io' AND (state = 'out' OR direction = 'out')
       eventId: entity.guid
+    gcp:
+      select: rate(sum(gcp.managedkafka.byte_out_count), 1 second)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
 
 messagesInPerSecond:
-  title: "OTel: Messages in per second"
+  title: Messages in per second
   unit: MESSAGES_PER_SECOND
   queries:
     opentelemetry:
@@ -27,9 +37,14 @@ messagesInPerSecond:
       from: Metric
       where: metricName = 'kafka.prod.msg.count'
       eventId: entity.guid
+    gcp:
+      select: rate(sum(gcp.managedkafka.message_in_count), 1 second)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
 
 consumerGroupLag:
-  title: "OTel: Consumer group lag"
+  title: Consumer group lag
   queries:
     opentelemetry:
       select: latest(kafka.consumer_group.lag_sum)
@@ -37,6 +52,11 @@ consumerGroupLag:
       where: metricName = 'kafka.consumer_group.lag_sum'
       eventId: entity.guid
       facet: group
+    gcp:
+      select: latest(gcp.managedkafka.consumer_lag)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
 
 underReplicatedPartitions:
   unit: COUNT


### PR DESCRIPTION
**Ticket:** [NR-567584](https://new-relic.atlassian.net/browse/NR-567584)

## Summary

Promotes the GCP Managed Kafka additions previously staged in the `.stg` files (from merged PR #2981) into the prod entity-definition files, and fixes an invalid-NRQL bug in the KAFKACLUSTER `gcp_dashboard.json` widget. **The `.stg` files are left unchanged**.

## Commits

### 1. `63240a20` — fix: KAFKACLUSTER gcp_dashboard "Request Latency" widget NRQL

The widget query used `AS 'p99 (ms)' AND `metric.percentile` = '99'` after the SELECT, which is invalid NRQL. `gcp.managedkafka.request_latencies` does not carry a `metric.percentile` attribute either. Replaced with a plain `average(...)` and retitled to *Request Latency (ms)*.

### 2. `a6cae71c` — feat: Promote GCP additions from stg to prod

Prod file edits (`.stg` untouched):

- **`infra-kafkacluster/definition.yml`** — adds `gcp:` dashboardTemplate + `gcp.projectId` / `gcp.region` goldenTags.
- **`infra-kafkacluster/golden_metrics.yml`** — adds `gcp:` subquery on `partitionCount` (`gcp.managedkafka.partitions`) and `offlinePartitions` (`gcp.managedkafka.offline_partitions`).
- **`infra-kafkatopic/definition.yml`** — adds `gcp:` dashboardTemplate + `gcp.projectId` / `gcp.region` goldenTags.
- **`infra-kafkatopic/golden_metrics.yml`** — adds `gcp:` subquery on `bytesInPerSecond`, `bytesOutPerSecond`, `messagesInPerSecond`, `consumerGroupLag`; drops the `OTel:` prefix from the four titles that now have multiple provider variants.

## NRQL validation (account `10876283`, `beyond-181918`, last 30 min)

| Metric | Data points |
|---|---|
| `gcp.managedkafka.partitions` | 81 |
| `gcp.managedkafka.offline_partitions` | 81 |
| `gcp.managedkafka.request_latencies` | 1,458 |
| `gcp.managedkafka.byte_in_count` | 161 |
| `gcp.managedkafka.byte_out_count` | 336 |
| `gcp.managedkafka.message_in_count` | 161 |
| `gcp.managedkafka.consumer_lag` | live |
| `gcp.managedkafka.cluster_message_in_count` | 81 |
| `gcp.managedkafka.cluster_byte_in_count` | 81 |
| `gcp.managedkafka.cluster_byte_out_count` | 81 |
| `gcp.managedkafka.cpu.core_usage_time` | 81 |
| `gcp.managedkafka.memory.usage` | 81 |

## Test plan
- [ ] CI schema + JSON validation.
- [ ] `KAFKACLUSTER` synthesized from a GCP Managed Kafka source shows the `gcp` dashboard + new golden metrics.
- [ ] `KAFKATOPIC` synthesized from a GCP Managed Kafka source shows the `gcp` dashboard + new golden metrics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[NR-567584]: https://new-relic.atlassian.net/browse/NR-567584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ