### PR TITLE
fix(gcp): add legacyFeatures to GCP Managed Kafka KAFKACLUSTER/KAFKATOPIC synthesis rules

### DIFF
--- a/entity-types/infra-kafkacluster/definition.stg.yml
+++ b/entity-types/infra-kafkacluster/definition.stg.yml
@@ -247,6 +247,9 @@ synthesis:
     identifier: cluster_id
     name: cluster_id
     encodeIdentifierInGUID: true
+    legacyFeatures:
+      useNonStandardAttributes: true
+      overrideGuidType: true
     conditions:
       - attribute: eventType
         value: Metric

--- a/entity-types/infra-kafkatopic/definition.stg.yml
+++ b/entity-types/infra-kafkatopic/definition.stg.yml
@@ -183,6 +183,9 @@ synthesis:
       - attribute: gcp.cluster_id
       - value: ")"
     encodeIdentifierInGUID: true
+    legacyFeatures:
+      useNonStandardAttributes: true
+      overrideGuidType: true
     conditions:
     - attribute: eventType
       value: Metric


### PR DESCRIPTION
## Problem

Follow-up to #3050.

The GCP Managed Kafka synthesis rules added in #3050 **don't register entities**. `KAFKACLUSTER` and `KAFKATOPIC` are legacy infra types whose GUIDs use a **non-standard `NA` type slot** — and without `legacyFeatures`, the entity platform won't mint/register an entity from the synthesis rule. The metric's `entity.guid` stays a dangling `NA` guid and nothing browsable is created (verified: 0 synthesized GCP `KAFKATOPIC`/`KAFKACLUSTER` entities; every existing one is a metadata-path `NA` guid).

Confirmed with the IDP Team: https://newrelic.slack.com/archives/C0FJ72M28/p1784536268575059?thread_ts=1784519694.135909&cid=C0FJ72M28



🤖 Generated with [Claude Code](https://claude.com/claude-code)