### PR TITLE
feat(haproxy): add apm calls haproxy instance rule (staging)

### DIFF
--- a/relationships/synthesis/EXT-SERVICE-to-INFRA-HAPROXYINSTANCE.stg.yml
+++ b/relationships/synthesis/EXT-SERVICE-to-INFRA-HAPROXYINSTANCE.stg.yml
@@ -1,0 +1,49 @@
+relationships:
+  # External Service CALLS HAProxy Instance (via distributed tracing)
+  # When an upstream service calls HAProxy, the HAProxy OTel filter emits a span
+  # with parent.service.name (the caller) and haproxy.addr + host.id (HAProxy's identity).
+  # This rule creates a direct CALLS relationship from the upstream EXT:SERVICE
+  # to the INFRA:HAPROXYINSTANCE entity (which is synthesized from haproxyreceiver metrics).
+  - name: extServiceCallsHaproxyInstance
+    version: "1"
+    origins:
+      - Distributed Tracing
+      - OpenTelemetry
+    conditions:
+      - attribute: eventType
+        anyOf: ["Span"]
+      - attribute: haproxy.addr
+        present: true
+      - attribute: host.id
+        present: true
+      - attribute: parent.service.name
+        present: true
+    relationship:
+      expires: PT75M
+      relationshipType: CALLS
+      source:
+        buildGuid:
+          account:
+            attribute: accountId
+          domain:
+            value: EXT
+          type:
+            value: SERVICE
+          identifier:
+            fragments:
+              - attribute: parent.service.name
+            hashAlgorithm: FARM_HASH
+      target:
+        buildGuid:
+          account:
+            attribute: accountId
+          domain:
+            value: INFRA
+          type:
+            value: HAPROXYINSTANCE
+          identifier:
+            fragments:
+              - attribute: host.id
+              - value: ":"
+              - attribute: haproxy.addr
+            hashAlgorithm: FARM_HASH


### PR DESCRIPTION


Summary

- Adds a new relationship synthesis rule that creates a CALLS relationship from an EXT:SERVICE entity to an INFRA:HAPROXYINSTANCE entity
- Deployed to staging only (.stg.yml) for validation before promoting to production

Background

When HAProxy has the OTel filter enabled, it emits spans as part of distributed traces. These spans contain:
- parent.service.name — the upstream service that called HAProxy (enriched by the DT pipeline)
- host.id — the host where HAProxy is running
- haproxy.addr — the HAProxy stats endpoint address

Meanwhile, the INFRA:HAPROXYINSTANCE entity is synthesized from metrics collected by the OTel Collector's haproxyreceiver, using a composite identifier of host.id:haproxy.addr (rule: infra_haproxyinstance_otel_new).

This relationship rule connects the two by:
1. Source — Building the EXT:SERVICE GUID from parent.service.name (FARM_HASH)
2. Target — Building the INFRA:HAPROXYINSTANCE GUID from host.id + : + haproxy.addr (FARM_HASH), matching exactly how the entity is synthesized

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid.
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
* [ ] I've linked an ARB ticket & received approval from API Review Board in order to make these changes
