### PR TITLE
Add collector.name entity tag for GCP managed Kafka topic/cluster

### DIFF
--- a/entity-types/infra-kafkacluster/definition.stg.yml
+++ b/entity-types/infra-kafkacluster/definition.stg.yml
@@ -260,6 +260,7 @@ synthesis:
     tags:
       # GCP resource attributes
       instrumentation.provider:
+      collector.name:
       gcp.projectId:
       gcp.projectName:
       gcp.region:

--- a/entity-types/infra-kafkacluster/definition.yml
+++ b/entity-types/infra-kafkacluster/definition.yml
@@ -236,6 +236,7 @@ synthesis:
       value: managedkafka.googleapis.com/Cluster
     tags:
       instrumentation.provider:
+      collector.name:
       gcp.projectId:
       gcp.projectName:
       gcp.region:

--- a/entity-types/infra-kafkatopic/definition.stg.yml
+++ b/entity-types/infra-kafkatopic/definition.stg.yml
@@ -198,6 +198,7 @@ synthesis:
       value: managedkafka.googleapis.com/Topic
     tags:
       instrumentation.provider:
+      collector.name:
       gcp.projectId:
       gcp.projectName:
       gcp.region:

--- a/entity-types/infra-kafkatopic/definition.yml
+++ b/entity-types/infra-kafkatopic/definition.yml
@@ -168,6 +168,7 @@ synthesis:
       value: managedkafka.googleapis.com/Topic
     tags:
       instrumentation.provider:
+      collector.name:
       gcp.projectId:
       gcp.projectName:
       gcp.region:


### PR DESCRIPTION
## Summary
- `collector.name` (`gcp-cloud-monitoring`) is present on the raw `Metric` data for GCP managed Kafka topics/clusters, but the `infra_kafkatopic_gcp_managedkafka` / `infra_kafkacluster_gcp_managedkafka` synthesis rules' `tags` whitelist never listed it, so it was never promoted to an entity tag.
- Added `collector.name:` to both rules in `definition.yml` and their `_stg` counterparts, matching how `instrumentation.provider` is already handled in the same block.

ARB: https://new-relic.atlassian.net/browse/NR-567584

<img width="1682" height="679" alt="Screenshot 2026-07-29 at 1 09 55 PM" src="https://github.com/user-attachments/assets/9f6060ec-0f29-43e2-834d-6d1b2a3c3f9f" />
