### PR TITLE
feat: Add OCIVNIC entity definition (staging)

### DIFF
--- a/entity-types/infra-ocivnic/definition.stg.yml
+++ b/entity-types/infra-ocivnic/definition.stg.yml
@@ -1,0 +1,28 @@
+domain: INFRA
+type: OCIVNIC
+goldenTags:
+  - oci.compartmentId
+  - oci.region
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
+      multiValue: false
+  rules:
+  - ruleName: infra_ocivnic_oci_resourceId
+    identifier: oci.resourceId
+    name: oci.resourceId
+    legacyFeatures:
+      overrideGuidType: true
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: oci.resourceId
+      prefix: "ocid1.vnic"
+    - attribute: oci.namespace
+      value: "oci_vcn"
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-ocivnic/golden_metrics.stg.yml
+++ b/entity-types/infra-ocivnic/golden_metrics.stg.yml
@@ -1,0 +1,24 @@
+bytesFromNetwork:
+  title: Bytes from Network
+  unit: BYTES
+  queries:
+    oci:
+      select: sum(oci.vcn.vnic.from.network.bytes)
+bytesToNetwork:
+  title: Bytes to Network
+  unit: BYTES
+  queries:
+    oci:
+      select: sum(oci.vcn.vnic.to.network.bytes)
+conntrackUtilization:
+  title: Connection Tracking Table Utilization
+  unit: PERCENTAGE
+  queries:
+    oci:
+      select: average(oci.vcn.vnic.conntrack.util.percent)
+throttledIngressPackets:
+  title: Throttled Ingress Packets
+  unit: COUNT
+  queries:
+    oci:
+      select: sum(oci.vcn.vnic.ingress.drops.throttle)

--- a/entity-types/infra-ocivnic/golden_metrics.stg.yml
+++ b/entity-types/infra-ocivnic/golden_metrics.stg.yml
@@ -3,13 +3,13 @@ bytesFromNetwork:
   unit: BYTES
   queries:
     oci:
-      select: sum(oci.vcn.vnic.from.network.bytes)
+      select: sum(`oci.vcn.vnic.from.network.bytes`)
 bytesToNetwork:
   title: Bytes to Network
   unit: BYTES
   queries:
     oci:
-      select: sum(oci.vcn.vnic.to.network.bytes)
+      select: sum(`oci.vcn.vnic.to.network.bytes`)
 conntrackUtilization:
   title: Connection Tracking Table Utilization
   unit: PERCENTAGE

--- a/entity-types/infra-ocivnic/golden_metrics.stg.yml
+++ b/entity-types/infra-ocivnic/golden_metrics.stg.yml
@@ -4,21 +4,33 @@ bytesFromNetwork:
   queries:
     oci:
       select: sum(`oci.vcn.vnic.from.network.bytes`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
 bytesToNetwork:
   title: Bytes to Network
   unit: BYTES
   queries:
     oci:
       select: sum(`oci.vcn.vnic.to.network.bytes`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
 conntrackUtilization:
   title: Connection Tracking Table Utilization
   unit: PERCENTAGE
   queries:
     oci:
       select: average(oci.vcn.vnic.conntrack.util.percent)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
 throttledIngressPackets:
   title: Throttled Ingress Packets
   unit: COUNT
   queries:
     oci:
       select: sum(oci.vcn.vnic.ingress.drops.throttle)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-ocivnic/summary_metrics.stg.yml
+++ b/entity-types/infra-ocivnic/summary_metrics.stg.yml
@@ -1,0 +1,21 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: OCI account
+  unit: STRING
+bytesFromNetwork:
+  goldenMetric: bytesFromNetwork
+  unit: BYTES
+  title: Bytes from Network
+bytesToNetwork:
+  goldenMetric: bytesToNetwork
+  unit: BYTES
+  title: Bytes to Network
+conntrackUtilization:
+  goldenMetric: conntrackUtilization
+  unit: PERCENTAGE
+  title: Connection Tracking Table Utilization
+throttledIngressPackets:
+  goldenMetric: throttledIngressPackets
+  unit: COUNT
+  title: Throttled Ingress Packets

--- a/entity-types/infra-ocivnic/tests/Metric.stg.json
+++ b/entity-types/infra-ocivnic/tests/Metric.stg.json
@@ -1,0 +1,14 @@
+[
+  {
+    "oci.compartmentId": "ocid1.compartment.oc1..exampleuniqueID",
+    "oci.namespace": "oci_vcn",
+    "oci.region": "us-ashburn-1",
+    "oci.resourceId": "ocid1.vnic.oc1.iad.exampleuniqueID",
+    "collector.name": "oci-metric-streams",
+    "instrumentation.provider": "oci",
+    "metricName": "oci.vcn.vnic.from.network.bytes",
+    "newrelic.cloudIntegrations.providerAccountId": "69877",
+    "newrelic.cloudIntegrations.providerAccountName": "oci_test_1",
+    "newrelic.source": "metricAPI"
+  }
+]


### PR DESCRIPTION
Add OCI VNIC entity definition with synthesis rules, golden metrics, and summary metrics (staging `.stg` files).

## Entity Type
- Type: `INFRA-OCIVNIC`
- Provider: OCI (Oracle Cloud Infrastructure)
- Namespace: `oci_vcn` (publishes **per-VNIC** network metrics)
- Synthesis: `identifier: oci.resourceId`, condition `prefix: ocid1.vnic` + `oci.namespace = oci_vcn`
- `name: oci.resourceId` — VNIC metrics carry no name dimension (matches `infra-ociblockstore` / `infra-ocistreaming`)

## Golden Metrics
- Bytes from Network (`oci.vcn.vnic.from.network.bytes`)
- Bytes to Network (`oci.vcn.vnic.to.network.bytes`)
- Connection Tracking Table Utilization (`oci.vcn.vnic.conntrack.util.percent`)
- Throttled Ingress Packets (`oci.vcn.vnic.ingress.drops.throttle`)

## Metric Source
https://docs.oracle.com/en-us/iaas/Content/Network/Reference/vnicmetrics.htm

Validated locally: `npm --prefix validator run check` (exit 0) + jest 7/7.

Staging-only (`.stg.yml`/`.stg.json`). Promote later via `--upstream production`.