### PR TITLE
fix: Correct OCINATGATEWAY drops metric to DropsFromNATgw

### DIFF
--- a/entity-types/infra-ocinatgateway/golden_metrics.stg.yml
+++ b/entity-types/infra-ocinatgateway/golden_metrics.stg.yml
@@ -25,12 +25,12 @@ connectionsEstablished:
       from: Metric
       eventId: entity.guid
       eventName: entity.name
-dropsToNatGateway:
-  title: Drops To NAT Gateway
+dropsFromNatGateway:
+  title: Drops From NAT Gateway
   unit: COUNT
   queries:
     oci:
-      select: sum(`oci.nat.gateway.drops.to.natgw`)
+      select: sum(`oci.nat.gateway.drops.from.natgw`)
       from: Metric
       eventId: entity.guid
       eventName: entity.name

--- a/entity-types/infra-ocinatgateway/summary_metrics.stg.yml
+++ b/entity-types/infra-ocinatgateway/summary_metrics.stg.yml
@@ -15,7 +15,7 @@ connectionsEstablished:
   goldenMetric: connectionsEstablished
   unit: COUNT
   title: Connections Established
-dropsToNatGateway:
-  goldenMetric: dropsToNatGateway
+dropsFromNatGateway:
+  goldenMetric: dropsFromNatGateway
   unit: COUNT
-  title: Drops To NAT Gateway
+  title: Drops From NAT Gateway


### PR DESCRIPTION
Follow-up correction to #3067 (already merged).

Verified against **live OCI Monitoring** (`oci monitoring metric list`) in the metrics compartment: the NAT gateway namespace emits **`DropsFromNATgw`**, not `DropsToNATgw`. The Oracle docs reference page (nat-gateway-metrics.htm) lists `DropsToNATgw`, which is inaccurate — no such metric is published. (`highPortUsageWatermark` from the docs is also not emitted.)

## Change
- Golden metric: `dropsToNatGateway` → `dropsFromNatGateway`, query `sum(\`oci.nat.gateway.drops.from.natgw\`)`
- Summary metric: same rename

Without this, the drops golden metric shows **No data**. Staging only (`.stg.yml`).