### PR TITLE
feat(stg): add OTel semconv messaging.kafka.cluster.id relationship rules

### DIFF
--- a/entity-types/infra-kafkatopic/definition.stg.yml
+++ b/entity-types/infra-kafkatopic/definition.stg.yml
@@ -32,6 +32,7 @@ synthesis:
     tags:
       instrumentation.provider:
       kafka.cluster.name:
+      kafka.cluster.id:
       topic:
 
   - ruleName: infra_kafkatopic_otel_jmxscraper_stg
@@ -59,6 +60,7 @@ synthesis:
     tags:
       instrumentation.provider:
       kafka.cluster.name:
+      kafka.cluster.id:
       topic:
 
   - ruleName: infra_kafkatopic_otel_kafkametrics_stg
@@ -114,6 +116,7 @@ synthesis:
     tags:
       instrumentation.provider:
       kafka.cluster.name:
+      kafka.cluster.id:
       topic:
 
   # Log-based rule: OTel kafkareceiver logs carry topic, kafka.cluster.name, and producer.service.name.

--- a/relationships/synthesis/EXT-SERVICE-to-KAFKATOPIC.stg.yml
+++ b/relationships/synthesis/EXT-SERVICE-to-KAFKATOPIC.stg.yml
@@ -425,76 +425,8 @@ relationships:
             - field: producerServiceName
               attribute: producer.service.name
 
-  # Self-hosted Kafka producer span → KAFKATOPIC via kafka.cluster.id + messaging.destination.name
+  # OTel producer span → KAFKATOPIC via messaging.kafka.cluster.id (OTel incubating semconv)
   - name: extServiceProducesSelfHostKafkaTopicClusterIdStg
-    version: "1"
-    origins:
-      - Distributed Tracing
-      - OpenTelemetry
-    conditions:
-      - attribute: eventType
-        anyOf: [ "Span" ]
-      - attribute: newrelic.source
-        anyOf: [ "api.traces.otlp" ]
-      - attribute: entity.type
-        anyOf: [ "SERVICE" ]
-      - attribute: span.kind
-        anyOf: [ "producer", "client" ]
-      - attribute: messaging.destination.name
-        present: true
-      - attribute: kafka.cluster.id
-        present: true
-    relationship:
-      expires: PT75M
-      relationshipType: PRODUCES
-      source:
-        extractGuid:
-          attribute: entity.guid
-      target:
-        lookupGuid:
-          candidateCategory: KAFKATOPIC
-          fields:
-            - field: clusterId
-              attribute: kafka.cluster.id
-            - field: topic
-              attribute: messaging.destination.name
-
-  # Self-hosted Kafka consumer span → KAFKATOPIC via kafka.cluster.id + messaging.destination.name
-  - name: extServiceConsumesSelfHostKafkaTopicClusterIdStg
-    version: "1"
-    origins:
-      - Distributed Tracing
-      - OpenTelemetry
-    conditions:
-      - attribute: eventType
-        anyOf: [ "Span" ]
-      - attribute: newrelic.source
-        anyOf: [ "api.traces.otlp" ]
-      - attribute: entity.type
-        anyOf: [ "SERVICE" ]
-      - attribute: span.kind
-        anyOf: [ "consumer", "server" ]
-      - attribute: messaging.destination.name
-        present: true
-      - attribute: kafka.cluster.id
-        present: true
-    relationship:
-      expires: PT75M
-      relationshipType: CONSUMES
-      source:
-        extractGuid:
-          attribute: entity.guid
-      target:
-        lookupGuid:
-          candidateCategory: KAFKATOPIC
-          fields:
-            - field: clusterId
-              attribute: kafka.cluster.id
-            - field: topic
-              attribute: messaging.destination.name
-
-  # OTel instrumentation producer span → KAFKATOPIC via messaging.kafka.cluster.id (OTel semconv)
-  - name: extServiceProducesOtelInstrKafkaTopicStg
     version: "1"
     origins:
       - Distributed Tracing
@@ -527,8 +459,8 @@ relationships:
             - field: topic
               attribute: messaging.destination.name
 
-  # OTel instrumentation consumer span → KAFKATOPIC via messaging.kafka.cluster.id (OTel semconv)
-  - name: extServiceConsumesOtelInstrKafkaTopicStg
+  # OTel consumer span → KAFKATOPIC via messaging.kafka.cluster.id (OTel incubating semconv)
+  - name: extServiceConsumesSelfHostKafkaTopicClusterIdStg
     version: "1"
     origins:
       - Distributed Tracing

--- a/relationships/synthesis/EXT-SERVICE-to-KAFKATOPIC.stg.yml
+++ b/relationships/synthesis/EXT-SERVICE-to-KAFKATOPIC.stg.yml
@@ -493,3 +493,71 @@ relationships:
             - field: topic
               attribute: messaging.destination.name
 
+  # OTel instrumentation producer span → KAFKATOPIC via messaging.kafka.cluster.id (OTel semconv)
+  - name: extServiceProducesOtelInstrKafkaTopicStg
+    version: "1"
+    origins:
+      - Distributed Tracing
+      - OpenTelemetry
+    conditions:
+      - attribute: eventType
+        anyOf: [ "Span" ]
+      - attribute: newrelic.source
+        anyOf: [ "api.traces.otlp" ]
+      - attribute: entity.type
+        anyOf: [ "SERVICE" ]
+      - attribute: span.kind
+        anyOf: [ "producer", "client" ]
+      - attribute: messaging.destination.name
+        present: true
+      - attribute: messaging.kafka.cluster.id
+        present: true
+    relationship:
+      expires: PT75M
+      relationshipType: PRODUCES
+      source:
+        extractGuid:
+          attribute: entity.guid
+      target:
+        lookupGuid:
+          candidateCategory: KAFKATOPIC
+          fields:
+            - field: clusterId
+              attribute: messaging.kafka.cluster.id
+            - field: topic
+              attribute: messaging.destination.name
+
+  # OTel instrumentation consumer span → KAFKATOPIC via messaging.kafka.cluster.id (OTel semconv)
+  - name: extServiceConsumesOtelInstrKafkaTopicStg
+    version: "1"
+    origins:
+      - Distributed Tracing
+      - OpenTelemetry
+    conditions:
+      - attribute: eventType
+        anyOf: [ "Span" ]
+      - attribute: newrelic.source
+        anyOf: [ "api.traces.otlp" ]
+      - attribute: entity.type
+        anyOf: [ "SERVICE" ]
+      - attribute: span.kind
+        anyOf: [ "consumer", "server" ]
+      - attribute: messaging.destination.name
+        present: true
+      - attribute: messaging.kafka.cluster.id
+        present: true
+    relationship:
+      expires: PT75M
+      relationshipType: CONSUMES
+      source:
+        extractGuid:
+          attribute: entity.guid
+      target:
+        lookupGuid:
+          candidateCategory: KAFKATOPIC
+          fields:
+            - field: clusterId
+              attribute: messaging.kafka.cluster.id
+            - field: topic
+              attribute: messaging.destination.name
+

--- a/relationships/synthesis/EXT-SERVICE-to-KAFKATOPIC.stg.yml
+++ b/relationships/synthesis/EXT-SERVICE-to-KAFKATOPIC.stg.yml
@@ -493,3 +493,69 @@ relationships:
             - field: topic
               attribute: messaging.destination.name
 
+  # Java kafka-clients-cluster-metrics producer metrics → KAFKATOPIC via messaging.kafka.cluster.id + topic
+  - name: extServiceProducesKafkaClientMetricsTopicClusterIdStg
+    version: "1"
+    origins:
+      - OpenTelemetry
+    conditions:
+      - attribute: eventType
+        anyOf: [ "Metric" ]
+      - attribute: instrumentation.provider
+        anyOf: [ "opentelemetry" ]
+      - attribute: metricName
+        startsWith: "kafka.producer"
+      - attribute: entity.type
+        anyOf: [ "SERVICE" ]
+      - attribute: messaging.kafka.cluster.id
+        present: true
+      - attribute: topic
+        present: true
+    relationship:
+      expires: PT75M
+      relationshipType: PRODUCES
+      source:
+        extractGuid:
+          attribute: entity.guid
+      target:
+        lookupGuid:
+          candidateCategory: KAFKATOPIC
+          fields:
+            - field: clusterId
+              attribute: messaging.kafka.cluster.id
+            - field: topic
+              attribute: topic
+
+  # Java kafka-clients-cluster-metrics consumer metrics → KAFKATOPIC via messaging.kafka.cluster.id + topic
+  - name: extServiceConsumesKafkaClientMetricsTopicClusterIdStg
+    version: "1"
+    origins:
+      - OpenTelemetry
+    conditions:
+      - attribute: eventType
+        anyOf: [ "Metric" ]
+      - attribute: instrumentation.provider
+        anyOf: [ "opentelemetry" ]
+      - attribute: metricName
+        startsWith: "kafka.consumer"
+      - attribute: entity.type
+        anyOf: [ "SERVICE" ]
+      - attribute: messaging.kafka.cluster.id
+        present: true
+      - attribute: topic
+        present: true
+    relationship:
+      expires: PT75M
+      relationshipType: CONSUMES
+      source:
+        extractGuid:
+          attribute: entity.guid
+      target:
+        lookupGuid:
+          candidateCategory: KAFKATOPIC
+          fields:
+            - field: clusterId
+              attribute: messaging.kafka.cluster.id
+            - field: topic
+              attribute: topic
+


### PR DESCRIPTION
### Relevant information

OTel instrumentation packages for Kafka emit the OTel incubating semantic convention attribute `messaging.kafka.cluster.id` on producer and consumer spans.

The existing STG relationship rules in `EXT-SERVICE-to-KAFKATOPIC.stg.yml` (added by #2994) match on `kafka.cluster.id` — a legacy attribute not emitted by OTel instrumentation packages. This PR adds the parallel rules for `messaging.kafka.cluster.id` so that services instrumented with these OTel packages can have their spans resolved to `KAFKATOPIC` entities.

**Changes:**

1. **`relationships/synthesis/EXT-SERVICE-to-KAFKATOPIC.stg.yml`** — Two new rules:
   - `extServiceProducesOtelInstrKafkaTopicStg` — producer spans with `messaging.kafka.cluster.id`
   - `extServiceConsumesOtelInstrKafkaTopicStg` — consumer spans with `messaging.kafka.cluster.id`

   Both rules look up `KAFKATOPIC` via the existing `clusterId` field in `KAFKATOPIC.stg.yml` candidates, mapping `messaging.kafka.cluster.id` → entity tag `kafka.cluster.id`.

2. **`entity-types/infra-kafkatopic/definition.stg.yml`** — Add `kafka.cluster.id:` tag to `infra_kafkatopic_otel_jmxmetrics_stg`, `infra_kafkatopic_otel_jmxscraper_stg`, and `infra_kafkatopic_otel_prometheus_stg` rules. Only `infra_kafkatopic_otel_kafkametrics_stg` had this tag; the other three OTel receivers set `kafka.cluster.id` on their metrics but the tag was not being captured on the synthesized entity, which would have caused the candidate lookup to miss those entities.

**Flow:**

```
OTel span (messaging.kafka.cluster.id=<uuid>, messaging.destination.name=<topic>)
  → new synthesis rule extServiceProducesOtelInstrKafkaTopicStg / extServiceConsumesOtelInstrKafkaTopicStg
    → lookupGuid: candidateCategory=KAFKATOPIC, clusterId=<uuid>, topic=<topic>
      → KAFKATOPIC.stg.yml candidates: match entity tag kafka.cluster.id=<uuid> + tag topic=<topic>
        → KAFKATOPIC entity (synthesized from kafkametricsreceiver / jmxmetrics / jmxscraper / prometheus)
```

ARB Jira ticket:
https://new-relic.atlassian.net/browse/NR-XXXX

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid.
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
* [ ] I've linked an ARB ticket & received approval from API Review Board in order to make these changes