### PR TITLE
feat(rabbitmqexchange): add OpenTelemetry synthesis, golden metrics & dashboard (staging)

### DIFF
--- a/entity-types/infra-rabbitmqexchange/definition.stg.yml
+++ b/entity-types/infra-rabbitmqexchange/definition.stg.yml
@@ -1,13 +1,40 @@
 domain: INFRA
 type: RABBITMQEXCHANGE
-goldenTags:
-- account
-configuration:
-  entityExpirationTime: DAILY
-  alertable: true
 
 synthesis:
   rules:
+  # OpenTelemetry RabbitMQ Receiver
+  - ruleName: infra_rabbitmqexchange_composite
+    compositeIdentifier:
+      separator: ":"
+      attributes:
+      - rabbitmq.exchange.name
+      - rabbitmq.vhost.name
+    name: rabbitmq.exchange.name
+    encodeIdentifierInGUID: true
+    conditions:
+      - attribute: eventType
+        value: Metric
+      # All metrics from the receiver starts with the 'rabbitmq.' prefix.
+      - attribute: metricName
+        prefix: rabbitmq.
+      - attribute: instrumentation.provider
+        value: opentelemetry
+      # This filters only metrics coming from rabbitmq receiver, given that metrics
+      # could differ between different runtime receivers.
+      - attribute: otel.library.name
+        value: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/rabbitmqreceiver"
+    tags:
+      # Default resource attributes
+      rabbitmq.exchange.name:
+      rabbitmq.exchange.type:
+      rabbitmq.vhost.name:
+      # OTel attributes
+      # The library name contains the name of the receiver that is used to identify the source
+      # and select the dashboard.
+      otel.library.name:
+        entityTagName: instrumentation.name
+
   # Data from RabbitMQ integation OHI
   - ruleName: infra_rabbitmqexchange_entityId
     identifier: entityId
@@ -31,10 +58,26 @@ synthesis:
       reportingEndpoint:
         ttl: P1D
 
+  tags:
+    # For OpenTelemetry
+    telemetry.sdk.name:
+      entityTagName: instrumentation.provider
+
+goldenTags:
+- rabbitmq.exchange.name
+- rabbitmq.vhost.name
+- account
+
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+
 dashboardTemplates:
   # This should match the entity created from the ohi in the infra pipeline
   newRelic:
     template: newrelic_dashboard.json
+  opentelemetry:
+    template: opentelemetry_dashboard.stg.json
 
 ownership:
   primaryOwner:

--- a/entity-types/infra-rabbitmqexchange/golden_metrics.stg.yml
+++ b/entity-types/infra-rabbitmqexchange/golden_metrics.stg.yml
@@ -29,7 +29,7 @@ messagesPublishedPerChannelPerSecond:
       eventId: entityGuid
       eventName: entityName
     opentelemetry:
-      select: rate(sum(rabbitmq.exchange.messages.published_in), 1 second)
+      select: sum(rabbitmq.exchange.messages.published_in) / sum((endTimestamp - timestamp) / 1000)
       from: Metric
       where: instrumentation.provider = 'opentelemetry'
       eventId: entity.guid
@@ -57,7 +57,7 @@ messagesPublishedQueuePerSecond:
       eventId: entityGuid
       eventName: entityName
     opentelemetry:
-      select: rate(sum(rabbitmq.exchange.messages.published_out), 1 second)
+      select: sum(rabbitmq.exchange.messages.published_out) / sum((endTimestamp - timestamp) / 1000)
       from: Metric
       where: instrumentation.provider = 'opentelemetry'
       eventId: entity.guid

--- a/entity-types/infra-rabbitmqexchange/golden_metrics.stg.yml
+++ b/entity-types/infra-rabbitmqexchange/golden_metrics.stg.yml
@@ -1,0 +1,64 @@
+bindings:
+  title: Bindings
+  queries:
+    newRelic:
+      select: average(exchange.bindings)
+      from: RabbitmqExchangeSample
+      eventId: entityGuid
+      eventName: entityName
+messagesPublishedPerChannel:
+  title: Messages published per channel
+  queries:
+    newRelic:
+      select: sum(exchange.messagesPublishedPerChannel)
+      from: RabbitmqExchangeSample
+      eventId: entityGuid
+      eventName: entityName
+    opentelemetry:
+      select: sum(rabbitmq.exchange.messages.published_in)
+      from: Metric
+      where: instrumentation.provider = 'opentelemetry'
+      eventId: entity.guid
+      eventName: entity.name
+messagesPublishedPerChannelPerSecond:
+  title: Messages published per channel per second
+  queries:
+    newRelic:
+      select: average(exchange.messagesPublishedPerChannelPerSecond)
+      from: RabbitmqExchangeSample
+      eventId: entityGuid
+      eventName: entityName
+    opentelemetry:
+      select: rate(sum(rabbitmq.exchange.messages.published_in), 1 second)
+      from: Metric
+      where: instrumentation.provider = 'opentelemetry'
+      eventId: entity.guid
+      eventName: entity.name
+messagesPublishedQueue:
+  title: Messages published queue
+  queries:
+    newRelic:
+      select: sum(exchange.messagesPublishedQueue)
+      from: RabbitmqExchangeSample
+      eventId: entityGuid
+      eventName: entityName
+    opentelemetry:
+      select: sum(rabbitmq.exchange.messages.published_out)
+      from: Metric
+      where: instrumentation.provider = 'opentelemetry'
+      eventId: entity.guid
+      eventName: entity.name
+messagesPublishedQueuePerSecond:
+  title: Messages published queue per second
+  queries:
+    newRelic:
+      select: average(exchange.messagesPublishedQueuePerSecond)
+      from: RabbitmqExchangeSample
+      eventId: entityGuid
+      eventName: entityName
+    opentelemetry:
+      select: rate(sum(rabbitmq.exchange.messages.published_out), 1 second)
+      from: Metric
+      where: instrumentation.provider = 'opentelemetry'
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-rabbitmqexchange/opentelemetry_dashboard.stg.json
+++ b/entity-types/infra-rabbitmqexchange/opentelemetry_dashboard.stg.json
@@ -1,0 +1,68 @@
+{
+  "name": "RabbitMQ Exchange Metrics (OpenTelemetry)",
+  "pages": [
+    {
+      "name": "RabbitMQ Exchange Metrics",
+      "widgets": [
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "height": 4,
+            "width": 4
+          },
+          "title": "Messages Published In (Rate)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT rate(sum(rabbitmq.exchange.messages.published_in), 1 second) WHERE instrumentation.provider = 'opentelemetry' TIMESERIES AUTO",
+                "accountId": 0}
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "height": 4,
+            "width": 4
+          },
+          "title": "Messages Published Out (Rate)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT rate(sum(rabbitmq.exchange.messages.published_out), 1 second) WHERE instrumentation.provider = 'opentelemetry' TIMESERIES AUTO",
+                "accountId": 0}
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "height": 4,
+            "width": 4
+          },
+          "title": "Publish In vs Out",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT latest(rabbitmq.exchange.messages.published_in) AS 'Published In', latest(rabbitmq.exchange.messages.published_out) AS 'Published Out' WHERE instrumentation.provider = 'opentelemetry'",
+                "accountId": 0}
+            ],
+            "thresholds": []
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-rabbitmqexchange/tests/Metric.stg.json
+++ b/entity-types/infra-rabbitmqexchange/tests/Metric.stg.json
@@ -1,0 +1,27 @@
+[
+    {
+        "description": "The total number of messages published into an exchange from channels.",
+        "endTimestamp": 1753417380000,
+        "eventType": "Metric",
+        "instrumentation.provider": "opentelemetry",
+        "messaging.system": "rabbitmq",
+        "metricName": "rabbitmq.exchange.messages.published_in",
+        "newrelic.source": "api.metrics.otlp",
+        "nr.dataPointCount": 1,
+        "nr.duration": 60000,
+        "nr.endTimestampRange": 1753417380000,
+        "otel.library.name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/rabbitmqreceiver",
+        "otel.library.version": "0.130.1",
+        "rabbitmq.exchange.messages.published_in": {
+            "type": "cumulativeCount",
+            "count": 0,
+            "cumulative": 1500
+        },
+        "rabbitmq.exchange.name": "test.direct",
+        "rabbitmq.exchange.type": "direct",
+        "rabbitmq.vhost.name": "/",
+        "service.name": "rabbitmq-service-test-rohan",
+        "timestamp": 1753417320000,
+        "unit": "{messages}"
+    }
+]


### PR DESCRIPTION
## What

Adds OpenTelemetry synthesis for `RABBITMQEXCHANGE` entities, sourced from the `rabbitmqreceiver`'s new exchange-level metrics ([open-telemetry/opentelemetry-collector-contrib#49553](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/49553), merged, tracking [#49552](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49552)):
- `rabbitmq.exchange.messages.published_in`
- `rabbitmq.exchange.messages.published_out`
- resource attributes `rabbitmq.exchange.name`, `rabbitmq.exchange.type`, `rabbitmq.vhost.name`

The existing `nri-rabbitmq` OHI synthesis rule (`infra_rabbitmqexchange_entityId`, `RabbitmqExchangeSample`) is left completely untouched — it uses `legacyFeatures` to preserve existing entity GUIDs for current native-integration customers.

All changes are **staging-only** (`.stg` overrides), per the sibling `infra-rabbitmqnode` / `infra-rabbitmqqueue` pattern.

## Composite identifier

Unlike `RABBITMQQUEUE`'s `[rabbitmq.node.name, rabbitmq.queue.name, rabbitmq.vhost.name]`, the exchange scraper (`scraper.go#collectExchange`) does not set a node-name resource attribute — the `/api/exchanges` management endpoint has no node info. So the identifier here is:

```yaml
compositeIdentifier:
  separator: ":"
  attributes:
  - rabbitmq.exchange.name
  - rabbitmq.vhost.name
```

This also matches RabbitMQ's own identity model — an exchange is uniquely identified by `(vhost, name)`; `type` is metadata, so it's a tag, not part of the identifier. No explicit presence/absence conditions are needed since `rabbitmq.exchange.name` is never present on node- or queue-scoped metric points.

Known cosmetic edge case: RabbitMQ's default exchange has an empty `name: ""`, so its identifier degenerates to `":<vhost>"` — this is real upstream behavior (see the receiver's own golden test fixtures), not something fixable at this layer.

## Files changed

- `entity-types/infra-rabbitmqexchange/definition.stg.yml`: new `infra_rabbitmqexchange_composite` rule, extended `goldenTags`, `opentelemetry` dashboard template
- `entity-types/infra-rabbitmqexchange/golden_metrics.stg.yml` (new): adds `opentelemetry:` queries to the 4 publish-related golden metrics (mapping NRI's `publish_in`→`messagesPublishedPerChannel(PerSecond)` / `publish_out`→`messagesPublishedQueue(PerSecond)`, matching nri-rabbitmq's own field mapping). `bindings` stays NRI-only (no OTel equivalent). Per-second rates use the `rate(sum(...), 1 second)` idiom already used elsewhere in this repo (e.g. `infra-awsefsfilesystem`).
- `entity-types/infra-rabbitmqexchange/opentelemetry_dashboard.stg.json` (new): published_in/out rate charts + a billboard surfacing the `published_in > published_out` "unroutable messages" signal called out in the OTel PR description
- `entity-types/infra-rabbitmqexchange/tests/Metric.stg.json` (new): OTel test fixture, values drawn from the receiver's own test data

## Explicitly out of scope

- No Prometheus-receiver rule for exchange (no equivalent `rabbitmq_exchange_*` prometheus-exporter metric family found in this repo, unlike queue's third rule)
- No relationship synthesis file — no shared attribute exists yet to build a meaningful relationship on

## Validation

- `docker compose run validate-definitions` passes locally (schema validation, rule validation, relationship-synthesis validation, folder validation — all clean)
- `docker compose run sanitize-dashboards` run locally, no changes to the new dashboard file