### PR TITLE
Add collector.name predicate to AZUREVIRTUALNETWORKS candidate

### DIFF
--- a/relationships/candidates/AZUREVIRTUALNETWORKS.yml
+++ b/relationships/candidates/AZUREVIRTUALNETWORKS.yml
@@ -8,6 +8,8 @@ lookups:
       predicates:
         - tagKeys: ["azure.resourceId"]
           field: azureResourceId
+        - tagKeys: ["collector.name"]
+          field: collectorName
     onMatch:
       onMultipleMatches: RELATE_ALL
     onMiss:


### PR DESCRIPTION
Adds a second target-candidate predicate on the collector.name tag, pinned to "auto-discover" by the ACF-side emitter. Restricts cross-sub VNet-peering matches to autodiscovery-registered targets — manually- registered or infra-agent-owned entities that happen to share the same azure.resourceId will no longer resolve, and the resolver falls through to onMiss: CREATE_UNINSTRUMENTED instead.

Paired with the ACF-side change already in production that adds "collectorName" to every CandidateRelationship's target-candidate map: https://source.datanerd.us/beyond/azure-configuration-fetcher/pull/40

Order of operations (safe): the ACF emit-side change shipped first and is currently in staging with the field being ignored by the resolver (no predicate yet references it). Once this YAML change lands and promotes to PRODUCTION, the predicate starts being enforced.

Related tickets: NR-582475 (pilot), NR-595175 (cutover), NR-595176 (extend to other Azure target entity types).

### Relevant information

<!--
  Describe what you have done.
  Provide details that are relevant to the PR

  Always think that the person reviewing the PR doesn't have the context you have.

  Links to examples, documentation and similar resources make the process easier to review.
-->

<!--
  Contributions to this repository are reviewed at least twice a week

  There's no further action required once the PR has been created.
 -->

#### Api Review Board (ARB) -- Not required

Any pull request with changes to this repository has to be linked with an ARB ticket, which has to be approved before merging.

If you are an external contributor please contact New Relic Support.

If you don't know about the ARB process check [this](https://newrelic.enterprise.slack.com/docs/T02D34WJD/F08AW240NSV)

ARB Jira ticket:
https://new-relic.atlassian.net/browse/NR-XXXX

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid.
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
* [ ] I've linked an ARB ticket & received approval from API Review Board in order to make these changes
