### PR TITLE
feat: Added TTLs for OTel tags and cloud.resource_id, aws.lambda.invoked_arn to ext_service_service_name_3 (staging)

### DIFF
--- a/entity-types/ext-service/definition.stg.yml
+++ b/entity-types/ext-service/definition.stg.yml
@@ -124,9 +124,17 @@ synthesis:
       telemetry.sdk.language:
         entityTagName: language
       telemetry.sdk.version:
+        ttl: P1D
       service.namespace:
+        ttl: P1D
       faas.name:
+        ttl: P1D
       faas.id:
+        ttl: P1D
+      aws.lambda.invoked_arn:
+        ttl: P1D
+      cloud.resource_id:
+        ttl: P1D
       newrelic.service.type:
         ttl: P1D
 


### PR DESCRIPTION
## Summary
Adds TTLs for OTel tags and introduces new `cloud.resource_id`, `aws.lambda.invoked_arn` tag mappings to `ext_service_service_name_3` in `definition.stg.yml` ( Staging )

- This pr Mirrors production changes  PRs mentioned below to the `staging entity definition`.

## Changes
**entity-types/ext-service/definition.stg.yml** (rule `ext_service_service_name_3`)

| Tag | Change |
|-----|--------|
| `telemetry.sdk.version` | + ttl: P1D |
| `service.namespace` | + ttl: P1D |
| `faas.name` | + ttl: P1D |
| `faas.id` | + ttl: P1D |
| `cloud.resource_id` | New tag + ttl: P1D |
| `aws.lambda.invoked_arn` | New tag + ttl: P1D |

## References
**Production PRs:**
- PR: #3035 
- PR: #3049

**ARB Ticket:**
https://new-relic.atlassian.net/browse/NR-597948