### PR TITLE
fix: Update candidate tagKeys

### DIFF
--- a/relationships/candidates/KUBERNETES_NAMESPACE.stg.yml
+++ b/relationships/candidates/KUBERNETES_NAMESPACE.stg.yml
@@ -6,9 +6,9 @@ lookups:
     tags:
       matchingMode: ALL
       predicates:
-        - tagKeys: ["k8s.cluster.name", "clusterName"]
+        - tagKeys: ["k8s.clusterName"]
           field: k8s.clusterName
-        - tagKeys: ["k8s.namespace.name", "namespaceName"]
+        - tagKeys: ["k8s.namespaceName"]
           field: k8s.namespaceName
     onMatch:
       onMultipleMatches: RELATE_ALL


### PR DESCRIPTION
Introduces back newrelic/entity-definitions#2902