### PR TITLE
feat: Migrate cluster metrics from golden-metrics-service

### DIFF
--- a/entity-types/infra-kubernetescluster/golden_metrics.stg.yml
+++ b/entity-types/infra-kubernetescluster/golden_metrics.stg.yml
@@ -1,0 +1,32 @@
+cpuUsage:
+  title: CPU usage (%)
+  unit: PERCENTAGE
+  queries:
+    newRelic:
+      select: average(allocatableCpuCoresUtilization)
+      from: K8sNodeSample
+      facet: clusterName
+      eventObjectId: ENTITY_NAMES
+      eventId: clusterName
+    opentelemetry:
+      select: average(node.cpu.usage.percentage) * 100
+      from: Metric
+      facet: k8s.cluster.name
+      eventObjectId: ENTITY_NAMES
+      eventId: k8s.cluster.name
+memoryUsage:
+  title: Memory usage (%)
+  unit: PERCENTAGE
+  queries:
+    newRelic:
+      select: average(allocatableMemoryUtilization)
+      from: K8sNodeSample
+      facet: clusterName
+      eventObjectId: ENTITY_NAMES
+      eventId: clusterName
+    opentelemetry:
+      select: average(node.memory.usage.percentage) * 100
+      from: Metric
+      facet: k8s.cluster.name
+      eventObjectId: ENTITY_NAMES
+      eventId: k8s.cluster.name


### PR DESCRIPTION
### Relevant information

Migrating golden metrics for k8s cluster from https://source.datanerd.us/entity-platform/golden-metric-service/blob/master/src/main/resources/golden-metric-definitions/infra-kubernetescluster.yaml to this repo. 

Note: This seems to be the first use of `eventObjectId: ENTITY_NAMES` in this repo. Is this a valid value?

#### Api Review Board (ARB)

NA

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid.
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
* [ ] I've linked an ARB ticket & received approval from API Review Board in order to make these changes
