### PR TITLE
feat: Add Exadata/Exascale VM-cluster synthesis rules to OCIDATABASE (staging)

### DIFF
--- a/entity-types/infra-ocidatabase/definition.stg.yml
+++ b/entity-types/infra-ocidatabase/definition.stg.yml
@@ -17,6 +17,7 @@ synthesis:
       entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
       multiValue: false
   rules:
+  # Base Database Service (VM/BM DB systems) — resourceId is the DB System OCID
   - ruleName: infra_ocidatabase_oci_resourceId
     identifier: oci.resourceId
     name: oci.resourceName
@@ -26,6 +27,42 @@ synthesis:
     conditions:
     - attribute: oci.resourceId
       prefix: "ocid1.dbsystem"
+    - attribute: oci.namespace
+      value: "oci_database"
+  # Exadata Database Service (dedicated / Cloud) — resourceId is the Cloud VM Cluster OCID
+  - ruleName: infra_ocidatabase_oci_resourceId_2
+    identifier: oci.resourceId
+    name: oci.resourceName
+    legacyFeatures:
+      overrideGuidType: true
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: oci.resourceId
+      prefix: "ocid1.cloudvmcluster"
+    - attribute: oci.namespace
+      value: "oci_database"
+  # Exadata Database Service on Cloud@Customer — resourceId is the VM Cluster OCID
+  - ruleName: infra_ocidatabase_oci_resourceId_3
+    identifier: oci.resourceId
+    name: oci.resourceName
+    legacyFeatures:
+      overrideGuidType: true
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: oci.resourceId
+      prefix: "ocid1.vmcluster"
+    - attribute: oci.namespace
+      value: "oci_database"
+  # Globally Distributed Exadata Database on Exascale Infrastructure — resourceId is the Exadata DB VM Cluster OCID
+  - ruleName: infra_ocidatabase_oci_resourceId_4
+    identifier: oci.resourceId
+    name: oci.resourceName
+    legacyFeatures:
+      overrideGuidType: true
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: oci.resourceId
+      prefix: "ocid1.exadbvmcluster"
     - attribute: oci.namespace
       value: "oci_database"
 ownership:

--- a/entity-types/infra-ocidatabase/tests/Metric.stg.json
+++ b/entity-types/infra-ocidatabase/tests/Metric.stg.json
@@ -14,5 +14,53 @@
     "metricName": "oci.database.cpu.utilization",
     "newrelic.cloudIntegrations.integrationName": "OCI Monitor metrics",
     "newrelic.cloudIntegrations.providerAccountName": "oci-dev-all-metrics"
+  },
+  {
+    "oci.availabilityDomain": "AD-1",
+    "oci.compartmentId": "ocid1.compartment.oc1..exampleuniqueID",
+    "oci.displayName": "Test Exadata VM Cluster",
+    "oci.lifecycleState": "AVAILABLE",
+    "oci.subscriptionId": "ocid1.subscription.oc1..exampleuniqueSubID",
+    "oci.namespace": "oci_database",
+    "oci.region": "us-ashburn-1",
+    "oci.resourceId": "ocid1.cloudvmcluster.oc1.us-ashburn-1.exampleuniqueID",
+    "oci.resourceName": "test-exadata-vmcluster",
+    "collector.name": "oci-monitor",
+    "instrumentation.provider": "oci",
+    "metricName": "oci.database.cpu.utilization",
+    "newrelic.cloudIntegrations.integrationName": "OCI Monitor metrics",
+    "newrelic.cloudIntegrations.providerAccountName": "oci-dev-all-metrics"
+  },
+  {
+    "oci.availabilityDomain": "AD-1",
+    "oci.compartmentId": "ocid1.compartment.oc1..exampleuniqueID",
+    "oci.displayName": "Test ExaCC VM Cluster",
+    "oci.lifecycleState": "AVAILABLE",
+    "oci.subscriptionId": "ocid1.subscription.oc1..exampleuniqueSubID",
+    "oci.namespace": "oci_database",
+    "oci.region": "us-ashburn-1",
+    "oci.resourceId": "ocid1.vmcluster.oc1.us-ashburn-1.exampleuniqueID",
+    "oci.resourceName": "test-exacc-vmcluster",
+    "collector.name": "oci-monitor",
+    "instrumentation.provider": "oci",
+    "metricName": "oci.database.cpu.utilization",
+    "newrelic.cloudIntegrations.integrationName": "OCI Monitor metrics",
+    "newrelic.cloudIntegrations.providerAccountName": "oci-dev-all-metrics"
+  },
+  {
+    "oci.availabilityDomain": "AD-1",
+    "oci.compartmentId": "ocid1.compartment.oc1..exampleuniqueID",
+    "oci.displayName": "Test Exascale DB VM Cluster",
+    "oci.lifecycleState": "AVAILABLE",
+    "oci.subscriptionId": "ocid1.subscription.oc1..exampleuniqueSubID",
+    "oci.namespace": "oci_database",
+    "oci.region": "us-ashburn-1",
+    "oci.resourceId": "ocid1.exadbvmcluster.oc1.us-ashburn-1.exampleuniqueID",
+    "oci.resourceName": "test-exascale-vmcluster",
+    "collector.name": "oci-monitor",
+    "instrumentation.provider": "oci",
+    "metricName": "oci.database.cpu.utilization",
+    "newrelic.cloudIntegrations.integrationName": "OCI Monitor metrics",
+    "newrelic.cloudIntegrations.providerAccountName": "oci-dev-all-metrics"
   }
 ]


### PR DESCRIPTION
Follow-up to #3041. `oci_database` is a shared metric namespace whose `resourceId` differs by deployment type. #3041 covered Base Database (`ocid1.dbsystem`); this adds the Exadata family.

## New synthesis rules (multi-subtype, same OCIDATABASE type)
| Deployment | resourceId prefix | rule |
|---|---|---|
| Base Database (existing) | `ocid1.dbsystem` | infra_ocidatabase_oci_resourceId |
| Exadata DB Service (Cloud) | `ocid1.cloudvmcluster` | _2 |
| Exadata DB Service (Cloud@Customer) | `ocid1.vmcluster` | _3 |
| Globally Distributed Exadata on Exascale | `ocid1.exadbvmcluster` | _4 |

## Notes
- Purely **additive** — the existing `ocid1.dbsystem` rule is unchanged, so existing Base DB entity GUIDs are unaffected. Rules only widen which resources synthesize into `OCIDATABASE`.
- Exadata's `oci_database` metrics are dimensioned by the **VM Cluster OCID** (per Oracle docs), not the DB System OCID — hence the additional prefixes.
- `tests/Metric.stg.json` extended with one sample per new prefix.
- Staging (`.stg.yml`).

> ⚠️ **Verify before production promotion:** the exact OCID segments for Exadata Cloud@Customer (`ocid1.vmcluster`) and Exascale (`ocid1.exadbvmcluster`) should be confirmed against real resources. `ocid1.cloudvmcluster` (Exadata Cloud Service) is the well-established one.