### PR TITLE
feat: Add OCIDYNAMICROUTINGGATEWAY entity definition (staging)

### DIFF
--- a/entity-types/infra-ocidynamicroutinggateway/definition.stg.yml
+++ b/entity-types/infra-ocidynamicroutinggateway/definition.stg.yml
@@ -1,0 +1,34 @@
+domain: INFRA
+type: OCIDYNAMICROUTINGGATEWAY
+goldenTags:
+- oci.compartmentId
+- oci.displayName
+- oci.lifecycleState
+- oci.region
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
+      multiValue: false
+  rules:
+  # DRG metrics are emitted per DRG attachment: dimension resourceId is the DRG
+  # attachment OCID (ocid1.drgattachment), while drgOcid is the DRG itself
+  # (ocid1.drg). The entity represents the DRG, so synthesis keys on oci.drgOcid.
+  # Ref: https://docs.oracle.com/en-us/iaas/Content/Network/Reference/drgmetrics.htm
+  - ruleName: infra_ocidynamicroutinggateway_oci_drgOcid
+    identifier: oci.drgOcid
+    name: oci.drgOcid
+    legacyFeatures:
+      overrideGuidType: true
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: oci.drgOcid
+      prefix: "ocid1.drg"
+    - attribute: oci.namespace
+      value: "oci_dynamic_routing_gateway"
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-ocidynamicroutinggateway/golden_metrics.stg.yml
+++ b/entity-types/infra-ocidynamicroutinggateway/golden_metrics.stg.yml
@@ -1,0 +1,36 @@
+bytesToDrgAttachment:
+  title: Bytes Sent From DRG
+  unit: BYTES
+  queries:
+    oci:
+      select: sum(oci.dynamic.routing.gateway.bytes.to.drg.attachment)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+bytesFromDrgAttachment:
+  title: Bytes Sent To DRG
+  unit: BYTES
+  queries:
+    oci:
+      select: sum(oci.dynamic.routing.gateway.bytes.from.drg.attachment)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+packetDropsToDrgAttachment:
+  title: Packet Drops To DRG Attachment
+  unit: COUNT
+  queries:
+    oci:
+      select: sum(oci.dynamic.routing.gateway.packet.drops.to.drg.attachment)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+packetDropsFromDrgAttachment:
+  title: Packet Drops From DRG Attachment
+  unit: COUNT
+  queries:
+    oci:
+      select: sum(oci.dynamic.routing.gateway.packet.drops.from.drg.attachment)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-ocidynamicroutinggateway/golden_metrics.stg.yml
+++ b/entity-types/infra-ocidynamicroutinggateway/golden_metrics.stg.yml
@@ -3,7 +3,7 @@ bytesToDrgAttachment:
   unit: BYTES
   queries:
     oci:
-      select: sum(oci.dynamic.routing.gateway.bytes.to.drg.attachment)
+      select: sum(`oci.dynamic.routing.gateway.bytes.to.drg.attachment`)
       from: Metric
       eventId: entity.guid
       eventName: entity.name
@@ -12,7 +12,7 @@ bytesFromDrgAttachment:
   unit: BYTES
   queries:
     oci:
-      select: sum(oci.dynamic.routing.gateway.bytes.from.drg.attachment)
+      select: sum(`oci.dynamic.routing.gateway.bytes.from.drg.attachment`)
       from: Metric
       eventId: entity.guid
       eventName: entity.name
@@ -21,7 +21,7 @@ packetDropsToDrgAttachment:
   unit: COUNT
   queries:
     oci:
-      select: sum(oci.dynamic.routing.gateway.packet.drops.to.drg.attachment)
+      select: sum(`oci.dynamic.routing.gateway.packet.drops.to.drg.attachment`)
       from: Metric
       eventId: entity.guid
       eventName: entity.name
@@ -30,7 +30,7 @@ packetDropsFromDrgAttachment:
   unit: COUNT
   queries:
     oci:
-      select: sum(oci.dynamic.routing.gateway.packet.drops.from.drg.attachment)
+      select: sum(`oci.dynamic.routing.gateway.packet.drops.from.drg.attachment`)
       from: Metric
       eventId: entity.guid
       eventName: entity.name

--- a/entity-types/infra-ocidynamicroutinggateway/golden_metrics.stg.yml
+++ b/entity-types/infra-ocidynamicroutinggateway/golden_metrics.stg.yml
@@ -1,5 +1,5 @@
 bytesToDrgAttachment:
-  title: Bytes Sent From DRG
+  title: Bytes To DRG Attachment
   unit: BYTES
   queries:
     oci:
@@ -8,7 +8,7 @@ bytesToDrgAttachment:
       eventId: entity.guid
       eventName: entity.name
 bytesFromDrgAttachment:
-  title: Bytes Sent To DRG
+  title: Bytes From DRG Attachment
   unit: BYTES
   queries:
     oci:

--- a/entity-types/infra-ocidynamicroutinggateway/summary_metrics.stg.yml
+++ b/entity-types/infra-ocidynamicroutinggateway/summary_metrics.stg.yml
@@ -1,0 +1,21 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: OCI account
+  unit: STRING
+bytesToDrgAttachment:
+  goldenMetric: bytesToDrgAttachment
+  unit: BYTES
+  title: Bytes Sent From DRG
+bytesFromDrgAttachment:
+  goldenMetric: bytesFromDrgAttachment
+  unit: BYTES
+  title: Bytes Sent To DRG
+packetDropsToDrgAttachment:
+  goldenMetric: packetDropsToDrgAttachment
+  unit: COUNT
+  title: Packet Drops To DRG Attachment
+packetDropsFromDrgAttachment:
+  goldenMetric: packetDropsFromDrgAttachment
+  unit: COUNT
+  title: Packet Drops From DRG Attachment

--- a/entity-types/infra-ocidynamicroutinggateway/summary_metrics.stg.yml
+++ b/entity-types/infra-ocidynamicroutinggateway/summary_metrics.stg.yml
@@ -6,11 +6,11 @@ providerAccountName:
 bytesToDrgAttachment:
   goldenMetric: bytesToDrgAttachment
   unit: BYTES
-  title: Bytes Sent From DRG
+  title: Bytes To DRG Attachment
 bytesFromDrgAttachment:
   goldenMetric: bytesFromDrgAttachment
   unit: BYTES
-  title: Bytes Sent To DRG
+  title: Bytes From DRG Attachment
 packetDropsToDrgAttachment:
   goldenMetric: packetDropsToDrgAttachment
   unit: COUNT

--- a/entity-types/infra-ocidynamicroutinggateway/tests/Metric.stg.json
+++ b/entity-types/infra-ocidynamicroutinggateway/tests/Metric.stg.json
@@ -1,0 +1,22 @@
+[
+  {
+    "oci.compartmentId": "ocid1.compartment.oc1..aaaaaaaabbbbbbccccccccdddddddeeeeeeefffffffgggggggghhhhhhhhiiiiiiiiijjjjjjjj",
+    "oci.namespace": "oci_dynamic_routing_gateway",
+    "oci.region": "us-ashburn-1",
+    "oci.resourceId": "ocid1.drgattachment.oc1.iad.aaaaaaaabbbbbbccccccccdddddddeeeeeeefffffffgggggggghhhhhhhhiiiiiiiiijjjjjjjj",
+    "oci.drgOcid": "ocid1.drg.oc1.iad.aaaaaaaabbbbbbccccccccdddddddeeeeeeefffffffgggggggghhhhhhhhiiiiiiiiikkkkkkkk",
+    "oci.drgRouteTableId": "ocid1.drgroutetable.oc1.iad.aaaaaaaabbbbbbccccccccdddddddeeeeeeefffffffgggggggghhhhhhhhiiiiiiiiillllllll",
+    "oci.attachmentType": "VCN",
+    "oci.displayName": "test-drg",
+    "oci.lifecycleState": "AVAILABLE",
+    "collector.name": "oci-monitor",
+    "displayName": "test-drg",
+    "instrumentation.provider": "oci",
+    "metricName": "oci.dynamic.routing.gateway.bytes.to.drg.attachment",
+    "newrelic.cloudIntegrations.integrationName": "OCI Monitor metrics",
+    "newrelic.cloudIntegrations.providerAccountId": "1",
+    "newrelic.cloudIntegrations.providerAccountName": "oci-dev-all-metrics",
+    "newrelic.source": "metricAPI",
+    "timestamp": 1746680903
+  }
+]


### PR DESCRIPTION
Add OCI Dynamic Routing Gateway entity definition with synthesis rules, golden metrics, and summary metrics. Staging-only (`.stg.yml` / `Metric.stg.json`).

## Entity Type
- Type: `INFRA-OCIDYNAMICROUTINGGATEWAY`
- Provider: OCI (Oracle Cloud Infrastructure)
- Namespace: `oci_dynamic_routing_gateway`

## Synthesis
DRG metrics are emitted **per DRG attachment**: the `resourceId` dimension is the attachment OCID (`ocid1.drgattachment`), while `drgOcid` is the DRG itself (`ocid1.drg`). To represent the **DRG**, synthesis keys on `oci.drgOcid` (prefix `ocid1.drg`) rather than the default `oci.resourceId`. This follows the existing identifier-override precedent used by `oci_service_connector_hub` (`oci.connectorId`).

## Golden Metrics
- `BytesToDrgAttachment` → `oci.dynamic.routing.gateway.bytes.to.drg.attachment`
- `BytesFromDrgAttachment` → `oci.dynamic.routing.gateway.bytes.from.drg.attachment`
- `PacketDropsToDrgAttachment` → `oci.dynamic.routing.gateway.packet.drops.to.drg.attachment`
- `PacketDropsFromDrgAttachment` → `oci.dynamic.routing.gateway.packet.drops.from.drg.attachment`

## Metric Source
https://docs.oracle.com/en-us/iaas/Content/Network/Reference/drgmetrics.htm