### PR TITLE
feat: Add OCIDATABASECLUSTER entity definition (staging)

### DIFF
--- a/entity-types/infra-ocidatabasecluster/definition.stg.yml
+++ b/entity-types/infra-ocidatabasecluster/definition.stg.yml
@@ -1,0 +1,43 @@
+domain: INFRA
+type: OCIDATABASECLUSTER
+goldenTags:
+  - oci.availabilityDomain
+  - oci.compartmentId
+  - oci.displayName
+  - oci.lifecycleState
+  - oci.subscriptionId
+  - oci.shape
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
+      multiValue: false
+  rules:
+  - ruleName: infra_ocidatabasecluster_oci_resourceId
+    identifier: oci.resourceId
+    name: oci.resourceName
+    legacyFeatures:
+      overrideGuidType: true
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: oci.resourceId
+      prefix: "ocid1.cloudvmcluster"
+    - attribute: oci.namespace
+      value: "oci_database_cluster"
+  - ruleName: infra_ocidatabasecluster_oci_resourceId_2
+    identifier: oci.resourceId
+    name: oci.resourceName
+    legacyFeatures:
+      overrideGuidType: true
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: oci.resourceId
+      prefix: "ocid1.vmcluster"
+    - attribute: oci.namespace
+      value: "oci_database_cluster"
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-ocidatabasecluster/golden_metrics.stg.yml
+++ b/entity-types/infra-ocidatabasecluster/golden_metrics.stg.yml
@@ -1,0 +1,24 @@
+cpuUtilization:
+  title: CPU Utilization
+  unit: PERCENTAGE
+  queries:
+    oci:
+      select: average(oci.database.cluster.cpu.utilization)
+memoryUtilization:
+  title: Memory Utilization
+  unit: PERCENTAGE
+  queries:
+    oci:
+      select: average(oci.database.cluster.memory.utilization)
+asmDiskgroupUtilization:
+  title: ASM Diskgroup Utilization
+  unit: PERCENTAGE
+  queries:
+    oci:
+      select: average(oci.database.cluster.asm.diskgroup.utilization)
+nodeStatus:
+  title: Node Status
+  unit: COUNT
+  queries:
+    oci:
+      select: latest(oci.database.cluster.node.status)

--- a/entity-types/infra-ocidatabasecluster/summary_metrics.stg.yml
+++ b/entity-types/infra-ocidatabasecluster/summary_metrics.stg.yml
@@ -1,0 +1,21 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: OCI account
+  unit: STRING
+cpuUtilization:
+  goldenMetric: cpuUtilization
+  unit: PERCENTAGE
+  title: CPU Utilization
+memoryUtilization:
+  goldenMetric: memoryUtilization
+  unit: PERCENTAGE
+  title: Memory Utilization
+asmDiskgroupUtilization:
+  goldenMetric: asmDiskgroupUtilization
+  unit: PERCENTAGE
+  title: ASM Diskgroup Utilization
+nodeStatus:
+  goldenMetric: nodeStatus
+  unit: COUNT
+  title: Node Status

--- a/entity-types/infra-ocidatabasecluster/tests/Metric.stg.json
+++ b/entity-types/infra-ocidatabasecluster/tests/Metric.stg.json
@@ -1,0 +1,36 @@
+[
+  {
+    "oci.availabilityDomain": "AD-1",
+    "oci.compartmentId": "ocid1.compartment.oc1..exampleuniqueID",
+    "oci.displayName": "Test Exadata VM Cluster",
+    "oci.lifecycleState": "AVAILABLE",
+    "oci.subscriptionId": "ocid1.subscription.oc1..exampleuniqueSubID",
+    "oci.shape": "Exadata.X9M",
+    "oci.namespace": "oci_database_cluster",
+    "oci.region": "us-ashburn-1",
+    "oci.resourceId": "ocid1.cloudvmcluster.oc1.us-ashburn-1.exampleuniqueID",
+    "oci.resourceName": "test-cloud-vmcluster",
+    "collector.name": "oci-monitor",
+    "instrumentation.provider": "oci",
+    "metricName": "oci.database.cluster.cpu.utilization",
+    "newrelic.cloudIntegrations.integrationName": "OCI Monitor metrics",
+    "newrelic.cloudIntegrations.providerAccountName": "oci-dev-all-metrics"
+  },
+  {
+    "oci.availabilityDomain": "AD-1",
+    "oci.compartmentId": "ocid1.compartment.oc1..exampleuniqueID",
+    "oci.displayName": "Test ExaCC VM Cluster",
+    "oci.lifecycleState": "AVAILABLE",
+    "oci.subscriptionId": "ocid1.subscription.oc1..exampleuniqueSubID",
+    "oci.shape": "ExadataCC.X9M",
+    "oci.namespace": "oci_database_cluster",
+    "oci.region": "us-ashburn-1",
+    "oci.resourceId": "ocid1.vmcluster.oc1.us-ashburn-1.exampleuniqueID2",
+    "oci.resourceName": "test-cc-vmcluster",
+    "collector.name": "oci-monitor",
+    "instrumentation.provider": "oci",
+    "metricName": "oci.database.cluster.memory.utilization",
+    "newrelic.cloudIntegrations.integrationName": "OCI Monitor metrics",
+    "newrelic.cloudIntegrations.providerAccountName": "oci-dev-all-metrics"
+  }
+]


### PR DESCRIPTION
Add OCI Database Cluster entity definition (Exadata Database Service VM Cluster) with synthesis rules, golden metrics, and summary metrics. Staging-only (`.stg.yml` / `.stg.json`).

## Entity Type
- Type: `INFRA-OCIDATABASECLUSTER`
- Provider: OCI (Oracle Cloud Infrastructure)
- Namespace: `oci_database_cluster` (VM-cluster / host-level Exadata metrics)

## Synthesis rules (multi-subtype, shared metrics namespace)
- `ocid1.cloudvmcluster` — Exadata Cloud Service (dedicated infra)
- `ocid1.vmcluster` — Exadata Cloud@Customer

## Golden Metrics
- CpuUtilization
- MemoryUtilization
- ASMDiskgroupUtilization
- NodeStatus

## Metric Source
https://docs.oracle.com/en/engineered-systems/exadata-cloud-service/ecscm/reference.html