### PR TITLE
feat: change tag name based on ARB feedback

### DIFF
--- a/entity-types/ext-service/definition.stg.yml
+++ b/entity-types/ext-service/definition.stg.yml
@@ -86,9 +86,10 @@ synthesis:
       telemetry.sdk.version:
       service.namespace:
 
-  # Must be positioned before `ext_service_service_name_3`
-  # Conditions and tags must stay a superset of `ext_service_service_name_3`
-  # to ensure backwards compatibility for the collector AND avoid accidental matches of non-collector telemetry.
+  # Enforce via validate_rules test:
+  # - Must be positioned before `ext_service_service_name_3`
+  # - Conditions and tags must stay a superset of `ext_service_service_name_3`
+  #   to ensure backwards compatibility for the collector AND avoid accidental matches of non-collector telemetry.
   - ruleName: ext_service_service_name_3_otel_collector
     identifier: service.name
     name: service.name
@@ -104,7 +105,7 @@ synthesis:
         prefix: otelcol
     tags:
       service.name:
-        entityTagName: otel_collector
+        entityTagName: otelCollector
         ttl: P1D
       k8s.cluster.name:
         entityTagName: k8s.clusterName

--- a/entity-types/ext-service/definition.stg.yml
+++ b/entity-types/ext-service/definition.stg.yml
@@ -103,7 +103,7 @@ synthesis:
       - attribute: metricName
         prefix: otelcol
     tags:
-      instrumentation.provider: # static value guaranteed by condition chosen intentionally
+      instrumentation.provider: # static value 'opentelemetry' guaranteed by condition chosen intentionally
         entityTagName: otelCollector
         ttl: P1D
       k8s.cluster.name:

--- a/entity-types/ext-service/definition.stg.yml
+++ b/entity-types/ext-service/definition.stg.yml
@@ -86,10 +86,9 @@ synthesis:
       telemetry.sdk.version:
       service.namespace:
 
-  # Enforced via validate_rules test:
-  # - Must be positioned before `ext_service_service_name_3`
-  # - Conditions and tags must stay a superset of `ext_service_service_name_3`
-  #   to ensure backwards compatibility for the collector AND avoid accidental matches of non-collector telemetry.
+  # Must be positioned before `ext_service_service_name_3`
+  # Conditions and tags must stay a superset of `ext_service_service_name_3`
+  # to ensure backwards compatibility for the collector AND avoid accidental matches of non-collector telemetry.
   - ruleName: ext_service_service_name_3_otel_collector
     identifier: service.name
     name: service.name

--- a/entity-types/ext-service/definition.stg.yml
+++ b/entity-types/ext-service/definition.stg.yml
@@ -86,7 +86,7 @@ synthesis:
       telemetry.sdk.version:
       service.namespace:
 
-  # Enforce via validate_rules test:
+  # Enforced via validate_rules test:
   # - Must be positioned before `ext_service_service_name_3`
   # - Conditions and tags must stay a superset of `ext_service_service_name_3`
   #   to ensure backwards compatibility for the collector AND avoid accidental matches of non-collector telemetry.
@@ -104,7 +104,7 @@ synthesis:
       - attribute: metricName
         prefix: otelcol
     tags:
-      service.name:
+      instrumentation.provider: # static value guaranteed by condition chosen intentionally
         entityTagName: otelCollector
         ttl: P1D
       k8s.cluster.name:

--- a/validator/tools/validate_rules.js
+++ b/validator/tools/validate_rules.js
@@ -244,44 +244,6 @@ const RULES = [
       }
 
     }
-  },
-  {
-    name: "ext_service_service_name_3_otel_collector must be positioned before, and stay a superset of, ext_service_service_name_3",
-    apply: (def, isProd) => {
-      if (isProd || def.domain !== 'EXT' || def.type !== 'SERVICE') {
-        return;
-      }
-
-      const rules = def.synthesis.rules;
-      const collectorIndex = rules.findIndex((rule) => rule.ruleName === 'ext_service_service_name_3_otel_collector');
-      const baseIndex = rules.findIndex((rule) => rule.ruleName === 'ext_service_service_name_3');
-
-      if (collectorIndex === -1 || baseIndex === -1) {
-        throw new Error(`Expected both 'ext_service_service_name_3_otel_collector' and 'ext_service_service_name_3' rules to exist.`);
-      }
-
-      if (collectorIndex >= baseIndex) {
-        throw new Error(`'ext_service_service_name_3_otel_collector' must be positioned before 'ext_service_service_name_3'.`);
-      }
-
-      const collectorRule = rules[collectorIndex];
-      const baseRule = rules[baseIndex];
-
-      const missingConditions = (baseRule.conditions || [])
-        .filter((condition) => !(collectorRule.conditions || []).some((other) => isEqual(condition, other)));
-
-      if (missingConditions.length > 0) {
-        throw new Error(`'ext_service_service_name_3_otel_collector' conditions must be a superset of 'ext_service_service_name_3' conditions. Missing: ${JSON.stringify(missingConditions)}`);
-      }
-
-      const missingTags = Object.entries(baseRule.tags || {})
-        .filter(([tagName, tagConfig]) => !isEqual(collectorRule.tags?.[tagName], tagConfig))
-        .map(([tagName]) => tagName);
-
-      if (missingTags.length > 0) {
-        throw new Error(`'ext_service_service_name_3_otel_collector' tags must be a superset of 'ext_service_service_name_3' tags. Missing/mismatched: ${missingTags.join(', ')}`);
-      }
-    }
   }
 ];
 

--- a/validator/tools/validate_rules.js
+++ b/validator/tools/validate_rules.js
@@ -244,6 +244,44 @@ const RULES = [
       }
 
     }
+  },
+  {
+    name: "ext_service_service_name_3_otel_collector must be positioned before, and stay a superset of, ext_service_service_name_3",
+    apply: (def, isProd) => {
+      if (isProd || def.domain !== 'EXT' || def.type !== 'SERVICE') {
+        return;
+      }
+
+      const rules = def.synthesis.rules;
+      const collectorIndex = rules.findIndex((rule) => rule.ruleName === 'ext_service_service_name_3_otel_collector');
+      const baseIndex = rules.findIndex((rule) => rule.ruleName === 'ext_service_service_name_3');
+
+      if (collectorIndex === -1 || baseIndex === -1) {
+        throw new Error(`Expected both 'ext_service_service_name_3_otel_collector' and 'ext_service_service_name_3' rules to exist.`);
+      }
+
+      if (collectorIndex >= baseIndex) {
+        throw new Error(`'ext_service_service_name_3_otel_collector' must be positioned before 'ext_service_service_name_3'.`);
+      }
+
+      const collectorRule = rules[collectorIndex];
+      const baseRule = rules[baseIndex];
+
+      const missingConditions = (baseRule.conditions || [])
+        .filter((condition) => !(collectorRule.conditions || []).some((other) => isEqual(condition, other)));
+
+      if (missingConditions.length > 0) {
+        throw new Error(`'ext_service_service_name_3_otel_collector' conditions must be a superset of 'ext_service_service_name_3' conditions. Missing: ${JSON.stringify(missingConditions)}`);
+      }
+
+      const missingTags = Object.entries(baseRule.tags || {})
+        .filter(([tagName, tagConfig]) => !isEqual(collectorRule.tags?.[tagName], tagConfig))
+        .map(([tagName]) => tagName);
+
+      if (missingTags.length > 0) {
+        throw new Error(`'ext_service_service_name_3_otel_collector' tags must be a superset of 'ext_service_service_name_3' tags. Missing/mismatched: ${missingTags.join(', ')}`);
+      }
+    }
   }
 ];
 


### PR DESCRIPTION
### Relevant information

Incorporate feedback of ARB into staging rule
- `otel_collector` tag should be renamed to `otelCollector`
- while pending ARB review, PR #3093 was merged, thus making #3133 necessary. In order to prevent this in the future, I added some static validation to formalize the invariant of `ext_service_service_name_3_otel_collector ` being an extension of `ext_service_service_name_3`. The alternative would be an after-the-fact validation in a separate repo and reconciliation PRs, so I am hoping this can stay even though it is a special case. My team OTELCOMM is the primary owner of the EXT-SERVICE definition, so we'll help resolve any conflict arising from this test failing.
  - When the rule gets promoted to prod, the test will get updated accordingly.

#### Api Review Board (ARB)

ARB Jira ticket:
https://new-relic.atlassian.net/browse/NR-601477

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid.
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
* [x] I've linked an ARB ticket & received approval from API Review Board in order to make these changes
