### PR TITLE
Add OTEL APM to ES Cluster relationship (staging only)

### DIFF
--- a/relationships/synthesis/OTEL-SERVICE-to-INFRA-ELASTICSEARCHCLUSTER.stg.yml
+++ b/relationships/synthesis/OTEL-SERVICE-to-INFRA-ELASTICSEARCHCLUSTER.stg.yml
@@ -1,0 +1,37 @@
+relationships:
+  # OTEL APM Application calls Elasticsearch Cluster
+  # Matches on elasticsearch.cluster.name attribute in spans
+  # Agent reads cluster name from ES GET / response and enriches spans
+  - name: otelApmCallsElasticsearchClusterByName
+    version: "1"
+    origins:
+      - OpenTelemetry
+    conditions:
+      - attribute: eventType
+        anyOf: ["Span"]
+      - attribute: instrumentation.provider
+        anyOf: ["opentelemetry"]
+      - attribute: entity.type
+        anyOf: ["SERVICE", "APPLICATION"]
+      - attribute: db.system
+        anyOf: ["elasticsearch"]
+      - attribute: elasticsearch.cluster.name
+        present: true
+    relationship:
+      expires: PT75M
+      relationshipType: CALLS
+      source:
+        extractGuid:
+          attribute: entity.guid
+      target:
+        buildGuid:
+          account:
+            attribute: accountId
+          domain:
+            value: INFRA
+          type:
+            value: ELASTICSEARCHCLUSTER
+          identifier:
+            fragments:
+              - attribute: elasticsearch.cluster.name
+            hashAlgorithm: FARM_HASH


### PR DESCRIPTION
## Summary
- Adds relationship synthesis rule for OTEL-instrumented APM applications calling Elasticsearch clusters
- Staging override only (`.stg.yml`) — not promoted to production
- Matches on `elasticsearch.cluster.name` attribute in Span events to build target ELASTICSEARCHCLUSTER entity GUID

## How it works
1. OTEL Java Agent enriches ES spans with `elasticsearch.cluster.name` (read from ES `GET /` response)
2. This rule matches those spans and creates a CALLS relationship to the ES Cluster entity
3. Entity GUID is built using `FARM_HASH` on the cluster name (same as entity identifier)

## Conditions matched
- `eventType`: Span
- `instrumentation.provider`: opentelemetry
- `entity.type`: SERVICE or APPLICATION
- `db.system`: elasticsearch
- `elasticsearch.cluster.name`: present

## Test plan
- [ ] Validate in staging with test Java app + ES cluster
- [ ] Verify relationship appears in Service Map
- [ ] Verify relationship expires after 75 minutes of no data
- [ ] Test with cluster name change — new relationship should form