### PR TITLE
fix: guard ECS EC2 OTel host rules against service.name metrics

### DIFF
--- a/entity-types/infra-host/definition.yml
+++ b/entity-types/infra-host/definition.yml
@@ -54,6 +54,9 @@ synthesis:
           present: true
         - attribute: host.id
           present: true
+        # if service.name is present, it's a service, not a host
+        - attribute: service.name
+          present: false
       tags:
         # Host attributes
         host.name:
@@ -95,6 +98,9 @@ synthesis:
           value: ec2
         - attribute: host.name
           present: true
+        # if service.name is present, it's a service, not a host
+        - attribute: service.name
+          present: false
       tags:
         # Host attributes
         host.name:


### PR DESCRIPTION
These rules were added in #2729. This has caused a regression where telemetry from a service is incorrectly synthesized as a host entity. It is of utmost importance that the `service.name present: false` predicate is applied to all rules in this file to avoid future regressions.

@muruganishekar please take note of this and ensure that other rules you may have recently introduced do not suffer from this same problem.