### PR TITLE
feat: Add staging ext-service rule for collector auto-tagging

### DIFF
--- a/entity-types/ext-service/definition.stg.yml
+++ b/entity-types/ext-service/definition.stg.yml
@@ -45,6 +45,19 @@ synthesis:
         entityTagName: language
       telemetry.sdk.version:
 
+  - ruleName: ext_service_otel_collector
+    # produces same entity guid as the default rule applying to all non-otelcol telemetry
+    identifier: service.name
+    name: service.name
+    encodeIdentifierInGUID: true
+    conditions:
+      - attribute: metricName
+        prefix: otelcol # matches both otelcol_ and otelcol.
+    tags:
+      service.name:
+        entityTagName: otel_collector
+        ttl: P1D
+
     # telemetry for gen_ai otel application with user opt-in tag
   - ruleName: ext_service_gen_ai_otel_app
     identifier: service.name


### PR DESCRIPTION
### Relevant information

This PR defines a staging rule for `ext-service` entities to auto-tag entities with `otel_collector` when any metric with an `otelcol_` prefix is detected. The purpose of this is to grant the ability to automatically detect when a collector is present in the entity.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid.
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
* [ ] I've linked an ARB ticket & received approval from API Review Board in order to make these changes
