### PR TITLE
feat: add staging OTel logs synthesis rule for POSTGRESQLINSTANCE

### DIFF
--- a/entity-types/infra-postgresqlinstance/definition.stg.yml
+++ b/entity-types/infra-postgresqlinstance/definition.stg.yml
@@ -1,0 +1,96 @@
+domain: INFRA
+type: POSTGRESQLINSTANCE
+
+synthesis:
+  rules:
+    # opentelemetry (postgresqlreceiver); service.instance.id is host:port, enabled by default
+    - ruleName: infra_postgresqlinstance_service_instance_id
+      identifier: service.instance.id # host:port
+      name: service.instance.id
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: eventType
+          value: Metric
+        - attribute: metricName
+          prefix: postgresql.
+        - attribute: instrumentation.provider
+          value: opentelemetry
+      tags:
+        # Environment resource attributes
+        host.type:
+        cloud.provider:
+        cloud.account.id:
+        cloud.region:
+        otel.library.name:
+          entityTagName: instrumentation.name
+        otel.library.version:
+          entityTagName: instrumentation.version
+
+    # opentelemetry logs (db.server.top_query / db.server.query_sample);
+    # db.system.name is always present on these log events when enabled.
+    # Using service.instance.id (host:port) to match the metric rule above.
+    - ruleName: infra_postgresqlinstance_otel_logs
+      identifier: service.instance.id # host:port
+      name: service.instance.id
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: eventType
+          value: Log
+        - attribute: instrumentation.provider
+          value: opentelemetry
+        - attribute: db.system.name
+          value: postgresql
+      tags:
+        host.type:
+        cloud.provider:
+        cloud.account.id:
+        cloud.region:
+        otel.library.name:
+          entityTagName: instrumentation.name
+        otel.library.version:
+          entityTagName: instrumentation.version
+
+    # nri-postgresql / PostgresqlInstanceSample
+    - ruleName: infra_postgresqlinstance_entityId
+      identifier: entityId
+      name: entityKey
+      legacyFeatures:
+        useNonStandardAttributes: true
+        overrideGuidType: true
+      prefixedTags:
+        label.:
+          ttl: PT4H
+      conditions:
+        - attribute: eventType
+          value: 'PostgresqlInstanceSample'
+      tags:
+        integrationName:
+          ttl: P1D
+        integrationVersion:
+          ttl: P1D
+        reportingAgent:
+          ttl: P1D
+        reportingEndpoint:
+          ttl: P1D
+
+  tags:
+    # For OpenTelemetry
+    telemetry.sdk.name:
+      entityTagName: instrumentation.provider
+
+goldenTags:
+- postgres.host
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+
+dashboardTemplates:
+  # This should match the entity created from the ohi in the infra pipeline
+  newRelic:
+    template: newrelic_dashboard.json
+  opentelemetry:
+    template: opentelemetry_dashboard.json
+
+ownership:
+  primaryOwner:
+    teamName: "Database Integrations"

--- a/entity-types/infra-postgresqlinstance/definition.stg.yml
+++ b/entity-types/infra-postgresqlinstance/definition.stg.yml
@@ -25,6 +25,10 @@ synthesis:
           entityTagName: instrumentation.name
         otel.library.version:
           entityTagName: instrumentation.version
+        server.address:
+          entityTagNames: [server.address, endpoint]
+        server.port:
+          entityTagName: server.port
 
     # opentelemetry logs (db.server.top_query / db.server.query_sample);
     # db.system.name is always present on these log events when enabled.
@@ -49,6 +53,10 @@ synthesis:
           entityTagName: instrumentation.name
         otel.library.version:
           entityTagName: instrumentation.version
+        server.address:
+          entityTagNames: [server.address, endpoint]
+        server.port:
+          entityTagName: server.port
 
     # nri-postgresql / PostgresqlInstanceSample
     - ruleName: infra_postgresqlinstance_entityId

--- a/entity-types/infra-postgresqlinstance/tests/Log.stg.json
+++ b/entity-types/infra-postgresqlinstance/tests/Log.stg.json
@@ -1,0 +1,35 @@
+[
+  {
+    "eventType": "Log",
+    "instrumentation.provider": "opentelemetry",
+    "db.system.name": "postgresql",
+    "db.namespace": "testdb",
+    "db.query.text": "SELECT 1",
+    "event.name": "db.server.top_query",
+    "service.instance.id": "localhost:5432",
+    "newrelic.source": "api.logs.otlp",
+    "otel.library.name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver",
+    "postgresql.calls": 10,
+    "postgresql.queryid": "12345",
+    "postgresql.rolname": "app_user",
+    "postgresql.rows": 100,
+    "postgresql.total_exec_time": 5.2,
+    "timestamp": 1784408557426
+  },
+  {
+    "eventType": "Log",
+    "instrumentation.provider": "opentelemetry",
+    "db.system.name": "postgresql",
+    "db.namespace": "testdb",
+    "db.query.text": "SELECT id FROM users WHERE active = $1",
+    "event.name": "db.server.query_sample",
+    "service.instance.id": "localhost:5432",
+    "newrelic.source": "api.logs.otlp",
+    "otel.library.name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver",
+    "postgresql.state": "active",
+    "postgresql.pid": 1234,
+    "postgresql.rolname": "app_user",
+    "postgresql.total_exec_time": 1.5,
+    "timestamp": 1784408557426
+  }
+]

--- a/relationships/candidates/POSTGRESQLINSTANCE.stg.yml
+++ b/relationships/candidates/POSTGRESQLINSTANCE.stg.yml
@@ -1,0 +1,16 @@
+category: POSTGRESQLINSTANCE
+lookups:
+  - entityTypes:
+      - domain: INFRA
+        type: POSTGRESQLINSTANCE
+    tags:
+      matchingMode: ALL
+      predicates:
+        - tagKeys: ["server.address"]
+          field: serverAddress
+        - tagKeys: ["server.port"]
+          field: serverPort
+    onMatch:
+      onMultipleMatches: RELATE_ALL
+    onMiss:
+      action: NO_OP

--- a/relationships/synthesis/APM-APPLICATION-to-INFRA-POSTGRESQLINSTANCE.stg.yml
+++ b/relationships/synthesis/APM-APPLICATION-to-INFRA-POSTGRESQLINSTANCE.stg.yml
@@ -1,0 +1,53 @@
+relationships:
+  - name: apmApplicationCallsInfraPostgreSQLInstance
+    version: "1"
+    origins:
+      - APM Metrics
+    conditions:
+      - attribute: metricName
+        # "datastore/instance/Postgres/$host/$port"
+        startsWith: "datastore/instance/Postgres/"
+    relationship:
+      expires: PT75M
+      relationshipType: CALLS
+      source:
+        extractGuid:
+          attribute: entity.guid
+      target:
+        buildGuid:
+          account:
+            lookup: true
+          domain:
+            value: INFRA
+          type:
+            value: POSTGRESQLINSTANCE
+            valueInGuid: NA
+          identifier:
+            fragments:
+              - value: "pg-instance:"
+              - attribute: metricName__4 # hostname
+              - value: ":"
+              - attribute: metricName__5 # port
+            hashAlgorithm: FARM_HASH
+
+  - name: apmApplicationCallsInfraPostgreSQLInstanceTimeslice
+    version: "1"
+    origins:
+      - APM Metrics
+    conditions:
+      - attribute: metricName
+        regex: "^[Dd]atastore/instance/Postgres/[^/]+/[0-9]+"
+    relationship:
+      expires: PT75M
+      relationshipType: CALLS
+      source:
+        extractGuid:
+          attribute: entity.guid
+      target:
+        lookupGuid:
+          candidateCategory: POSTGRESQLINSTANCE
+          fields:
+            - field: serverAddress
+              attribute: metricName__4
+            - field: serverPort
+              attribute: metricName__5


### PR DESCRIPTION
### Relevant information
Adds `definition.stg.yml` for POSTGRESQLINSTANCE with a new synthesis rule that
associates OTel log events (`db.server.top_query`, `db.server.query_sample`)
with the existing POSTGRESQLINSTANCE entity, alongside the existing OTel
metrics rule.

- Uses `db.system.name: postgresql` as the log-rule discriminator - receiver-agnostic and present whenever log events are enabled.
- Identifier is `service.instance.id` (host:port) to match the existing OTel metric rule, so logs resolve to the same entity GUID.
- Adds `server.address` / `server.port` tags to both the metric and log rules.
- Test fixture is named `tests/Log.stg.json` (not `Log.json`) since this rule currently lives only in `definition.stg.yml` - entityBot pairs fixtures to definition files by suffix, so a plain `Log.json` would validate against `definition.yml` (which has no `Log` rule) and fail.

<!--
  Describe what you have done.
  Provide details that are relevant to the PR

  Always think that the person reviewing the PR doesn't have the context you have.

  Links to examples, documentation and similar resources make the process easier to review.
-->

<!--
  Contributions to this repository are reviewed at least twice a week

  There's no further action required once the PR has been created.
 -->

#### Api Review Board (ARB)

Any pull request with changes to this repository has to be linked with an ARB ticket, which has to be approved before merging.

If you are an external contributor please contact New Relic Support.

If you don't know about the ARB process check [this](https://newrelic.enterprise.slack.com/docs/T02D34WJD/F08AW240NSV)

ARB Jira ticket:
https://new-relic.atlassian.net/browse/NR-XXXX

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid.
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
* [ ] I've linked an ARB ticket & received approval from API Review Board in order to make these changes
