### PR TITLE
Updated tag keys to create APM → GCP database relationships

### DIFF
--- a/relationships/candidates/DATABASE.yml
+++ b/relationships/candidates/DATABASE.yml
@@ -40,7 +40,7 @@ lookups:
     tags:
       matchingMode: ANY
       predicates:
-        - tagKeys: ["endpoint", "nr.endpoint", "aws.endpoint", "aws.readerEndpoint", "aws.customEndpoints", "aws.rds.endpoint", "aws.rds.readerEndpoint", "aws.rds.customEndpoints","azure.endpoint","azure.failoverGroupDomainName", "gcp.ipAddress", "gcp.publicIpAddress", "gcp.connectionName"]
+        - tagKeys: ["endpoint", "nr.endpoint", "aws.endpoint", "aws.readerEndpoint", "aws.customEndpoints", "aws.rds.endpoint", "aws.rds.readerEndpoint", "aws.rds.customEndpoints","azure.endpoint","azure.failoverGroupDomainName", "gcp.privateIpAddress", "gcp.publicIpAddress", "gcp.connectionName"]
           field: endpoint
     onMatch:
      onMultipleMatches: RELATE_ALL

--- a/relationships/candidates/DATABASE.yml
+++ b/relationships/candidates/DATABASE.yml
@@ -40,7 +40,7 @@ lookups:
     tags:
       matchingMode: ANY
       predicates:
-        - tagKeys: ["endpoint", "nr.endpoint", "aws.endpoint", "aws.readerEndpoint", "aws.customEndpoints", "aws.rds.endpoint", "aws.rds.readerEndpoint", "aws.rds.customEndpoints","azure.endpoint","azure.failoverGroupDomainName"]
+        - tagKeys: ["endpoint", "nr.endpoint", "aws.endpoint", "aws.readerEndpoint", "aws.customEndpoints", "aws.rds.endpoint", "aws.rds.readerEndpoint", "aws.rds.customEndpoints","azure.endpoint","azure.failoverGroupDomainName", "gcp.ipAddress", "gcp.publicIpAddress", "gcp.connectionName"]
           field: endpoint
     onMatch:
      onMultipleMatches: RELATE_ALL

--- a/relationships/candidates/REDIS.yml
+++ b/relationships/candidates/REDIS.yml
@@ -17,10 +17,12 @@ lookups:
         type: AWSELASTICACHEVALKEYNODE
       - domain: INFRA
         type: AWSELASTICACHEVALKEYSERVERLESS
+      - domain: INFRA
+        type: GCPMEMORYSTOREINSTANCE
     tags:
       matchingMode: ANY
       predicates:
-        - tagKeys: ["endpoint", "aws.elasticache.endpointAddress", "aws.elasticache.configurationEndpointAddress", "aws.elasticache.primaryEndpointAddress", "aws.elasticache.readerEndpointAddress" ]
+        - tagKeys: ["endpoint", "aws.elasticache.endpointAddress", "aws.elasticache.configurationEndpointAddress", "aws.elasticache.primaryEndpointAddress", "aws.elasticache.readerEndpointAddress", "gcp.endpoint" ]
           field: endpoint
     onMatch:
       onMultipleMatches: RELATE_ALL


### PR DESCRIPTION
### Relevant information

Added tag keys to create APM -> GCP CloudSQL and APM -> GCP Memory Store relationships

Cloud SQL Tag:

<img width="1133" height="788" alt="Screenshot 2026-08-13 at 2 29 52 PM" src="https://github.com/user-attachments/assets/4bed1e41-8401-492a-b4ec-dcb3e3a0ee47" />

<img width="1133" height="788" alt="Screenshot 2026-08-13 at 2 30 42 PM" src="https://github.com/user-attachments/assets/49d30f14-0378-4665-b52f-711ebe4dda13" />

<img width="1133" height="788" alt="Screenshot 2026-08-13 at 2 31 34 PM" src="https://github.com/user-attachments/assets/8261f493-b850-49b1-924b-4219ea95410c" />



Memory Store Tag:

<img width="1156" height="769" alt="Screenshot 2026-08-13 at 10 58 44 AM" src="https://github.com/user-attachments/assets/26e69911-5252-4f9f-9dd9-8900b136765c" />


<!--
  Describe what you have done.
  Provide details that are relevant to the PR

  Always think that the person reviewing the PR doesn't have the context you have.

  Links to examples, documentation and similar resources make the process easier to review.
-->

<!--
  Contributions to this repository are reviewed at least twice a week

  There's no further action required once the PR has been created.
 -->

#### Api Review Board (ARB)

Any pull request with changes to this repository has to be linked with an ARB ticket, which has to be approved before merging.

If you are an external contributor please contact New Relic Support.

If you don't know about the ARB process check [this](https://newrelic.enterprise.slack.com/docs/T02D34WJD/F08AW240NSV)

ARB Jira ticket:
https://new-relic.atlassian.net/browse/NR-XXXX

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid.
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
* [ ] I've linked an ARB ticket & received approval from API Review Board in order to make these changes
