### PR TITLE
feat: Add OCIDNS entity definition (staging)

### DIFF
--- a/entity-types/infra-ocidns/definition.stg.yml
+++ b/entity-types/infra-ocidns/definition.stg.yml
@@ -1,0 +1,32 @@
+domain: INFRA
+type: OCIDNS
+goldenTags:
+- oci.compartmentId
+- oci.region
+- oci.displayName
+- oci.lifecycleState
+- oci.zoneType
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
+      multiValue: false
+  rules:
+  - ruleName: infra_ocidns_oci_resourceId
+    identifier: oci.resourceId
+    name: oci.resourceName
+    legacyFeatures:
+      overrideGuidType: true
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: oci.resourceId
+      prefix: "ocid1.dns-zone"
+    - attribute: oci.namespace
+      value: "oci_dns"
+
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-ocidns/golden_metrics.stg.yml
+++ b/entity-types/infra-ocidns/golden_metrics.stg.yml
@@ -1,0 +1,36 @@
+dnsQueries:
+  title: DNS Queries
+  unit: COUNT
+  queries:
+    oci:
+      select: sum(oci.dns.query.count)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+trafficManagementQueries:
+  title: Traffic Management Queries
+  unit: COUNT
+  queries:
+    oci:
+      select: sum(oci.dns.traffic.management.query.count)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+zoneTransferSuccesses:
+  title: Zone Transfer Successes
+  unit: COUNT
+  queries:
+    oci:
+      select: sum(oci.dns.zone.transfer.success.count)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+zoneTransferFailures:
+  title: Zone Transfer Failures
+  unit: COUNT
+  queries:
+    oci:
+      select: sum(oci.dns.zone.transfer.failure.count)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-ocidns/summary_metrics.stg.yml
+++ b/entity-types/infra-ocidns/summary_metrics.stg.yml
@@ -1,0 +1,21 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: OCI account
+  unit: STRING
+dnsQueries:
+  goldenMetric: dnsQueries
+  unit: COUNT
+  title: DNS Queries
+trafficManagementQueries:
+  goldenMetric: trafficManagementQueries
+  unit: COUNT
+  title: Traffic Management Queries
+zoneTransferSuccesses:
+  goldenMetric: zoneTransferSuccesses
+  unit: COUNT
+  title: Zone Transfer Successes
+zoneTransferFailures:
+  goldenMetric: zoneTransferFailures
+  unit: COUNT
+  title: Zone Transfer Failures

--- a/entity-types/infra-ocidns/tests/Metric.stg.json
+++ b/entity-types/infra-ocidns/tests/Metric.stg.json
@@ -1,0 +1,28 @@
+[
+  {
+    "oci.compartmentId": "ocid1.compartment.oc1..aaaaaaaabbbbbbccccccccdddddddeeeeeeefffffffgggggggghhhhhhhhiiiiiiiiijjjjjjjj",
+    "oci.namespace": "oci_dns",
+    "oci.region": "ap-hyderabad-1",
+    "oci.resourceId": "ocid1.dns-zone.oc1.ap-hyderabad-1.aaaaaaaabbbbbbccccccccdddddddeeeeeeefffffffgggggggghhhhhhhhiiiiiiiiijjjjjjjj",
+    "oci.resourceName": "example.com",
+    "oci.displayName": "example.com",
+    "oci.lifecycleState": "ACTIVE",
+    "oci.zoneType": "PRIMARY",
+    "oci.dns.query.count": 42,
+    "collector.name": "oci-monitor",
+    "collector.version": "release-007",
+    "displayName": "example.com",
+    "endTimestamp": 1746680903,
+    "instrumentation.provider": "oci",
+    "metricName": "oci.dns.query.count",
+    "newrelic.cloudIntegrations.integrationId": "1",
+    "newrelic.cloudIntegrations.integrationName": "OCI Monitor metrics",
+    "newrelic.cloudIntegrations.providerAccountId": "1",
+    "newrelic.cloudIntegrations.providerAccountName": "oci-dev-all-metrics",
+    "newrelic.cloudIntegrations.providerExternalId": "9bcb5134-f0a6-11ed-a05b-0242ac120003",
+    "newrelic.source": "metricAPI",
+    "nr.entity.id": "-2281987194047346714",
+    "tags.owner": "test",
+    "timestamp": 1746680903
+  }
+]


### PR DESCRIPTION
Add OCI DNS (DNS zone) entity definition with synthesis rules, golden metrics, and summary metrics. Staging-only (`.stg.yml`/`.stg.json`).

## Entity Type
- Type: `INFRA-OCIDNS` (display name: DNS Zone)
- Provider: OCI (Oracle Cloud Infrastructure)
- Namespace: `oci_dns`
- Synthesis anchor: DNS zone (metric `resourceID` dimension = zone OCID, prefix `ocid1.dns-zone`)

## Golden Metrics
- DNS Queries (`oci.dns.query.count`)
- Traffic Management Queries (`oci.dns.traffic.management.query.count`)
- Zone Transfer Successes (`oci.dns.zone.transfer.success.count`)
- Zone Transfer Failures (`oci.dns.zone.transfer.failure.count`)

## Metric Source
https://docs.oracle.com/en-us/iaas/Content/DNS/Reference/dnsmetrics.htm