### PR TITLE
feat(gcp): promote GCP Managed Kafka synthesis rules to production (KAFKACLUSTER/KAFKATOPIC)

### DIFF
--- a/entity-types/infra-kafkacluster/definition.yml
+++ b/entity-types/infra-kafkacluster/definition.yml
@@ -220,6 +220,28 @@ synthesis:
       instrumentation.provider:
       kafka.cluster.name:
 
+  - ruleName: infra_kafkacluster_gcp_managedkafka
+    identifier: cluster_id
+    name: cluster_id
+    encodeIdentifierInGUID: true
+    legacyFeatures:
+      useNonStandardAttributes: true
+      overrideGuidType: true
+    conditions:
+    - attribute: eventType
+      value: Metric
+    - attribute: instrumentation.provider
+      value: gcp
+    - attribute: gcp.resource.type
+      value: managedkafka.googleapis.com/Cluster
+    tags:
+      instrumentation.provider:
+      gcp.projectId:
+      gcp.projectName:
+      gcp.region:
+      cluster_id:
+        entityTagName: clusterName
+
 dashboardTemplates:
   # otel receiver
   opentelemetry:

--- a/entity-types/infra-kafkacluster/tests/Metric.json
+++ b/entity-types/infra-kafkacluster/tests/Metric.json
@@ -18,5 +18,26 @@
       "otel.library.name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkametricsreceiver",
       "otel.library.version": "0.131.0",
       "timestamp": 1757449202856
+    },
+    {
+      "instrumentation.provider": "gcp",
+      "gcp.resource.type": "managedkafka.googleapis.com/Cluster",
+      "gcp.asset.type": "managedkafka.googleapis.com/Cluster",
+      "fullResourceName": "//managedkafka.googleapis.com/projects/beyonddev-193118/locations/us-east1/clusters/regression-cn-kafka",
+      "cluster_id": "regression-cn-kafka",
+      "gcp.projectId": "beyonddev-193118",
+      "gcp.projectName": "beyondDev",
+      "gcp.region": "us-east1",
+      "gcp.managedkafka.cluster_byte_in_count": {
+        "type": "summary",
+        "count": 1,
+        "sum": 1024,
+        "min": 1024,
+        "max": 1024,
+        "latest": 1024
+      },
+      "metricName": "gcp.managedkafka.cluster_byte_in_count",
+      "newrelic.source": "api.metrics.otlp",
+      "timestamp": 1757449202856
     }
 ]

--- a/entity-types/infra-kafkatopic/definition.stg.yml
+++ b/entity-types/infra-kafkatopic/definition.stg.yml
@@ -196,6 +196,7 @@ synthesis:
     tags:
       instrumentation.provider:
       gcp.projectId:
+      gcp.projectName:
       gcp.region:
       gcp.cluster_id:
         entityTagName: clusterName

--- a/entity-types/infra-kafkatopic/definition.yml
+++ b/entity-types/infra-kafkatopic/definition.yml
@@ -143,6 +143,39 @@ synthesis:
       reportingAgent:
         ttl: P1D
 
+  - ruleName: infra_kafkatopic_gcp_managedkafka
+    compositeIdentifier:
+      separator: ":"
+      attributes:
+      - gcp.topic_id
+      - gcp.cluster_id
+    compositeName:
+      fragments:
+      - attribute: gcp.topic_id
+      - value: " ("
+      - attribute: gcp.cluster_id
+      - value: ")"
+    encodeIdentifierInGUID: true
+    legacyFeatures:
+      useNonStandardAttributes: true
+      overrideGuidType: true
+    conditions:
+    - attribute: eventType
+      value: Metric
+    - attribute: instrumentation.provider
+      value: gcp
+    - attribute: gcp.resource.type
+      value: managedkafka.googleapis.com/Topic
+    tags:
+      instrumentation.provider:
+      gcp.projectId:
+      gcp.projectName:
+      gcp.region:
+      gcp.cluster_id:
+        entityTagName: clusterName
+      gcp.topic_id:
+        entityTagName: topic
+
 goldenTags:
 - clusterName
 - topic

--- a/entity-types/infra-kafkatopic/tests/Metric.json
+++ b/entity-types/infra-kafkatopic/tests/Metric.json
@@ -25,5 +25,26 @@
         "timestamp": 1756213629189,
         "topic": "user-activities",
         "kafka.topic.name": "user-activities"
+    },
+    {
+        "instrumentation.provider": "gcp",
+        "gcp.resource.type": "managedkafka.googleapis.com/Topic",
+        "fullResourceName": "__internal_google_managed_kafka_topic_12:regression-cn-kafka",
+        "gcp.projectId": "beyonddev-193118",
+        "gcp.projectName": "beyondDev",
+        "gcp.region": "us-east1",
+        "gcp.cluster_id": "regression-cn-kafka",
+        "gcp.topic_id": "__internal_google_managed_kafka_topic_12",
+        "gcp.managedkafka.byte_in_count": {
+          "type": "summary",
+          "count": 1,
+          "sum": 2048,
+          "min": 2048,
+          "max": 2048,
+          "latest": 2048
+        },
+        "metricName": "gcp.managedkafka.byte_in_count",
+        "newrelic.source": "api.metrics.otlp",
+        "timestamp": 1756213629189
     }
 ]


### PR DESCRIPTION
## What

Promote the GCP Managed Kafka synthesis rules — validated in staging via #3050 + #3057 — to the **production** `definition.yml` for both `KAFKACLUSTER` and `KAFKATOPIC`.

ARB: https://new-relic.atlassian.net/browse/NR-567584

Staging Validaton:
Kafka Cluster:
<img width="1152" height="737" alt="Screenshot 2026-07-20 at 6 45 59 PM" src="https://github.com/user-attachments/assets/2ae347ba-b36e-45d8-a42d-71a6d1da4c1e" />

Kafka Topic:
<img width="1152" height="737" alt="Screenshot 2026-07-20 at 6 45 24 PM" src="https://github.com/user-attachments/assets/1ed89171-bb99-4fb9-a8b7-488f47673099" />
