### PR TITLE
feat: Add OCIDATABASE entity definition (staging)

### DIFF
--- a/entity-types/infra-ocidatabase/definition.stg.yml
+++ b/entity-types/infra-ocidatabase/definition.stg.yml
@@ -1,0 +1,33 @@
+domain: INFRA
+type: OCIDATABASE
+goldenTags:
+  - oci.availabilityDomain
+  - oci.compartmentId
+  - oci.displayName
+  - oci.lifecycleState
+  - oci.subscriptionId
+  - oci.dbVersion
+  - oci.shape
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
+      multiValue: false
+  rules:
+  - ruleName: infra_ocidatabase_oci_resourceId
+    identifier: oci.resourceId
+    name: oci.resourceName
+    legacyFeatures:
+      overrideGuidType: true
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: oci.resourceId
+      prefix: "ocid1.dbsystem"
+    - attribute: oci.namespace
+      value: "oci_database"
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-ocidatabase/golden_metrics.stg.yml
+++ b/entity-types/infra-ocidatabase/golden_metrics.stg.yml
@@ -1,0 +1,24 @@
+cpuUtilization:
+  title: CPU Utilization
+  unit: PERCENTAGE
+  queries:
+    oci:
+      select: average(oci.database.cpu.utilization)
+storageUtilization:
+  title: Storage Utilization
+  unit: PERCENTAGE
+  queries:
+    oci:
+      select: average(oci.database.storage.utilization)
+executeCount:
+  title: Execute Count
+  unit: COUNT
+  queries:
+    oci:
+      select: sum(oci.database.execute.count)
+transactionCount:
+  title: Transaction Count
+  unit: COUNT
+  queries:
+    oci:
+      select: sum(oci.database.transaction.count)

--- a/entity-types/infra-ocidatabase/summary_metrics.stg.yml
+++ b/entity-types/infra-ocidatabase/summary_metrics.stg.yml
@@ -1,0 +1,21 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: OCI account
+  unit: STRING
+cpuUtilization:
+  goldenMetric: cpuUtilization
+  unit: PERCENTAGE
+  title: CPU Utilization
+storageUtilization:
+  goldenMetric: storageUtilization
+  unit: PERCENTAGE
+  title: Storage Utilization
+executeCount:
+  goldenMetric: executeCount
+  unit: COUNT
+  title: Execute Count
+transactionCount:
+  goldenMetric: transactionCount
+  unit: COUNT
+  title: Transaction Count

--- a/entity-types/infra-ocidatabase/tests/Metric.stg.json
+++ b/entity-types/infra-ocidatabase/tests/Metric.stg.json
@@ -1,0 +1,18 @@
+[
+  {
+    "oci.availabilityDomain": "AD-1",
+    "oci.compartmentId": "ocid1.compartment.oc1..exampleuniqueID",
+    "oci.displayName": "Test Database",
+    "oci.lifecycleState": "AVAILABLE",
+    "oci.subscriptionId": "ocid1.subscription.oc1..exampleuniqueSubID",
+    "oci.namespace": "oci_database",
+    "oci.region": "us-ashburn-1",
+    "oci.resourceId": "ocid1.dbsystem.oc1.us-ashburn-1.exampleuniqueID",
+    "oci.resourceName": "test-database",
+    "collector.name": "oci-monitor",
+    "instrumentation.provider": "oci",
+    "metricName": "oci.database.cpu.utilization",
+    "newrelic.cloudIntegrations.integrationName": "OCI Monitor metrics",
+    "newrelic.cloudIntegrations.providerAccountName": "oci-dev-all-metrics"
+  }
+]


### PR DESCRIPTION
Add OCI Database entity definition with synthesis rules, golden metrics, and summary metrics (staging `.stg.yml`).

## Entity Type
- Type: `INFRA-OCIDATABASE`
- Provider: OCI (Oracle Cloud Infrastructure)
- Namespace: `oci_database`
- Synthesis prefix: `ocid1.dbsystem` (resourceId = DB System OCID, per OCI docs)

## Golden Metrics
- CpuUtilization → oci.database.cpu.utilization
- StorageUtilization → oci.database.storage.utilization
- ExecuteCount → oci.database.execute.count
- TransactionCount → oci.database.transaction.count

## Metric Source
https://docs.oracle.com/en/cloud/paas/base-database/available-metrics/

Staging-only definition (all files use `.stg` suffix).