### PR TITLE
fix: OTEL APM to Elasticsearch relationship synthesis rule (staging only)

### DIFF
--- a/relationships/synthesis/OTEL-SERVICE-to-INFRA-ELASTICSEARCHCLUSTER.stg.yml
+++ b/relationships/synthesis/OTEL-SERVICE-to-INFRA-ELASTICSEARCHCLUSTER.stg.yml
@@ -1,11 +1,11 @@
 relationships:
-  # OTEL APM Application calls Elasticsearch Cluster
-  # Matches on elasticsearch.cluster.name attribute in spans
-  # Agent reads cluster name from ES GET / response and enriches spans
+  # OTEL APM Service calls Elasticsearch Cluster
+  # Matches on db.namespace attribute (cluster name) in spans where db.system=elasticsearch
+  # OTel ES instrumentation fetches cluster name via GET / and sets db.namespace
   - name: otelApmCallsElasticsearchClusterByName
     version: "1"
     origins:
-      - OpenTelemetry
+      - Distributed Tracing
     conditions:
       - attribute: eventType
         anyOf: ["Span"]
@@ -15,7 +15,7 @@ relationships:
         anyOf: ["SERVICE", "APPLICATION"]
       - attribute: db.system
         anyOf: ["elasticsearch"]
-      - attribute: elasticsearch.cluster.name
+      - attribute: db.namespace
         present: true
     relationship:
       expires: PT75M
@@ -26,12 +26,12 @@ relationships:
       target:
         buildGuid:
           account:
-            attribute: accountId
+            lookup: true
           domain:
             value: INFRA
           type:
             value: ELASTICSEARCHCLUSTER
           identifier:
             fragments:
-              - attribute: elasticsearch.cluster.name
+              - attribute: db.namespace
             hashAlgorithm: FARM_HASH


### PR DESCRIPTION
## Summary

Fix the staging synthesis rule for OTEL APM Service → INFRA ELASTICSEARCHCLUSTER relationship. This change is **staging only** (`.stg.yml`).

## Changes

- **origins**: `OpenTelemetry` → `Distributed Tracing` — the rule processes Span events, not Metrics
- **account**: `attribute: accountId` → `lookup: true` — accountId is not available as a span attribute; lookup derives it from the source entity GUID
- **attribute**: `elasticsearch.cluster.name` → `db.namespace` — aligns with current OTel semantic conventions (v1.43+), where `db.namespace` is the standard attribute for database namespace (cluster name for ES)

## Context

The OTel ES instrumentation fetches the cluster name via `GET /` on first connection and sets `db.namespace` on all subsequent spans. Combined with the auto-populated `db.system = elasticsearch` condition, this uniquely identifies the target Elasticsearch cluster entity.

The synthesis rule uses FARM_HASH on the `db.namespace` value to build the target entity GUID, matching the ELASTICSEARCHCLUSTER entity definition.

## Scope

- **Staging only** — `.stg.yml` file, no production impact
- Works for all OTel-instrumented languages (Java, Python, Node.js, Go, .NET)

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid.
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
* [ ] I've linked an ARB ticket & received approval from API Review Board in order to make these changes