### PR TITLE
chore: add OTELCOMM as owner to ext-service

### DIFF
--- a/entity-types/ext-service/definition.stg.yml
+++ b/entity-types/ext-service/definition.stg.yml
@@ -437,6 +437,6 @@ configuration:
 
 ownership:
   primaryOwner:
-    teamName: "no owner"
+    teamName: "OpenTelemetry Community Leadership Team"
   secondaryOwners:
     - teamName: "eBPF"

--- a/entity-types/ext-service/definition.yml
+++ b/entity-types/ext-service/definition.yml
@@ -388,6 +388,6 @@ configuration:
 
 ownership:
   primaryOwner:
-    teamName: "no owner"
+    teamName: "OpenTelemetry Community Leadership Team"
   secondaryOwners:
     - teamName: "eBPF"


### PR DESCRIPTION
### Relevant information

- Adding OTELCOMM as the owning team for EXT-SERVICE. While multiple teams have contributed to this definition, OTELCOMM (and in particular @alanwest) is most likely the only team in a position to coordinate competing efforts that would require conflict resolution. 

#### Api Review Board (ARB)

N/A

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid.
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
* [ ] I've linked an ARB ticket & received approval from API Review Board in order to make these changes
