### PR TITLE
feat: Add OCINETWORKFIREWALL entity definition (staging)

### DIFF
--- a/entity-types/infra-ocinetworkfirewall/definition.stg.yml
+++ b/entity-types/infra-ocinetworkfirewall/definition.stg.yml
@@ -1,0 +1,33 @@
+domain: INFRA
+type: OCINETWORKFIREWALL
+goldenTags:
+- oci.compartmentId
+- oci.displayName
+- oci.lifecycleState
+- oci.region
+- oci.availabilityDomain
+- oci.networkFirewallPolicyId
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
+      multiValue: false
+  rules:
+  - ruleName: infra_ocinetworkfirewall_oci_resourceId
+    identifier: oci.resourceId
+    name: oci.resourceName
+    legacyFeatures:
+      overrideGuidType: true
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: oci.resourceId
+      prefix: "ocid1.networkfirewall"
+    - attribute: oci.namespace
+      value: "oci_network_firewall"
+
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-ocinetworkfirewall/golden_metrics.stg.yml
+++ b/entity-types/infra-ocinetworkfirewall/golden_metrics.stg.yml
@@ -1,0 +1,36 @@
+firewallThroughput:
+  title: Firewall Throughput
+  unit: BITS_PER_SECOND
+  queries:
+    oci:
+      select: average(oci.network.firewall.firewall.throughput)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+sessions:
+  title: Firewall Sessions
+  unit: COUNT
+  queries:
+    oci:
+      select: average(oci.network.firewall.sessions)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+packetDropCount:
+  title: Packet Drop Count
+  unit: COUNT
+  queries:
+    oci:
+      select: sum(oci.network.firewall.packet.drop.count)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+securityRuleHitCount:
+  title: Security Rule Hits
+  unit: COUNT
+  queries:
+    oci:
+      select: sum(oci.network.firewall.security.rule.hit.count)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-ocinetworkfirewall/summary_metrics.stg.yml
+++ b/entity-types/infra-ocinetworkfirewall/summary_metrics.stg.yml
@@ -1,0 +1,21 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: OCI account
+  unit: STRING
+firewallThroughput:
+  goldenMetric: firewallThroughput
+  unit: BITS_PER_SECOND
+  title: Firewall Throughput
+sessions:
+  goldenMetric: sessions
+  unit: COUNT
+  title: Firewall Sessions
+packetDropCount:
+  goldenMetric: packetDropCount
+  unit: COUNT
+  title: Packet Drop Count
+securityRuleHitCount:
+  goldenMetric: securityRuleHitCount
+  unit: COUNT
+  title: Security Rule Hits

--- a/entity-types/infra-ocinetworkfirewall/tests/Metric.stg.json
+++ b/entity-types/infra-ocinetworkfirewall/tests/Metric.stg.json
@@ -1,0 +1,25 @@
+[
+  {
+    "oci.compartmentId": "ocid1.compartment.oc1..aaaaaaaabbbbbbccccccccdddddddeeeeeeefffffffgggggggghhhhhhhhiiiiiiiiijjjjjjjj",
+    "oci.namespace": "oci_network_firewall",
+    "oci.region": "us-ashburn-1",
+    "oci.resourceId": "ocid1.networkfirewall.oc1.us-ashburn-1.aaaaaaaabbbbbbccccccccdddddddeeeeeeefffffffgggggggghhhhhhhhiiiiiiiiijjjjjjjj",
+    "oci.resourceName": "test-network-firewall",
+    "oci.displayName": "test-network-firewall",
+    "oci.lifecycleState": "ACTIVE",
+    "oci.availabilityDomain": "AD-1",
+    "oci.networkFirewallPolicyId": "ocid1.networkfirewallpolicy.oc1.us-ashburn-1.aaaaaaaakkkkkkkkllllllllmmmmmmmmnnnnnnnnooooooooppppppppqqqqqqqqrrrrrrrrssss",
+    "collector.name": "oci-monitor",
+    "collector.version": "release-007",
+    "displayName": "test-network-firewall",
+    "endTimestamp": 1746680903,
+    "instrumentation.provider": "oci",
+    "metricName": "oci.network.firewall.firewall.throughput",
+    "newrelic.cloudIntegrations.integrationId": "1",
+    "newrelic.cloudIntegrations.integrationName": "OCI Monitor metrics",
+    "newrelic.cloudIntegrations.providerAccountId": "1",
+    "newrelic.cloudIntegrations.providerAccountName": "oci-dev-all-metrics",
+    "newrelic.cloudIntegrations.providerExternalId": "9bcb5134-f0a6-11ed-a05b-0242ac120003",
+    "timestamp": 1746680903
+  }
+]


### PR DESCRIPTION
Add OCI Network Firewall entity definition with synthesis rules, golden metrics, and summary metrics.

## Entity Type
- Type: `INFRA-OCINETWORKFIREWALL`
- Provider: OCI (Oracle Cloud Infrastructure)
- Namespace: `oci_network_firewall`
- OCID prefix: `ocid1.networkfirewall` (verified via OCI CLI: `get_network_firewall` accepts this prefix as a well-formed OCID, rejects bogus prefixes)

## Golden Metrics
- Firewall Throughput (`oci.network.firewall.firewall.throughput`, BITS_PER_SECOND)
- Firewall Sessions (`oci.network.firewall.sessions`, COUNT)
- Packet Drop Count (`oci.network.firewall.packet.drop.count`, COUNT)
- Security Rule Hits (`oci.network.firewall.security.rule.hit.count`, COUNT)

## Metric Source
https://docs.oracle.com/en-us/iaas/Content/network-firewall/metrics.htm

## Staging
Files use `.stg.yml` / `.stg.json` suffix (staging only). Validated locally with the repo validator (schema + folders + rules all pass).