### PR TITLE
feat(gcp): GCP Managed Kafka synthesis rules for KAFKACLUSTER and KAFKATOPIC

### DIFF
--- a/entity-types/infra-kafkacluster/definition.stg.yml
+++ b/entity-types/infra-kafkacluster/definition.stg.yml
@@ -242,6 +242,27 @@ synthesis:
       # Cluster information
       clusterName:
 
+    # This rule is for GCP Managed Kafka cluster metrics from Cloud Monitoring (gcp-polling-v2)
+  - ruleName: infra_kafkacluster_gcp_managedkafka_stg
+    identifier: cluster_id
+    name: cluster_id
+    encodeIdentifierInGUID: true
+    conditions:
+      - attribute: eventType
+        value: Metric
+      - attribute: instrumentation.provider
+        value: gcp
+      - attribute: gcp.resource.type
+        value: managedkafka.googleapis.com/Cluster
+    tags:
+      # GCP resource attributes
+      instrumentation.provider:
+      gcp.projectId:
+      gcp.projectName:
+      gcp.region:
+      cluster_id:
+        entityTagName: clusterName
+
 dashboardTemplates:
   # This should match the entity created from the ohi in the infra pipeline
   newRelic:

--- a/entity-types/infra-kafkacluster/tests/Metric.stg.json
+++ b/entity-types/infra-kafkacluster/tests/Metric.stg.json
@@ -18,5 +18,26 @@
       "otel.library.name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkametricsreceiver",
       "otel.library.version": "0.131.0",
       "timestamp": 1757449202856
+    },
+    {
+      "instrumentation.provider": "gcp",
+      "gcp.resource.type": "managedkafka.googleapis.com/Cluster",
+      "gcp.asset.type": "managedkafka.googleapis.com/Cluster",
+      "fullResourceName": "//managedkafka.googleapis.com/projects/beyonddev-193118/locations/us-east1/clusters/regression-cn-kafka",
+      "cluster_id": "regression-cn-kafka",
+      "gcp.projectId": "beyonddev-193118",
+      "gcp.projectName": "beyondDev",
+      "gcp.region": "us-east1",
+      "gcp.managedkafka.cluster_byte_in_count": {
+        "type": "summary",
+        "count": 1,
+        "sum": 1024,
+        "min": 1024,
+        "max": 1024,
+        "latest": 1024
+      },
+      "metricName": "gcp.managedkafka.cluster_byte_in_count",
+      "newrelic.source": "api.metrics.otlp",
+      "timestamp": 1757449202856
     }
 ]

--- a/entity-types/infra-kafkatopic/definition.stg.yml
+++ b/entity-types/infra-kafkatopic/definition.stg.yml
@@ -169,6 +169,36 @@ synthesis:
       reportingAgent:
         ttl: P1D
 
+  # This rule is for GCP Managed Kafka topic metrics from Cloud Monitoring (gcp-polling-v2)
+  - ruleName: infra_kafkatopic_gcp_managedkafka_stg
+    compositeIdentifier:
+      separator: ":"
+      attributes:
+      - gcp.topic_id
+      - gcp.cluster_id
+    compositeName:
+      fragments:
+      - attribute: gcp.topic_id
+      - value: " ("
+      - attribute: gcp.cluster_id
+      - value: ")"
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: eventType
+      value: Metric
+    - attribute: instrumentation.provider
+      value: gcp
+    - attribute: gcp.resource.type
+      value: managedkafka.googleapis.com/Topic
+    tags:
+      instrumentation.provider:
+      gcp.projectId:
+      gcp.region:
+      gcp.cluster_id:
+        entityTagName: clusterName
+      gcp.topic_id:
+        entityTagName: topic
+
 goldenTags:
 - clusterName
 - topic

--- a/entity-types/infra-kafkatopic/tests/Metric.stg.json
+++ b/entity-types/infra-kafkatopic/tests/Metric.stg.json
@@ -25,5 +25,26 @@
         "timestamp": 1756213629189,
         "topic": "user-activities",
         "kafka.topic.name": "user-activities"
+    },
+    {
+        "instrumentation.provider": "gcp",
+        "gcp.resource.type": "managedkafka.googleapis.com/Topic",
+        "fullResourceName": "__internal_google_managed_kafka_topic_12:regression-cn-kafka",
+        "gcp.projectId": "beyonddev-193118",
+        "gcp.projectName": "beyondDev",
+        "gcp.region": "us-east1",
+        "gcp.cluster_id": "regression-cn-kafka",
+        "gcp.topic_id": "__internal_google_managed_kafka_topic_12",
+        "gcp.managedkafka.byte_in_count": {
+          "type": "summary",
+          "count": 1,
+          "sum": 2048,
+          "min": 2048,
+          "max": 2048,
+          "latest": 2048
+        },
+        "metricName": "gcp.managedkafka.byte_in_count",
+        "newrelic.source": "api.metrics.otlp",
+        "timestamp": 1756213629189
     }
 ]


### PR DESCRIPTION
## What

GCP **Managed Service for Apache Kafka** synthesis rules for the staging definitions of `KAFKACLUSTER` and `KAFKATOPIC` (`definition.stg.yml`)

## Why

Managed Kafka metrics from **gcp-polling-v2** carry `instrumentation.provider = gcp`; no existing OTEL/native rule matches them, and the legacy metadata path mints `NA`-typed GUIDs that never register. These shared infra types now need real GCP synthesis rules.

KAFKACLUSTER:
cluster_id identifier: regression-cn-kafka
<img width="1694" height="748" alt="Screenshot 2026-07-16 at 11 55 01 AM" src="https://github.com/user-attachments/assets/e81f4821-b5c7-4859-9f8a-95b7ceb52e96" />

KAFKATOPIC:
gcp.topic_id identifier:  regression-cn-topic
gcp.cluster_id identifier: regression-cn-kafka
<img width="1694" height="748" alt="Screenshot 2026-07-16 at 12 02 34 PM" src="https://github.com/user-attachments/assets/ee29b247-e7ad-4c56-a9b6-b5c7f8b6d6e9" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)