### PR TITLE
fix: match new MessageBroker/Kafka/Cluster/{id}/[Produce|Consume]/{topic} format

### DIFF
--- a/relationships/synthesis/APM-APPLICATION-to-KAFKATOPIC.stg.yml
+++ b/relationships/synthesis/APM-APPLICATION-to-KAFKATOPIC.stg.yml
@@ -171,14 +171,14 @@ relationships:
               - attribute: clusterName
             hashAlgorithm: FARM_HASH
 
-  # Self-hosted Kafka: NR APM MessageBroker/Kafka/Cluster/{cluster_id}/Topic/{topic}/Produce
+  # Self-hosted Kafka: NR APM MessageBroker/Kafka/Cluster/{cluster_id}/Produce/{topic}
   - name: apmProducesNRKafkaTopicByClusterIdStg
     version: "1"
     origins:
       - APM Metrics
     conditions:
       - attribute: metricName
-        regex: "^MessageBroker/Kafka/Cluster/[^/]+/Topic/[^/]+/Produce$"
+        regex: "^MessageBroker/Kafka/Cluster/[^/]+/Produce/[^/]+$"
     relationship:
       expires: PT75M
       relationshipType: PRODUCES
@@ -194,14 +194,14 @@ relationships:
             - field: topic
               attribute: metricName__6
 
-  # Self-hosted Kafka: NR APM MessageBroker/Kafka/Cluster/{cluster_id}/Topic/{topic}/Consume
+  # Self-hosted Kafka: NR APM MessageBroker/Kafka/Cluster/{cluster_id}/Consume/{topic}
   - name: apmConsumesNRKafkaTopicByClusterIdStg
     version: "1"
     origins:
       - APM Metrics
     conditions:
       - attribute: metricName
-        regex: "^MessageBroker/Kafka/Cluster/[^/]+/Topic/[^/]+/Consume$"
+        regex: "^MessageBroker/Kafka/Cluster/[^/]+/Consume/[^/]+$"
     relationship:
       expires: PT75M
       relationshipType: CONSUMES


### PR DESCRIPTION
## Summary

`agent-specs` PR #817 realigned the APM per-cluster Kafka metric name to match the existing `Nodes` metric shape (verb before topic, not after):

- Old: `MessageBroker/Kafka/Cluster/{cluster_id}/Topic/{topic}/Produce`
- New: `MessageBroker/Kafka/Cluster/{cluster_id}/Produce/{topic}`

This updates the `apmProducesNRKafkaTopicByClusterIdStg` / `apmConsumesNRKafkaTopicByClusterIdStg` relationship conditions in `APM-APPLICATION-to-KAFKATOPIC.stg.yml` to match. The `metricName__4` (clusterId) / `metricName__6` (topic) field indices are unchanged — the segment count and positions are identical under the new format, so only the regex and comments needed updating.

## Why now

No agent has shipped the old metric format yet — all 4 language-agent implementations (java, dotnet, python, node) are still open drafts. This closes the window before anything ships against a metric shape this relationship rule can no longer match.

## Related

- Spec change: source.datanerd.us/agents/agent-specs/pull/817