### PR TITLE
Link DocDB cluster name from APM datastore metric to DocDB instances

### DIFF
--- a/relationships/candidates/AWSDOCDBINSTANCE.yml
+++ b/relationships/candidates/AWSDOCDBINSTANCE.yml
@@ -30,7 +30,23 @@ lookups:
       onMultipleMatches: RELATE_ALL
     onMiss:
       action: NO_OP
-  # Tier 3: Guaranteed match - instanceId only (always present across all collection methods)
+  # Tier 3: Cluster identifier match - relates to all instances in the cluster
+  # Used when only the DocDB cluster endpoint is known (e.g. drivers/agents that only
+  # ever see the cluster hostname, not a specific instance endpoint). Matches every
+  # instance belonging to that cluster since the cluster endpoint can route to any of them.
+  - entityTypes:
+      - domain: INFRA
+        type: AWSDOCDBINSTANCE
+    tags:
+      matchingMode: ALL
+      predicates:
+        - tagKeys: ["aws.rds.dbClusterIdentifier", "aws.dbClusterIdentifier"]
+          field: clusterIdentifier
+    onMatch:
+      onMultipleMatches: RELATE_ALL
+    onMiss:
+      action: NO_OP
+  # Tier 4: Guaranteed match - instanceId only (always present across all collection methods)
   # Final fallback ensuring APM relationships never miss and entities show as instrumented
   - entityTypes:
       - domain: INFRA

--- a/relationships/synthesis/APM-APPLICATION-to-INFRA-AWSDOCDBINSTANCE.yml
+++ b/relationships/synthesis/APM-APPLICATION-to-INFRA-AWSDOCDBINSTANCE.yml
@@ -30,6 +30,13 @@ relationships:
             # Extract port from metric name for additional matching when available
             - field: port
               attribute: metricName__5
+            # Extract cluster identifier when the hostname is a DocDB cluster endpoint
+            # (e.g. .NET agent reports the cluster hostname, not an instance hostname:
+            # docdb-sandbox.cluster-xyz.us-west-2.docdb.amazonaws.com -> docdb-sandbox)
+            - field: clusterIdentifier
+              capture:
+                attribute: metricName__4
+                regex: '^([^.]+)\.cluster-[^.]+\..*\.docdb\.amazonaws\.com$'
 
   # Pattern 2: Distributed Tracing - Span with peer.hostname pointing to DocumentDB
   - name: apmApplicationCallsAwsDocDbInstanceFromSpan
@@ -62,3 +69,10 @@ relationships:
             # Also pass port for additional matching when available
             - field: port
               attribute: server.port
+            # Extract cluster identifier when the hostname is a DocDB cluster endpoint
+            # (e.g. .NET agent reports the cluster hostname, not an instance hostname:
+            # docdb-sandbox.cluster-xyz.us-west-2.docdb.amazonaws.com -> docdb-sandbox)
+            - field: clusterIdentifier
+              capture:
+                attribute: peer.hostname
+                regex: '^([^.]+)\.cluster-[^.]+\..*\.docdb\.amazonaws\.com$'


### PR DESCRIPTION
### Relevant information

I am working on implementing APM -> AWS DocumentDB entity relationships.  JIRA ticket: https://new-relic.atlassian.net/browse/NR-585214

- .NET-instrumented APM applications (and other language agents, potentially) connecting to Amazon DocumentDB via the MongoDB driver are only able to capture the cluster endpoint hostname (e.g. docdb-sandbox.cluster-cokpc3aw6fev.us-west-2.docdb.amazonaws.com), assuming that the customer's application is connecting to the cluster and not a specific instance - which is the expected pattern. The existing AWSDOCDBINSTANCE relationship patterns assumed the reported hostname was always an instance endpoint, so for the `Datastore/instance` metrics reported by the .NET agent, the derived instanceId/endpoint fields never matched a real instance and relationships silently failed (or created a bogus uninstrumented entity).
- Added a new matching tier to the AWSDOCDBINSTANCE candidate keyed on the instance's own aws.rds.dbClusterIdentifier/aws.dbClusterIdentifier tag, so a cluster-level connection can relate to every real instance in that cluster (RELATE_ALL) instead of requiring an exact instance-level endpoint match.
- Updated both APM-APPLICATION-to-INFRA-AWSDOCDBINSTANCE.yml patterns (legacy timeslice metric name, and DT span peer.hostname) to also extract a clusterIdentifier field from the hostname and pass it through to the new tier.

Changes

- relationships/candidates/AWSDOCDBINSTANCE.yml: new Tier 3 lookup on clusterIdentifier, inserted between the existing endpoint-based tiers and the instanceId fallback tier (now Tier 4).
- relationships/synthesis/APM-APPLICATION-to-INFRA-AWSDOCDBINSTANCE.yml: both patterns now capture clusterIdentifier (the label preceding .cluster- in the hostname) in addition to the existing instanceId/endpoint/port fields.

Testing

- ajv validate against relationship-synthesis-schema-v1.json and entity-schema-v1.json — passes.
- validator/tools/validate_rules.js — passes with no errors.
- Confirmed via git stash that the pre-existing failures in validate_relationship_synthesis_rules.js (unrelated filename-format issue on APM-APPLICATION-to-DATABASE.yml) and the Jest dashboard-sanitizer test predate this change and aren't introduced by it.

Note: I contacted the #help-entity-platform hero about the ARB process and was told that an ARB ticket was not necessary for this PR because the changes are only to relationships / candidates.

ARB Jira ticket: N/A

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid.
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
* [X] ~I've linked an ARB ticket & received approval from API Review Board in order to make these changes~ N/A
