### PR TITLE
feat: update ext-service collector auto-detection rule

### DIFF
--- a/entity-types/ext-service/definition.stg.yml
+++ b/entity-types/ext-service/definition.stg.yml
@@ -45,19 +45,6 @@ synthesis:
         entityTagName: language
       telemetry.sdk.version:
 
-  - ruleName: ext_service_otel_collector
-    # produces same entity guid as the default rule applying to all non-otelcol telemetry
-    identifier: service.name
-    name: service.name
-    encodeIdentifierInGUID: true
-    conditions:
-      - attribute: metricName
-        prefix: otelcol # matches both otelcol_ and otelcol.
-    tags:
-      service.name:
-        entityTagName: otel_collector
-        ttl: P1D
-
     # telemetry for gen_ai otel application with user opt-in tag
   - ruleName: ext_service_gen_ai_otel_app
     identifier: service.name
@@ -99,7 +86,48 @@ synthesis:
       telemetry.sdk.version:
       service.namespace:
 
+  # Must be positioned before `ext_service_service_name_3`
+  # Conditions and tags must stay a superset of `ext_service_service_name_3`
+  # to ensure backwards compatibility for the collector AND avoid accidental matches of non-collector telemetry.
+  - ruleName: ext_service_service_name_3_otel_collector
+    identifier: service.name
+    name: service.name
+    encodeIdentifierInGUID: true
+    conditions:
+      - attribute: instrumentation.provider
+        value: opentelemetry
+      - attribute: newrelic.entity.type
+        present: false
+      - attribute: trace_role
+        present: false
+      - attribute: metricName
+        prefix: otelcol
+    tags:
+      service.name:
+        entityTagName: otel_collector
+        ttl: P1D
+      k8s.cluster.name:
+        entityTagName: k8s.clusterName
+        ttl: P1D
+      k8s.deployment.name:
+        entityTagName: k8s.deploymentName
+        ttl: P1D
+      k8s.namespace.name:
+        entityTagName: k8s.namespaceName
+        ttl: P1D
+      telemetry.sdk.language:
+        entityTagName: language
+      telemetry.sdk.version:
+      service.namespace:
+      faas.name:
+      faas.id:
+      cloud.resource_id:
+        ttl: P1D
+      newrelic.service.type:
+        ttl: P1D
+
     # telemetry from opentelemetry provider
+    # make sure to mirror changes in ext_service_service_name_3_otel_collector, see above
   - ruleName: ext_service_service_name_3
     identifier: service.name
     name: service.name


### PR DESCRIPTION
### Relevant information

- Update to #3061 to match final design from [CDD](https://newrelic.atlassian.net/wiki/x/AwDRXgE). CDD contains details about the design of the rule including the comment above the rule regarding ordering which is a stopgap discussed with EP while the necessary [FR](https://new-relic.atlassian.net/browse/NR-598253) is considered.
- The general idea is for the new rule to be a specialization of the existing `ext_service_service_name_3` to allow tagging OTel Collectors with an entity tag, so that [this manual step](https://docs.newrelic.com/docs/opentelemetry/collector-observability/collector-observability/#add-tag) is no longer necessary to have the UI treat the entity as a special type of EXT-SERVICE.

#### Api Review Board (ARB)

- Will be filed before this rule gets promoted to prod. Our understanding is that testing this rule in staging should not require prior ARB approval.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid.
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
* [ ] (N/A - see above) I've linked an ARB ticket & received approval from API Review Board in order to make these changes
