### PR TITLE
feat: Add staging OTel log synthesis rule for POSTGRESQLINSTANCE

### DIFF
--- a/entity-types/infra-postgresqlinstance/definition.stg.yml
+++ b/entity-types/infra-postgresqlinstance/definition.stg.yml
@@ -1,0 +1,92 @@
+domain: INFRA
+type: POSTGRESQLINSTANCE
+
+synthesis:
+  rules:
+    # opentelemetry (postgresqlreceiver); service.instance.id is host:port, enabled by default
+    - ruleName: infra_postgresqlinstance_service_instance_id
+      identifier: service.instance.id # host:port
+      name: service.instance.id
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: eventType
+          value: Metric
+        - attribute: metricName
+          prefix: postgresql.
+        - attribute: instrumentation.provider
+          value: opentelemetry
+      tags:
+        # Environment resource attributes
+        host.type:
+        cloud.provider:
+        cloud.account.id:
+        cloud.region:
+        otel.library.name:
+          entityTagName: instrumentation.name
+
+    # opentelemetry logs (db.server.top_query / db.server.query_sample);
+    # db.system.name is always present on these log events when enabled.
+    # Using service.instance.id (host:port) to match the metric rule above.
+    - ruleName: infra_postgresqlinstance_otel_logs
+      identifier: service.instance.id # host:port
+      name: service.instance.id
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: eventType
+          value: Log
+        - attribute: instrumentation.provider
+          value: opentelemetry
+        - attribute: db.system.name
+          value: postgresql
+      tags:
+        host.type:
+        cloud.provider:
+        cloud.account.id:
+        cloud.region:
+        otel.library.name:
+          entityTagName: instrumentation.name
+
+    # nri-postgresql / PostgresqlInstanceSample
+    - ruleName: infra_postgresqlinstance_entityId
+      identifier: entityId
+      name: entityKey
+      legacyFeatures:
+        useNonStandardAttributes: true
+        overrideGuidType: true
+      prefixedTags:
+        label.:
+          ttl: PT4H
+      conditions:
+        - attribute: eventType
+          value: 'PostgresqlInstanceSample'
+      tags:
+        integrationName:
+          ttl: P1D
+        integrationVersion:
+          ttl: P1D
+        reportingAgent:
+          ttl: P1D
+        reportingEndpoint:
+          ttl: P1D
+
+  tags:
+    # For OpenTelemetry
+    telemetry.sdk.name:
+      entityTagName: instrumentation.provider
+
+goldenTags:
+- postgres.host
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+
+dashboardTemplates:
+  # This should match the entity created from the ohi in the infra pipeline
+  newRelic:
+    template: newrelic_dashboard.json
+  opentelemetry:
+    template: opentelemetry_dashboard.json
+
+ownership:
+  primaryOwner:
+    teamName: "Database Integrations"

--- a/entity-types/infra-postgresqlinstance/tests/Log.json
+++ b/entity-types/infra-postgresqlinstance/tests/Log.json
@@ -1,0 +1,35 @@
+[
+  {
+    "eventType": "Log",
+    "instrumentation.provider": "opentelemetry",
+    "db.system.name": "postgresql",
+    "db.namespace": "testdb",
+    "db.query.text": "SELECT 1",
+    "event.name": "db.server.top_query",
+    "service.instance.id": "localhost:5432",
+    "newrelic.source": "api.logs.otlp",
+    "otel.library.name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver",
+    "postgresql.calls": 10,
+    "postgresql.queryid": "12345",
+    "postgresql.rolname": "app_user",
+    "postgresql.rows": 100,
+    "postgresql.total_exec_time": 5.2,
+    "timestamp": 1784408557426
+  },
+  {
+    "eventType": "Log",
+    "instrumentation.provider": "opentelemetry",
+    "db.system.name": "postgresql",
+    "db.namespace": "testdb",
+    "db.query.text": "SELECT id FROM users WHERE active = $1",
+    "event.name": "db.server.query_sample",
+    "service.instance.id": "localhost:5432",
+    "newrelic.source": "api.logs.otlp",
+    "otel.library.name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver",
+    "postgresql.state": "active",
+    "postgresql.pid": 1234,
+    "postgresql.rolname": "app_user",
+    "postgresql.total_exec_time": 1.5,
+    "timestamp": 1784408557426
+  }
+]


### PR DESCRIPTION
### Relevant information

<!--
   Adds definition.stg.yml with a new synthesis rule that associates OTel
   log events (db.server.top_query, db.server.query_sample) with the
   existing POSTGRESQLINSTANCE entity. Uses db.system.name: postgresql as
   the discriminator — receiver-agnostic and always present when log events
   are enabled. Identifier is service.instance.id (host:port) to match the
   existing OTel metric rule, ensuring logs resolve to the same entity GUID.

   Also adds tests/Log.json covering both log event types for CI validation.
-->

<!--
  Contributions to this repository are reviewed at least twice a week

  There's no further action required once the PR has been created.
 -->

#### Api Review Board (ARB)

Any pull request with changes to this repository has to be linked with an ARB ticket, which has to be approved before merging.

If you are an external contributor please contact New Relic Support.

If you don't know about the ARB process check [this](https://newrelic.enterprise.slack.com/docs/T02D34WJD/F08AW240NSV)

ARB Jira ticket:
https://new-relic.atlassian.net/browse/NR-XXXX

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid.
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
* [ ] I've linked an ARB ticket & received approval from API Review Board in order to make these changes
