### PR TITLE
feat: Add OCIWAF entity definition (staging)

### DIFF
--- a/entity-types/infra-ociwaf/definition.stg.yml
+++ b/entity-types/infra-ociwaf/definition.stg.yml
@@ -1,0 +1,31 @@
+domain: INFRA
+type: OCIWAF
+goldenTags:
+- oci.compartmentId
+- oci.displayName
+- oci.lifecycleState
+- oci.region
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
+      multiValue: false
+  rules:
+  - ruleName: infra_ociwaf_oci_resourceId
+    identifier: oci.resourceId
+    name: oci.resourceName
+    legacyFeatures:
+      overrideGuidType: true
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: oci.resourceId
+      prefix: "ocid1.waaspolicy"
+    - attribute: oci.namespace
+      value: "oci_waf"
+
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-ociwaf/golden_metrics.stg.yml
+++ b/entity-types/infra-ociwaf/golden_metrics.stg.yml
@@ -1,0 +1,36 @@
+numberOfRequests:
+  title: Requests
+  unit: COUNT
+  queries:
+    oci:
+      select: sum(oci.waf.number.of.requests)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+numberOfRequestsDetected:
+  title: Detects
+  unit: COUNT
+  queries:
+    oci:
+      select: sum(oci.waf.number.of.requests.detected)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+bandwidth:
+  title: Bandwidth
+  unit: BYTES_PER_SECOND
+  queries:
+    oci:
+      select: average(oci.waf.bandwidth)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+traffic:
+  title: Traffic
+  unit: BYTES
+  queries:
+    oci:
+      select: sum(oci.waf.traffic)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-ociwaf/summary_metrics.stg.yml
+++ b/entity-types/infra-ociwaf/summary_metrics.stg.yml
@@ -1,0 +1,21 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: OCI account
+  unit: STRING
+numberOfRequests:
+  goldenMetric: numberOfRequests
+  unit: COUNT
+  title: Requests
+numberOfRequestsDetected:
+  goldenMetric: numberOfRequestsDetected
+  unit: COUNT
+  title: Detects
+bandwidth:
+  goldenMetric: bandwidth
+  unit: BYTES_PER_SECOND
+  title: Bandwidth
+traffic:
+  goldenMetric: traffic
+  unit: BYTES
+  title: Traffic

--- a/entity-types/infra-ociwaf/tests/Metric.stg.json
+++ b/entity-types/infra-ociwaf/tests/Metric.stg.json
@@ -1,0 +1,25 @@
+[
+  {
+    "oci.compartmentId": "ocid1.compartment.oc1..aaaaaaaabbbbbbccccccccdddddddeeeeeeefffffffgggggggghhhhhhhhiiiiiiiiijjjjjjjj",
+    "oci.namespace": "oci_waf",
+    "oci.region": "us-ashburn-1",
+    "oci.resourceId": "ocid1.waaspolicy.oc1..aaaaaaaabbbbbbccccccccdddddddeeeeeeefffffffgggggggghhhhhhhhiiiiiiiiijjjjjjjj",
+    "oci.resourceName": "test-waf-policy",
+    "oci.lifecycleState": "ACTIVE",
+    "collector.name": "oci-monitor",
+    "collector.version": "release-007",
+    "displayName": "test-waf-policy",
+    "endTimestamp": 1746680903,
+    "instrumentation.provider": "oci",
+    "metricName": "oci.waf.number.of.requests",
+    "newrelic.cloudIntegrations.integrationId": "1",
+    "newrelic.cloudIntegrations.integrationName": "OCI Monitor metrics",
+    "newrelic.cloudIntegrations.providerAccountId": "1",
+    "newrelic.cloudIntegrations.providerAccountName": "oci-dev-all-metrics",
+    "newrelic.cloudIntegrations.providerExternalId": "9bcb5134-f0a6-11ed-a05b-0242ac120003",
+    "newrelic.source": "metricAPI",
+    "nr.entity.id": "-2281987194047346712",
+    "tags.owner": "test",
+    "timestamp": 1746680903
+  }
+]


### PR DESCRIPTION
Add OCI Web Application Firewall entity definition with synthesis rules, golden metrics, and summary metrics (staging `.stg.yml`).

## Entity Type
- Type: `INFRA-OCIWAF`
- Provider: OCI (Oracle Cloud Infrastructure)
- Namespace: `oci_waf`
- Synthesis OCID prefix: `ocid1.waaspolicy` (WAF policy — verified from Oracle docs)

## Golden Metrics
- NumberOfRequests (Requests)
- NumberOfRequestsDetected (Detects)
- Bandwidth
- Traffic

## Metric Source
https://docs.oracle.com/en-us/iaas/Content/WAF/Reference/metricsalarms.htm