### PR TITLE
feat: Add OCIFASTCONNECT entity definition (staging)

### DIFF
--- a/entity-types/infra-ocifastconnect/definition.stg.yml
+++ b/entity-types/infra-ocifastconnect/definition.stg.yml
@@ -1,0 +1,43 @@
+domain: INFRA
+type: OCIFASTCONNECT
+goldenTags:
+- oci.availabilityDomain
+- oci.compartmentId
+- oci.region
+- oci.lifecycleState
+- oci.displayName
+- oci.bandwidthShapeName
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
+      multiValue: false
+  rules:
+  - ruleName: infra_ocifastconnect_oci_resourceId
+    identifier: oci.resourceId
+    name: oci.resourceName
+    legacyFeatures:
+      overrideGuidType: true
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: oci.resourceId
+      prefix: "ocid1.virtualcircuit"
+    - attribute: oci.namespace
+      value: "oci_fastconnect"
+  - ruleName: infra_ocifastconnect_oci_resourceId_2
+    identifier: oci.resourceId
+    name: oci.resourceName
+    legacyFeatures:
+      overrideGuidType: true
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: oci.resourceId
+      prefix: "ocid1.crossconnectgroup"
+    - attribute: oci.namespace
+      value: "oci_fastconnect"
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-ocifastconnect/golden_metrics.stg.yml
+++ b/entity-types/infra-ocifastconnect/golden_metrics.stg.yml
@@ -1,0 +1,36 @@
+connectionState:
+  title: Connection State
+  unit: COUNT
+  queries:
+    oci:
+      select: latest(`oci.fastconnect.connection.state`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+bitRateReceived:
+  title: Bit Rate Received
+  unit: BITS_PER_SECOND
+  queries:
+    oci:
+      select: average(`oci.fastconnect.bit.rate.received`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+bitRateSent:
+  title: Bit Rate Sent
+  unit: BITS_PER_SECOND
+  queries:
+    oci:
+      select: average(`oci.fastconnect.bit.rate.sent`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+packetsError:
+  title: Packets with Errors
+  unit: COUNT
+  queries:
+    oci:
+      select: sum(`oci.fastconnect.packets.error`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-ocifastconnect/summary_metrics.stg.yml
+++ b/entity-types/infra-ocifastconnect/summary_metrics.stg.yml
@@ -1,0 +1,21 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: OCI account
+  unit: STRING
+connectionState:
+  goldenMetric: connectionState
+  unit: COUNT
+  title: Connection State
+bitRateReceived:
+  goldenMetric: bitRateReceived
+  unit: BITS_PER_SECOND
+  title: Bit Rate Received
+bitRateSent:
+  goldenMetric: bitRateSent
+  unit: BITS_PER_SECOND
+  title: Bit Rate Sent
+packetsError:
+  goldenMetric: packetsError
+  unit: COUNT
+  title: Packets with Errors

--- a/entity-types/infra-ocifastconnect/tests/Metric.stg.json
+++ b/entity-types/infra-ocifastconnect/tests/Metric.stg.json
@@ -1,0 +1,33 @@
+[
+  {
+    "oci.availabilityDomain": "AD-1",
+    "oci.compartmentId": "ocid1.compartment.oc1..aaaaaaaabbbbbbccccccccdddddddeeeeeeefffffffgggggggghhhhhhhh",
+    "oci.displayName": "test-virtual-circuit",
+    "oci.lifecycleState": "PROVISIONED",
+    "oci.namespace": "oci_fastconnect",
+    "oci.region": "us-ashburn-1",
+    "oci.resourceId": "ocid1.virtualcircuit.oc1.us-ashburn-1.aaaaaaaabbbbbbccccccccdddddddeeeeeeefffffffgggggggghhhhhhhh",
+    "oci.resourceName": "test-virtual-circuit",
+    "oci.bandwidthShapeName": "1 Gbps",
+    "collector.name": "oci-monitor",
+    "instrumentation.provider": "oci",
+    "metricName": "oci.fastconnect.connection.state",
+    "newrelic.cloudIntegrations.integrationName": "OCI Monitor metrics",
+    "newrelic.cloudIntegrations.providerAccountName": "oci-dev-all-metrics"
+  },
+  {
+    "oci.availabilityDomain": "AD-1",
+    "oci.compartmentId": "ocid1.compartment.oc1..aaaaaaaabbbbbbccccccccdddddddeeeeeeefffffffgggggggghhhhhhhh",
+    "oci.displayName": "test-cross-connect-group",
+    "oci.lifecycleState": "PROVISIONED",
+    "oci.namespace": "oci_fastconnect",
+    "oci.region": "us-ashburn-1",
+    "oci.resourceId": "ocid1.crossconnectgroup.oc1.us-ashburn-1.iiiiiiiiijjjjjjjjkkkkkkkklllllllmmmmmmmnnnnnnnnoooooooo",
+    "oci.resourceName": "test-cross-connect-group",
+    "collector.name": "oci-monitor",
+    "instrumentation.provider": "oci",
+    "metricName": "oci.fastconnect.bit.rate.received",
+    "newrelic.cloudIntegrations.integrationName": "OCI Monitor metrics",
+    "newrelic.cloudIntegrations.providerAccountName": "oci-dev-all-metrics"
+  }
+]


### PR DESCRIPTION
Add OCI FastConnect entity definition with synthesis rules, golden metrics, and summary metrics. Staging (`.stg.yml`/`.stg.json`).

## Entity Type
- Type: `INFRA-OCIFASTCONNECT`
- Provider: OCI (Oracle Cloud Infrastructure)
- Namespace: `oci_fastconnect`

## Subtypes (2 synthesis rules, single metrics namespace)
- Virtual circuit — `ocid1.virtualcircuit`
- Cross-connect group (LAG) — `ocid1.crossconnectgroup`

## Golden Metrics
- ConnectionState, BitRateReceived, BitRateSent, PacketsError

## Metric Source
https://docs.oracle.com/en-us/iaas/Content/Network/Reference/fastconnectmetrics.htm

Validated locally: schema (definition/golden/summary), folders, and synthesis rules all pass.