### PR TITLE
feat: Add OCINOSQL entity definition (staging)

### DIFF
--- a/entity-types/infra-ocinosql/definition.stg.yml
+++ b/entity-types/infra-ocinosql/definition.stg.yml
@@ -1,0 +1,31 @@
+domain: INFRA
+type: OCINOSQL
+goldenTags:
+  - oci.compartmentId
+  - oci.displayName
+  - oci.lifecycleState
+  - oci.region
+  - oci.tableName
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
+      multiValue: false
+  rules:
+  - ruleName: infra_ocinosql_oci_resourceId
+    identifier: oci.resourceId
+    name: oci.tableName
+    legacyFeatures:
+      overrideGuidType: true
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: oci.resourceId
+      prefix: "ocid1.nosqltable"
+    - attribute: oci.namespace
+      value: "oci_nosql"
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-ocinosql/golden_metrics.stg.yml
+++ b/entity-types/infra-ocinosql/golden_metrics.stg.yml
@@ -1,0 +1,24 @@
+readUnits:
+  title: Read Units
+  unit: COUNT
+  queries:
+    oci:
+      select: sum(oci.nosql.read.units)
+writeUnits:
+  title: Write Units
+  unit: COUNT
+  queries:
+    oci:
+      select: sum(oci.nosql.write.units)
+readThrottleCount:
+  title: Read Throttle Count
+  unit: COUNT
+  queries:
+    oci:
+      select: sum(oci.nosql.read.throttle.count)
+writeThrottleCount:
+  title: Write Throttle Count
+  unit: COUNT
+  queries:
+    oci:
+      select: sum(oci.nosql.write.throttle.count)

--- a/entity-types/infra-ocinosql/summary_metrics.stg.yml
+++ b/entity-types/infra-ocinosql/summary_metrics.stg.yml
@@ -1,0 +1,21 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: OCI account
+  unit: STRING
+readUnits:
+  goldenMetric: readUnits
+  unit: COUNT
+  title: Read Units
+writeUnits:
+  goldenMetric: writeUnits
+  unit: COUNT
+  title: Write Units
+readThrottleCount:
+  goldenMetric: readThrottleCount
+  unit: COUNT
+  title: Read Throttle Count
+writeThrottleCount:
+  goldenMetric: writeThrottleCount
+  unit: COUNT
+  title: Write Throttle Count

--- a/entity-types/infra-ocinosql/tests/Metric.stg.json
+++ b/entity-types/infra-ocinosql/tests/Metric.stg.json
@@ -1,0 +1,15 @@
+[
+  {
+    "oci.compartmentId": "ocid1.compartment.oc1..exampleuniqueID",
+    "oci.namespace": "oci_nosql",
+    "oci.region": "us-ashburn-1",
+    "oci.resourceId": "ocid1.nosqltable.oc1.iad.exampleuniqueID",
+    "oci.tableName": "test-nosql-table",
+    "collector.name": "oci-metric-streams",
+    "instrumentation.provider": "oci",
+    "metricName": "oci.nosql.read.units",
+    "newrelic.cloudIntegrations.providerAccountId": "69877",
+    "newrelic.cloudIntegrations.providerAccountName": "oci_test_1",
+    "newrelic.source": "metricAPI"
+  }
+]


### PR DESCRIPTION
Add OCI NoSQL Database entity definition with synthesis rules, golden metrics, and summary metrics. Staging-only (`.stg.yml` / `.stg.json`).

## Entity Type
- Type: `INFRA-OCINOSQL`
- Provider: OCI (Oracle Cloud Infrastructure)
- Namespace: `oci_nosql`
- Identifier: `oci.resourceId` (OCID prefix `ocid1.nosqltable`)
- Name: `oci.tableName` (NoSQL metric streams carry `tableName`, not `resourceName`)

## Golden Metrics
- Read Units (`oci.nosql.read.units`)
- Write Units (`oci.nosql.write.units`)
- Read Throttle Count (`oci.nosql.read.throttle.count`)
- Write Throttle Count (`oci.nosql.write.throttle.count`)

## Metric Source
https://docs.oracle.com/en/cloud/paas/nosql-cloud/dtddt/monitoring-oracle-nosql-database-cloud-service.html