### PR TITLE
fix(ibmmq): synthesize native queue managers/queues that send instrumentation.provider

### DIFF
--- a/entity-types/infra-ibmmq_manager/definition.yml
+++ b/entity-types/infra-ibmmq_manager/definition.yml
@@ -3,8 +3,7 @@ type: IBMMQ_MANAGER
 
 synthesis:
   rules:
-    # nri-mq rules: native identity = targetName:qmgr. OTel excluded via instrumentation.provider absent
-    # so nri-mq and OpenTelemetry never double-synthesize the same queue manager.
+    # nri-mq rules: identity targetName:qmgr.
     - ruleName: infra_ibmmq_manager_nri_1
       compositeIdentifier:
         separator: ":"
@@ -17,10 +16,9 @@ synthesis:
           value: Metric
         - attribute: metricName
           prefix: ibmmq_qmgr
-        - attribute: instrumentation.provider
-          present: false
       tags:
         clusterName:
+        instrumentation.provider:
 
     - ruleName: infra_ibmmq_manager_nri_2
       compositeIdentifier:
@@ -34,10 +32,9 @@ synthesis:
           value: Metric
         - attribute: metricName
           prefix: ibmmq_channel
-        - attribute: instrumentation.provider
-          present: false
       tags:
         clusterName:
+        instrumentation.provider:
 
     - ruleName: infra_ibmmq_manager_nri_3
       compositeIdentifier:
@@ -51,10 +48,9 @@ synthesis:
           value: Metric
         - attribute: metricName
           prefix: ibmmq_subscription
-        - attribute: instrumentation.provider
-          present: false
       tags:
         clusterName:
+        instrumentation.provider:
 
     # OpenTelemetry rule (Prometheus receiver): identity keyed on host.id (== target.name in OTel data).
     # target.name is the fallback when host.id is absent (see *_fallback); mutually exclusive via

--- a/entity-types/infra-ibmmq_manager/tests/Metric.json
+++ b/entity-types/infra-ibmmq_manager/tests/Metric.json
@@ -7,6 +7,16 @@
     "newrelic.source": "metricAPI"
   },
   {
+    "host.name": "mq-host-01",
+    "metricName": "ibmmq_qmgr_status",
+    "targetName": "mq-host-01:9157",
+    "qmgr": "QM2",
+    "instrumentation.name": "ibmmq",
+    "instrumentation.provider": "newRelic",
+    "instrumentation.version": "0.4.3",
+    "newrelic.source": "metricAPI"
+  },
+  {
     "metricName": "ibmmq_qmgr_connection_count",
     "instrumentation.provider": "opentelemetry",
     "otel.library.name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",

--- a/entity-types/infra-ibmmq_queue/definition.yml
+++ b/entity-types/infra-ibmmq_queue/definition.yml
@@ -5,8 +5,7 @@ goldenTags:
 
 synthesis:
   rules:
-    # nri-mq rule: native identity = targetName:qmgr:queue. OTel excluded via instrumentation.provider
-    # absent so nri-mq and OpenTelemetry never double-synthesize the same queue.
+    # nri-mq rule: identity targetName:qmgr:queue.
     - ruleName: infra_ibmmq_queue_nri_1
       compositeIdentifier:
         separator: ":"
@@ -26,10 +25,9 @@ synthesis:
           value: Metric
         - attribute: metricName
           prefix: ibmmq_queue
-        - attribute: instrumentation.provider
-          present: false
       tags:
         qmgr:
+        instrumentation.provider:
 
     # OpenTelemetry rule (Prometheus receiver): identity keyed on host.id:qmgr:queue (host.id ==
     # target.name in OTel data); target.name is the fallback when host.id is absent (see *_fallback);

--- a/entity-types/infra-ibmmq_queue/tests/Metric.json
+++ b/entity-types/infra-ibmmq_queue/tests/Metric.json
@@ -8,6 +8,17 @@
     "newrelic.source": "metricAPI"
   },
   {
+    "host.name": "mq-host-01",
+    "metricName": "ibmmq_queue_depth",
+    "targetName": "mq-host-01:9157",
+    "qmgr": "QM2",
+    "queue": "DEV.QUEUE.2",
+    "instrumentation.name": "ibmmq",
+    "instrumentation.provider": "newRelic",
+    "instrumentation.version": "0.4.3",
+    "newrelic.source": "metricAPI"
+  },
+  {
     "metricName": "ibmmq_queue_depth",
     "instrumentation.provider": "opentelemetry",
     "otel.library.name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",


### PR DESCRIPTION
## Relevant information

Fixes **[NR-588586](https://new-relic.atlassian.net/browse/NR-588586)**.

#3022 added `instrumentation.provider present: false` to the **nri-mq** synthesis rules on `INFRA-IBMMQ_MANAGER` and `INFRA-IBMMQ_QUEUE` to keep the native and OpenTelemetry pipelines from double-synthesizing.

However, native IBM MQ telemetry — the infra-agent scraping the `mq-metric-samples` Prometheus endpoint — stamps `instrumentation.provider: newRelic`. So from Jul 6 2026 those data points no longer matched the rules, and affected customers' queue-manager and queue entities disappeared.

Sample of the customer's native data point:

```
"metricName": "ibmmq_qmgr_failed_mqset_count",
"instrumentation.name": "ibmmq",
"instrumentation.provider": "newRelic",
"targetName": "<host>:9157",
"qmgr": "<qmgr>",
"newrelic.source": "metricAPI"
```

### Fix

Remove the `instrumentation.provider present: false` guard from all nri rules. **De-duplication is still guaranteed by the composite identifier**: the native identity is `targetName:qmgr[:queue]`, and OTel telemetry has no `targetName` (it uses `target.name`). Per the synthesis contract, composite-identifier attributes *must exist* or the entity is not indexed ([docs/entities/synthesis.md](https://github.com/newrelic/entity-definitions/blob/main/docs/entities/synthesis.md#composite-identifier)) — so OTel data can never match the nri rules. The guard was never needed.

- **infra-ibmmq_manager** — drop the guard from the 3 nri rules (`qmgr` / `channel` / `subscription`).
- **infra-ibmmq_queue** — drop the guard from the nri rule.
- Carry `instrumentation.provider` as a **tag** on the nri rules (mirrors the OTel rules).
- Add a native `newRelic` sample (dummy data) to each `tests/Metric.json`. The nri path had **no** native fixture — #3022 trimmed fixtures to OpenTelemetry-only — which is why this regression shipped.

Identity rules are unchanged, so **existing entity GUIDs are preserved** — affected entities re-synthesize with the same GUIDs.

### Api Review Board (ARB)

Any pull request with changes to this repository has to be linked with an ARB ticket, which has to be approved before merging.

If you are an external contributor please contact New Relic Support.

If you don't know about the ARB process check [this](https://github.com/newrelic/entity-definitions/blob/main/CONTRIBUTING.md).

**ARB Jira ticket:**
https://new-relic.atlassian.net/browse/NR-579402

### Checklist

- [x] I've read the guidelines and understand the acceptance criteria.
- [x] The value of the attribute marked as identifier will be unique and valid.
- [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
- [x] I've linked an ARB ticket & received approval from API Review Board in order to make these changes

Assisted-by: Claude Opus 4.8 (1M context)

[NR-588586]: https://new-relic.atlassian.net/browse/NR-588586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ