### PR TITLE
Use matchingMode: ANY for single-field candidate lookups

### DIFF
--- a/relationships/candidates/APMAPPLICATION.yml
+++ b/relationships/candidates/APMAPPLICATION.yml
@@ -4,7 +4,7 @@ lookups:
       - domain: APM
         type: APPLICATION
     tags:
-      matchingMode: ALL
+      matchingMode: ANY
       predicates:
         - tagKeys: ["faas.app_name", "cloud.resource_id"]
           field: resourceId 

--- a/relationships/candidates/AWSAPPSYNCAPI.yml
+++ b/relationships/candidates/AWSAPPSYNCAPI.yml
@@ -4,7 +4,7 @@ lookups:
       - domain: INFRA
         type: AWSAPPSYNCAPI
     tags:
-      matchingMode: ALL
+      matchingMode: ANY
       predicates:
         - tagKeys: ["aws.appsync.GraphQLUrl", "aws.Arn"]
           field: graphQLUrl

--- a/relationships/candidates/AWSAUTOSCALINGGROUP.stg.yml
+++ b/relationships/candidates/AWSAUTOSCALINGGROUP.stg.yml
@@ -4,7 +4,7 @@ lookups:
       - domain: INFRA
         type: AWSAUTOSCALINGGROUP
     tags:
-      matchingMode: ALL
+      matchingMode: ANY
       predicates:
         - tagKeys: ["aws.instanceId"]
           field: instanceId

--- a/relationships/candidates/AWSAUTOSCALINGGROUP.yml
+++ b/relationships/candidates/AWSAUTOSCALINGGROUP.yml
@@ -4,7 +4,7 @@ lookups:
       - domain: INFRA
         type: AWSAUTOSCALINGGROUP
     tags:
-      matchingMode: ALL
+      matchingMode: ANY
       predicates:
         - tagKeys: ["aws.instanceId"]
           field: instanceId

--- a/relationships/candidates/AWSDOCDBINSTANCE.yml
+++ b/relationships/candidates/AWSDOCDBINSTANCE.yml
@@ -22,7 +22,7 @@ lookups:
       - domain: INFRA
         type: AWSDOCDBINSTANCE
     tags:
-      matchingMode: ALL
+      matchingMode: ANY
       predicates:
         - tagKeys: ["aws.rds.endpoint", "aws.endpoint"]
           field: endpoint
@@ -36,7 +36,7 @@ lookups:
       - domain: INFRA
         type: AWSDOCDBINSTANCE
     tags:
-      matchingMode: ALL
+      matchingMode: ANY
       predicates:
         - tagKeys: ["aws.rds.DBInstanceIdentifier", "aws.dbInstanceIdentifier"]
           field: instanceId

--- a/relationships/candidates/AWSDYNAMODBTABLE.yml
+++ b/relationships/candidates/AWSDYNAMODBTABLE.yml
@@ -4,7 +4,7 @@ lookups:
       - domain: INFRA
         type: AWSDYNAMODBTABLE
     tags:
-      matchingMode: ALL
+      matchingMode: ANY
       predicates:
         - tagKeys: ["aws.arn"]
           field: cloudResourceId

--- a/relationships/candidates/AWSECSCLUSTER.yml
+++ b/relationships/candidates/AWSECSCLUSTER.yml
@@ -4,7 +4,7 @@ lookups:
       - domain: INFRA
         type: AWSECSCLUSTER
     tags:
-      matchingMode: ALL
+      matchingMode: ANY
       predicates:
         - tagKeys: ["aws.Arn"]
           field: awsEcsClusterArn
@@ -18,7 +18,7 @@ lookups:
       - domain: INFRA
         type: AWSECSCLUSTER
     tags:
-      matchingMode: ALL
+      matchingMode: ANY
       predicates:
         - tagKeys: ["aws.clusterName"]
           field: awsEcsClusterName

--- a/relationships/candidates/AWSECSTASK.yml
+++ b/relationships/candidates/AWSECSTASK.yml
@@ -4,7 +4,7 @@ lookups:
       - domain: INFRA
         type: AWSECSTASK
     tags:
-      matchingMode: ALL
+      matchingMode: ANY
       predicates:
         - tagKeys: ["aws.taskArn"]
           field: awsEcsTaskArn

--- a/relationships/candidates/AWSELASTICSEARCHCLUSTER.yml
+++ b/relationships/candidates/AWSELASTICSEARCHCLUSTER.yml
@@ -4,7 +4,7 @@ lookups:
       - domain: INFRA
         type: AWSELASTICSEARCHCLUSTER
     tags:
-      matchingMode: ALL
+      matchingMode: ANY
       predicates:
         - tagKeys: ["aws.es.DomainEndpoint"]
           field: endpoint

--- a/relationships/candidates/AWSELASTICSEARCHCLUSTER_EXPLICIT.yml
+++ b/relationships/candidates/AWSELASTICSEARCHCLUSTER_EXPLICIT.yml
@@ -4,7 +4,7 @@ lookups:
       - domain: INFRA
         type: AWSELASTICSEARCHCLUSTER
     tags:
-      matchingMode: ALL
+      matchingMode: ANY
       predicates:
         - tagKeys: ["aws.Arn"]
           field: endpoint

--- a/relationships/candidates/AWSKINESISDELIVERYSTREAM.yml
+++ b/relationships/candidates/AWSKINESISDELIVERYSTREAM.yml
@@ -4,7 +4,7 @@ lookups:
       - domain: INFRA
         type: AWSKINESISDELIVERYSTREAM
     tags:
-      matchingMode: ALL
+      matchingMode: ANY
       predicates:
         - tagKeys: ["aws.Arn", "aws.arn"]
           field: cloudResourceId

--- a/relationships/candidates/AWSKINESISSTREAM.yml
+++ b/relationships/candidates/AWSKINESISSTREAM.yml
@@ -4,7 +4,7 @@ lookups:
       - domain: INFRA
         type: AWSKINESISSTREAM
     tags:
-      matchingMode: ALL
+      matchingMode: ANY
       predicates:
         - tagKeys: ["aws.Arn"]
           field: cloudResourceId

--- a/relationships/candidates/AWSLAMBDAALIAS.yml
+++ b/relationships/candidates/AWSLAMBDAALIAS.yml
@@ -4,7 +4,7 @@ lookups:
       - domain: INFRA
         type: AWSLAMBDAFUNCTIONALIAS
     tags:
-      matchingMode: ALL
+      matchingMode: ANY
       predicates:
         - tagKeys: [ "aws.Arn" ]
           field: awsLambdaAliasArn

--- a/relationships/candidates/AWSLAMBDAFUNCTION.yml
+++ b/relationships/candidates/AWSLAMBDAFUNCTION.yml
@@ -4,7 +4,7 @@ lookups:
       - domain: INFRA
         type: AWSLAMBDAFUNCTION
     tags:
-      matchingMode: ALL
+      matchingMode: ANY
       predicates:
         - tagKeys: ["aws.functionArn","aws.lambda.functionArn", "aws.Arn"]
           field: awsLambdaArn

--- a/relationships/candidates/AWSMQBROKER.yml
+++ b/relationships/candidates/AWSMQBROKER.yml
@@ -4,7 +4,7 @@ lookups:
       - domain: INFRA
         type: AWSMQBROKER
     tags:
-      matchingMode: ALL
+      matchingMode: ANY
       predicates:
         - tagKeys: ["aws.mq.endpoint"]
           field: endpoint

--- a/relationships/candidates/AWSMQBROKER_EXPLICIT.yml
+++ b/relationships/candidates/AWSMQBROKER_EXPLICIT.yml
@@ -4,7 +4,7 @@ lookups:
       - domain: INFRA
         type: AWSMQBROKER
     tags:
-      matchingMode: ALL
+      matchingMode: ANY
       predicates:
         - tagKeys: ["aws.Arn"]
           field: cloudResourceId

--- a/relationships/candidates/AWSREDSHIFTCLUSTER.yml
+++ b/relationships/candidates/AWSREDSHIFTCLUSTER.yml
@@ -4,7 +4,7 @@ lookups:
       - domain: INFRA
         type: AWSREDSHIFTCLUSTER
     tags:
-      matchingMode: ALL
+      matchingMode: ANY
       predicates:
         - tagKeys: ["aws.redshift.serverAddress", "aws.Arn"]
           field: serverAddress

--- a/relationships/candidates/AWSROUTE53RECORDSET.yml
+++ b/relationships/candidates/AWSROUTE53RECORDSET.yml
@@ -4,7 +4,7 @@ lookups:
       - domain: INFRA
         type: AWSROUTE53RECORDSET
     tags:
-      matchingMode: ALL
+      matchingMode: ANY
       predicates:
         - tagKeys: ["aws.recordName", "aws.recordUrl"]
           field: recordSetUrl

--- a/relationships/candidates/AWSSQSQUEUEEXT.yml
+++ b/relationships/candidates/AWSSQSQUEUEEXT.yml
@@ -4,7 +4,7 @@ lookups:
     - domain: INFRA
       type: AWSSQSQUEUE
     tags:
-      matchingMode: ALL
+      matchingMode: ANY
       predicates:
         - tagKeys: ["aws.arn", "aws.queueArn"]
           field: cloudResourceId

--- a/relationships/candidates/AZUREAPPSERVICE.yml
+++ b/relationships/candidates/AZUREAPPSERVICE.yml
@@ -6,7 +6,7 @@ lookups:
       - domain: INFRA
         type: AZUREFUNCTIONSAPP
     tags:
-      matchingMode: ALL
+      matchingMode: ANY
       predicates:
         - tagKeys: ["azure.resourceId"]
           field: resourceId

--- a/relationships/candidates/AZUREREDISENTERPRISECACHE.yml
+++ b/relationships/candidates/AZUREREDISENTERPRISECACHE.yml
@@ -5,7 +5,7 @@ lookups:
       - domain: INFRA 
         type: AZUREREDISENTERPRISECACHE 
     tags:
-      matchingMode: ALL
+      matchingMode: ANY
       predicates:
         - tagKeys: ["azure.endpoint"]
           field: endpoint

--- a/relationships/candidates/AZURESERVICEBUSNAMESPACE.yml
+++ b/relationships/candidates/AZURESERVICEBUSNAMESPACE.yml
@@ -4,7 +4,7 @@ lookups:
       - domain: INFRA 
         type: AZURESERVICEBUSNAMESPACE   
     tags:
-      matchingMode: ALL 
+      matchingMode: ANY 
       predicates:
         - tagKeys: ["azure.primary.endpoint"] 
           field: endpoint

--- a/relationships/candidates/EXTEBPFSERVICE.yml
+++ b/relationships/candidates/EXTEBPFSERVICE.yml
@@ -4,7 +4,7 @@ lookups:
       - domain: EXT
         type: SERVICE
     tags:
-      matchingMode: ALL
+      matchingMode: ANY
       predicates:
         - tagKeys: ["service.name"]
           field: service.name

--- a/relationships/candidates/KAFKATOPIC.stg.yml
+++ b/relationships/candidates/KAFKATOPIC.stg.yml
@@ -58,7 +58,7 @@ lookups:
       - domain: INFRA
         type: KAFKATOPIC
     tags:
-      matchingMode: ALL
+      matchingMode: ANY
       predicates:
         - tagKeys: ["producer.service.name"]
           field: producerServiceName

--- a/relationships/candidates/KAFKATOPIC_EXPLICIT.yml
+++ b/relationships/candidates/KAFKATOPIC_EXPLICIT.yml
@@ -4,7 +4,7 @@ lookups:
     - domain: INFRA
       type: AWSMSKTOPIC
     tags:
-      matchingMode: ALL
+      matchingMode: ANY
       predicates:
         - tagKeys: ["aws.Arn"]
           field: cloudResourceId

--- a/relationships/candidates/MEMCACHED_EXPLICIT.yml
+++ b/relationships/candidates/MEMCACHED_EXPLICIT.yml
@@ -6,7 +6,7 @@ lookups:
       - domain: INFRA
         type: AWSELASTICACHEMEMCACHEDNODE
     tags:
-      matchingMode: ALL
+      matchingMode: ANY
       predicates:
         - tagKeys: ["aws.Arn"]
           field: cloudResourceId

--- a/relationships/candidates/MSSQLDBINSTANCE.yml
+++ b/relationships/candidates/MSSQLDBINSTANCE.yml
@@ -18,7 +18,7 @@ lookups:
       - domain: INFRA
         type: MSSQLINSTANCE
     tags:
-      matchingMode: ALL
+      matchingMode: ANY
       predicates:
         - tagKeys: ["host.name"]
           field: hostName

--- a/relationships/candidates/NGINXSERVER.stg.yml
+++ b/relationships/candidates/NGINXSERVER.stg.yml
@@ -5,7 +5,7 @@ lookups:
       - domain: INFRA
         type: NGINXSERVER
     tags:
-      matchingMode: ALL
+      matchingMode: ANY
       predicates:
         - tagKeys: ["nginx.deployment.name"]
           field: deploymentName
@@ -19,7 +19,7 @@ lookups:
       - domain: INFRA
         type: NGINXSERVER
     tags:
-      matchingMode: ALL
+      matchingMode: ANY
       predicates:
         - tagKeys: ["nginx.server.address"]
           field: serverAddress

--- a/relationships/candidates/REDIS_EXPLICIT.yml
+++ b/relationships/candidates/REDIS_EXPLICIT.yml
@@ -6,7 +6,7 @@ lookups:
       - domain: INFRA
         type: AWSELASTICACHEREDISREPLICATIONGROUP
     tags:
-      matchingMode: ALL
+      matchingMode: ANY
       predicates:
         - tagKeys: ["aws.Arn"]
           field: cloudResourceId


### PR DESCRIPTION
ALL vs ANY is meaningless with one predicate, but ANY equivalent query is more efficient.

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid.
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
* [ ] I've linked an ARB ticket & received approval from API Review Board in order to make these changes
