### PR TITLE
feat: Add OCIFILESTORAGE entity definition (staging)

### DIFF
--- a/entity-types/infra-ocifilestorage/definition.stg.yml
+++ b/entity-types/infra-ocifilestorage/definition.stg.yml
@@ -1,0 +1,31 @@
+domain: INFRA
+type: OCIFILESTORAGE
+goldenTags:
+  - oci.availabilityDomain
+  - oci.compartmentId
+  - oci.displayName
+  - oci.lifecycleState
+  - oci.subscriptionId
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
+      multiValue: false
+  rules:
+  - ruleName: infra_ocifilestorage_oci_resourceId
+    identifier: oci.resourceId
+    name: oci.resourceName
+    legacyFeatures:
+      overrideGuidType: true
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: oci.resourceId
+      prefix: "ocid1.filesystem"
+    - attribute: oci.namespace
+      value: "oci_filestorage"
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-ocifilestorage/golden_metrics.stg.yml
+++ b/entity-types/infra-ocifilestorage/golden_metrics.stg.yml
@@ -1,0 +1,27 @@
+fileSystemUsage:
+  title: File System Usage
+  unit: BYTES
+  queries:
+    oci:
+      select: average(oci.filestorage.file.system.usage)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+fileSystemReadThroughput:
+  title: Read Throughput
+  unit: BYTES_PER_SECOND
+  queries:
+    oci:
+      select: average(oci.filestorage.file.system.read.throughput)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+fileSystemWriteThroughput:
+  title: Write Throughput
+  unit: BYTES_PER_SECOND
+  queries:
+    oci:
+      select: average(oci.filestorage.file.system.write.throughput)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-ocifilestorage/summary_metrics.stg.yml
+++ b/entity-types/infra-ocifilestorage/summary_metrics.stg.yml
@@ -1,0 +1,17 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: OCI account
+  unit: STRING
+fileSystemUsage:
+  goldenMetric: fileSystemUsage
+  unit: BYTES
+  title: File System Usage
+fileSystemReadThroughput:
+  goldenMetric: fileSystemReadThroughput
+  unit: BYTES_PER_SECOND
+  title: Read Throughput
+fileSystemWriteThroughput:
+  goldenMetric: fileSystemWriteThroughput
+  unit: BYTES_PER_SECOND
+  title: Write Throughput

--- a/entity-types/infra-ocifilestorage/tests/Metric.stg.json
+++ b/entity-types/infra-ocifilestorage/tests/Metric.stg.json
@@ -1,0 +1,18 @@
+[
+  {
+    "oci.availabilityDomain": "AD-1",
+    "oci.compartmentId": "ocid1.compartment.oc1..aaaaaaaabbbbbbccccccccdddddddeeeeeeefffffffgggggggghhhhhhhhiiiiiiiiijjjjjjjj",
+    "oci.displayName": "Test File Storage",
+    "oci.lifecycleState": "ACTIVE",
+    "oci.subscriptionId": "ocid1.subscription.oc1..exampleuniqueSubID",
+    "oci.namespace": "oci_filestorage",
+    "oci.region": "us-ashburn-1",
+    "oci.resourceId": "ocid1.filesystem.oc1.us-ashburn-1.aaaaaaaabbbbbbccccccccdddddddeeeeeeefffffffgggggggghhhhhhhhiiiiiiiiijjjjjjjj",
+    "oci.resourceName": "test-filestorage",
+    "collector.name": "oci-monitor",
+    "instrumentation.provider": "oci",
+    "metricName": "oci.filestorage.file.system.usage",
+    "newrelic.cloudIntegrations.integrationName": "OCI Monitor metrics",
+    "newrelic.cloudIntegrations.providerAccountName": "oci-dev-all-metrics"
+  }
+]


### PR DESCRIPTION
Add OCI File Storage entity definition (staging) with synthesis rules, golden metrics, and summary metrics.

## Entity Type
- Type: `INFRA-OCIFILESTORAGE`
- Provider: OCI (Oracle Cloud Infrastructure)
- Namespace: `oci_filestorage`
- Resource: File System (`ocid1.filesystem`)

## Golden Metrics
- FileSystemUsage
- FileSystemReadThroughput
- FileSystemWriteThroughput

## Metric Source
https://docs.oracle.com/en-us/iaas/Content/File/Reference/filemetrics.htm

Staging-only definition: uses `.stg.yml` / `.stg.json` suffix.