### PR TITLE
NR-590130: production APM → AWS-infra HTTP-endpoint relationship definitions

### DIFF
--- a/relationships/candidates/AWSHTTPENDPOINT.yml
+++ b/relationships/candidates/AWSHTTPENDPOINT.yml
@@ -31,12 +31,13 @@ lookups:
     tags:
       matchingMode: ANY
       predicates:
-        # aws.alb.dnsName (ALB, ACF master) and aws.nlb.dnsName (NLB, ACF PR #359) are live.
-        # aws.elb.dnsName (Classic ELB) is a DORMANT placeholder: Classic ELB is not yet
-        # ACF-discovered (no resource-arn-definitions entry) and no metric-stream / polling
-        # source emits it, so this key matches nothing today. It is kept - not dropped - so the
-        # relationship activates automatically once Classic ELB is onboarded to ACF, with no
-        # candidate edit needed then. Documented as intentional.
+        # aws.alb.dnsName (ALB) and aws.nlb.dnsName (NLB) are live via ACF.
+        # aws.elb.dnsName (Classic ELB) is now live too (NR-590130): AWSELB.yaml emits it from
+        # $.DNSName during CloudControl enrichment. Classic ELB is discovered by beyond-polling-aws'
+        # ClassicLoadBalancerDiscovery (not a CloudFormation resource scan), then ACF enriches it.
+        # All three prefixed keys are ACF-exclusive -- metric-stream / polling emit only the golden
+        # aws.dnsName -- so keying the candidate here gates the APM->INFRA relationship to
+        # auto-discovery: it forms only once ACF has enriched the entity.
         - tagKeys: ["endpoint", "aws.elb.dnsName", "aws.alb.dnsName", "aws.nlb.dnsName"]
           field: serverAddress
     onMatch:

--- a/relationships/candidates/AWSHTTPENDPOINT.yml
+++ b/relationships/candidates/AWSHTTPENDPOINT.yml
@@ -1,0 +1,114 @@
+category: AWSHTTPENDPOINT
+# Consolidated candidate for APM apps making HTTP calls to AWS edge/proxy resources
+# (CloudFront, ELB/ALB/NLB, API Gateway, and interface VPC endpoints / PrivateLink).
+# Driven by the metrics-only, host-regex-free synthesis rule
+# APM-APPLICATION-to-AWSHTTPENDPOINT - so every lookup MUST use onMiss: NO_OP (a broad
+# External matcher would otherwise stamp a typed AWS stub for every third-party host).
+# Each lookup matches the emitted host against BOTH the per-type native host tag (from
+# ACF PR #359 / polling / metric-streams) AND `endpoint` (already live; carries
+# Route53/custom-domain friendly names via ACF enrichMappingsWithDnsName).
+lookups:
+  - entityTypes:
+      - domain: INFRA
+        type: AWSCLOUDFRONTDISTRIBUTION
+    tags:
+      matchingMode: ANY
+      predicates:
+        - tagKeys: ["endpoint", "aws.cloudfront.domainName"]
+          field: serverAddress
+    onMatch:
+      onMultipleMatches: RELATE_ALL
+    onMiss:
+      action: NO_OP
+
+  - entityTypes:
+      - domain: INFRA
+        type: AWSELB
+      - domain: INFRA
+        type: AWSALB
+      - domain: INFRA
+        type: AWSNLB
+    tags:
+      matchingMode: ANY
+      predicates:
+        # aws.alb.dnsName (ALB, ACF master) and aws.nlb.dnsName (NLB, ACF PR #359) are live.
+        # aws.elb.dnsName (Classic ELB) is a DORMANT placeholder: Classic ELB is not yet
+        # ACF-discovered (no resource-arn-definitions entry) and no metric-stream / polling
+        # source emits it, so this key matches nothing today. It is kept - not dropped - so the
+        # relationship activates automatically once Classic ELB is onboarded to ACF, with no
+        # candidate edit needed then. Documented as intentional.
+        - tagKeys: ["endpoint", "aws.elb.dnsName", "aws.alb.dnsName", "aws.nlb.dnsName"]
+          field: serverAddress
+    onMatch:
+      onMultipleMatches: RELATE_ALL
+    onMiss:
+      action: NO_OP
+
+  - entityTypes:
+      - domain: INFRA
+        type: AWSAPIGATEWAYAPI
+    tags:
+      matchingMode: ANY
+      predicates:
+        # host-only (scheme-stripped) key; see ACF/beyond-common notes in README.
+        - tagKeys: ["endpoint", "aws.apigateway.endpoint"]
+          field: serverAddress
+    onMatch:
+      onMultipleMatches: RELATE_ALL
+    onMiss:
+      action: NO_OP
+
+  # NR-590130: Elasticsearch / OpenSearch reached over HTTP. The NR Java agent has NO
+  # elasticsearch/opensearch instrumentation module, so BOTH the low-level
+  # elasticsearch-rest-client (org.elasticsearch.client.RestClient) AND the high-level
+  # RestHighLevelClient run their HTTP over Apache HttpAsyncClient, which the agent's
+  # http-async-client-4 module records as an External HTTP call - category=http,
+  # span.kind=client, server.address = host - NOT a Datastore segment. VERIFIED on the rig
+  # for BOTH clients (low-level on the custom Route53 host; high-level pointed at the native
+  # search-*.es.amazonaws.com host): only External spans, ZERO datastore-category spans.
+  # (The pre-existing Datastore rule APM-APPLICATION-to-INFRA-AWSELASTICSEARCHCLUSTER +
+  # DATABASE candidate is a dead path for the Java agent; it only fires for agents/SDKs that
+  # DO emit an ES Datastore segment, e.g. OTel/Python with ES instrumentation.)
+  # That External host resolves here to the AWSELASTICSEARCHCLUSTER entity. Match the native
+  # host tag (aws.es.DomainEndpoint) OR the friendly Route53 value (endpoint, ACF
+  # enrichMappingsWithDnsName). NOTE: ES/OpenSearch is NOT ACF-discovered, so there is no
+  # aws.es.* auto-discovery key - the native tag aws.es.DomainEndpoint is the pre-existing
+  # metric-stream one. onMiss NO_OP as above.
+  - entityTypes:
+      - domain: INFRA
+        type: AWSELASTICSEARCHCLUSTER
+    tags:
+      matchingMode: ANY
+      predicates:
+        - tagKeys: ["endpoint", "aws.es.DomainEndpoint"]
+          field: serverAddress
+    onMatch:
+      onMultipleMatches: RELATE_ALL
+    onMiss:
+      action: NO_OP
+
+  # NR-590130: interface VPC endpoints (PrivateLink), both AWS-managed-service and customer
+  # "VPC Service" endpoints. With private DNS OFF the app dials the endpoint DNS name over
+  # HTTP, so the NR Java agent records an External call and the metrics-only rule above fires
+  # on the host (native vpce-<id>-<hash>.<svc>.<region>.vpce.amazonaws.com OR a Route53 custom
+  # domain). VERIFIED on the vpce-test-infra rig for both the AWS-managed (SQS) and customer
+  # VPC-Service cases. Routed through this NO_OP candidate rather than a dedicated
+  # regex-gated + CREATE_UNINSTRUMENTED rule so that (a) custom/Route53 domains relate exactly
+  # like the AWS-native host, and (b) an existing-but-untagged VPCE entity is never duplicated
+  # by a stub - it simply waits for the tag. The trade-off vs CREATE_UNINSTRUMENTED: no typed
+  # stub for endpoints in unmonitored accounts (falls through to HTTPSERVICE, same as the
+  # other types here). Match the native DNS name (aws.vpce.dnsName, ACF PR #359 - inert until
+  # published; Cloud Control Properties.DnsEntries[0] is "<zoneId>:<host>", strip the prefix)
+  # OR the friendly value (endpoint, ACF enrichMappingsWithDnsName).
+  - entityTypes:
+      - domain: INFRA
+        type: AWSPRIVATELINKENDPOINT
+    tags:
+      matchingMode: ANY
+      predicates:
+        - tagKeys: ["endpoint", "aws.vpce.dnsName"]
+          field: serverAddress
+    onMatch:
+      onMultipleMatches: RELATE_ALL
+    onMiss:
+      action: NO_OP

--- a/relationships/candidates/AWSHTTPENDPOINT.yml
+++ b/relationships/candidates/AWSHTTPENDPOINT.yml
@@ -9,8 +9,7 @@ category: AWSHTTPENDPOINT
 # Route53/custom-domain friendly names via ACF enrichMappingsWithDnsName).
 lookups:
   - entityTypes:
-      - domain: INFRA
-        type: AWSCLOUDFRONTDISTRIBUTION
+      - INFRA-AWSCLOUDFRONTDISTRIBUTION
     tags:
       matchingMode: ANY
       predicates:
@@ -22,12 +21,9 @@ lookups:
       action: NO_OP
 
   - entityTypes:
-      - domain: INFRA
-        type: AWSELB
-      - domain: INFRA
-        type: AWSALB
-      - domain: INFRA
-        type: AWSNLB
+      - INFRA-AWSELB
+      - INFRA-AWSALB
+      - INFRA-AWSNLB
     tags:
       matchingMode: ANY
       predicates:
@@ -46,8 +42,7 @@ lookups:
       action: NO_OP
 
   - entityTypes:
-      - domain: INFRA
-        type: AWSAPIGATEWAYAPI
+      - INFRA-AWSAPIGATEWAYAPI
     tags:
       matchingMode: ANY
       predicates:
@@ -76,8 +71,7 @@ lookups:
   # aws.es.* auto-discovery key - the native tag aws.es.DomainEndpoint is the pre-existing
   # metric-stream one. onMiss NO_OP as above.
   - entityTypes:
-      - domain: INFRA
-        type: AWSELASTICSEARCHCLUSTER
+      - INFRA-AWSELASTICSEARCHCLUSTER
     tags:
       matchingMode: ANY
       predicates:
@@ -102,12 +96,36 @@ lookups:
   # published; Cloud Control Properties.DnsEntries[0] is "<zoneId>:<host>", strip the prefix)
   # OR the friendly value (endpoint, ACF enrichMappingsWithDnsName).
   - entityTypes:
-      - domain: INFRA
-        type: AWSPRIVATELINKENDPOINT
+      - INFRA-AWSPRIVATELINKENDPOINT
     tags:
       matchingMode: ANY
       predicates:
         - tagKeys: ["endpoint", "aws.vpce.dnsName"]
+          field: serverAddress
+    onMatch:
+      onMultipleMatches: RELATE_ALL
+    onMiss:
+      action: NO_OP
+
+  # NR-590130: S3 buckets reached over HTTP. cloud.resource_id is null for S3 (unlike
+  # DynamoDB/SQS), so the match is HOST-based, not ARN-based. Two emitted-host shapes,
+  # BOTH VERIFIED on the rig:
+  #   - direct S3-SDK path -> region-qualified virtual-hosted endpoint
+  #     <bucket>.s3.<region>.amazonaws.com == CloudControl $.RegionalDomainName. Metric
+  #     streams / polling give S3 only name+ARN, so the native host tag
+  #     aws.s3.RegionalDomainName is ACF-exclusive (ACF PR #359 - AWS_S3_BUCKET.yaml maps it
+  #     from $.RegionalDomainName). This gates the direct-path relationship to auto-discovery.
+  #   - Route53 / custom-domain path -> the friendly host the app dialed, already carried by
+  #     the live `endpoint` tag (ACF enrichMappingsWithDnsName).
+  # (The S3 SDK also emits an External/<bucket>/S3/getObject segment on the BARE bucket name;
+  # that is not an HTTP-endpoint tag here and correctly falls through to HTTPSERVICE.)
+  # onMiss NO_OP as above - never stamp a typed S3 stub for an arbitrary External host.
+  - entityTypes:
+      - INFRA-AWSS3BUCKET
+    tags:
+      matchingMode: ANY
+      predicates:
+        - tagKeys: ["endpoint", "aws.s3.RegionalDomainName"]
           field: serverAddress
     onMatch:
       onMultipleMatches: RELATE_ALL

--- a/relationships/candidates/AWSMQBROKER.yml
+++ b/relationships/candidates/AWSMQBROKER.yml
@@ -5,7 +5,11 @@ lookups:
     tags:
       matchingMode: ALL
       predicates:
-        - tagKeys: ["aws.mq.endpoint"]
+        # NR-590130: `endpoint` is the ACF-exclusive match key (auto-discovery emits the generic
+        # `endpoint` tag with the broker host via enrichMappingsWithDnsName). It gates the
+        # APM->INFRA relationship to auto-discovery. `aws.mq.endpoint` is retained for continuity
+        # (tagKeys is an OR within the predicate; either key resolves the same host value).
+        - tagKeys: ["endpoint", "aws.mq.endpoint"]
           field: endpoint
     onMatch:
       onMultipleMatches: RELATE_ALL

--- a/relationships/candidates/DATABASE.yml
+++ b/relationships/candidates/DATABASE.yml
@@ -19,10 +19,12 @@ lookups:
     - INFRA-MYSQLNODE
     - INFRA-POSTGRESQLINSTANCE
     - INFRA-ORACLEDBINSTANCE
+    - INFRA-AWSRDSPROXY
+    - INFRA-AWSREDSHIFTCLUSTER
     tags:
       matchingMode: ANY
       predicates:
-        - tagKeys: ["endpoint", "nr.endpoint", "aws.endpoint", "aws.readerEndpoint", "aws.customEndpoints", "aws.rds.endpoint", "aws.rds.readerEndpoint", "aws.rds.customEndpoints","azure.endpoint","azure.failoverGroupDomainName", "gcp.privateIpAddress", "gcp.publicIpAddress", "gcp.connectionName"]
+        - tagKeys: ["endpoint", "nr.endpoint", "aws.endpoint", "aws.readerEndpoint", "aws.customEndpoints", "aws.rds.endpoint", "aws.rds.readerEndpoint", "aws.rds.customEndpoints", "aws.rds.proxyEndpoint", "aws.redshift.serverAddress","azure.endpoint","azure.failoverGroupDomainName", "gcp.privateIpAddress", "gcp.publicIpAddress", "gcp.connectionName"]
           field: endpoint
     onMatch:
      onMultipleMatches: RELATE_ALL

--- a/relationships/synthesis/APM-APPLICATION-to-AWSHTTPENDPOINT.yml
+++ b/relationships/synthesis/APM-APPLICATION-to-AWSHTTPENDPOINT.yml
@@ -1,0 +1,29 @@
+relationships:
+  # APM app -> AWS HTTP edge/proxy resource (CloudFront, ELB/ALB/NLB, API Gateway,
+  # Elasticsearch/OpenSearch, and interface VPC endpoints / PrivateLink).
+  # Metrics-only + host-regex-free: the External timeslice metric is unsampled (guaranteed
+  # coverage) and its 2nd segment is the host the app actually called - including Route53 /
+  # custom friendly domains, which host-regex-gated rules miss. The candidate
+  # (AWSHTTPENDPOINT) decides whether that host maps to a known AWS entity; unmatched hosts
+  # fall through to the existing EXT-SERVICE/HTTPSERVICE stub (candidate onMiss: NO_OP).
+  - name: apmApplicationCallsAwsHttpEndpointByAddress
+    version: "1"
+    origins:
+      - APM Metrics
+    conditions:
+      - attribute: metricName
+        regex: "^External/[^/]+/.*"
+    relationship:
+      expires: PT75M
+      relationshipType: CALLS
+      source:
+        extractGuid:
+          attribute: entity.guid
+      target:
+        lookupGuid:
+          candidateCategory: AWSHTTPENDPOINT
+          fields:
+            - field: serverAddress
+              capture:
+                attribute: metricName__2
+                regex: "^([^:/]+)"


### PR DESCRIPTION
## What

Ports the merged **staging** PR #3105 to production `.yml`, enabling `APM-APPLICATION → AWS-infra` `CALLS` relationships for AWS HTTP edge/proxy resources.

| File | Action | Summary |
|---|---|---|
| `relationships/candidates/AWSHTTPENDPOINT.yml` | **new** | Consolidated candidate: CloudFront, ELB/ALB/NLB, API Gateway, Elasticsearch/OpenSearch, interface VPC endpoints (PrivateLink). All lookups `onMiss: NO_OP`. |
| `relationships/synthesis/APM-APPLICATION-to-AWSHTTPENDPOINT.yml` | **new** | Metrics-only, host-regex-free rule (`^External/[^/]+/.*`); captures the called host and resolves it through the `AWSHTTPENDPOINT` candidate. |
| `relationships/candidates/DATABASE.yml` | **modify** | Fold in `AWSRDSPROXY` + `AWSREDSHIFTCLUSTER` entity types and `aws.rds.proxyEndpoint` / `aws.redshift.serverAddress` tag keys. |
| `relationships/candidates/AWSMQBROKER.yml` | **modify** | Add ACF-exclusive `endpoint` match key (keep `aws.mq.endpoint`); gates the APM→INFRA MQ relationship to auto-discovery. |

## Why

The External timeslice metric is unsampled (guaranteed coverage) and its 2nd segment is the host the app actually called — **including Route53 / custom friendly domains that host-regex-gated rules miss**. The candidate decides whether that host maps to a known AWS entity; unmatched hosts fall through to the existing EXT-SERVICE/HTTPSERVICE stub (candidate `onMiss: NO_OP`), so no typed stub is stamped for third-party hosts.

The `DATABASE.yml` fold-in lets the JDBC/Datastore path relate to RDS Proxy and Redshift entities instead of minting a `DATABASE` stub.

The `AWSMQBROKER.yml` change adds the ACF-exclusive generic `endpoint` tag key (emitted by auto-discovery via `enrichMappingsWithDnsName`) alongside the existing `aws.mq.endpoint`, so the MQ broker relationship forms only once ACF has enriched the entity.

## Competing-rule analysis (verified against `main`)

- **ALB / NLB / ELB / API-GW / CloudFront / PrivateLink** — no prior `APM-APPLICATION-to-INFRA-*` synthesis rule exists; this is the sole APM path. No conflict.
- **Elasticsearch** — existing `APM-APPLICATION-to-INFRA-AWSELASTICSEARCHCLUSTER` (host-regex Span + Datastore-metric) targets the same entity; coexists additively. This rule adds Route53/friendly-domain coverage. `NO_OP` lookup adds no new stubs.
- **Redshift** — existing `APM-APPLICATION-to-INFRA-REDSHIFTCLUSTER` (native-host Span) and the DATABASE/JDBC path are complementary; both land on the same `AWSREDSHIFTCLUSTER` entity.
- **MQ broker** — existing `APM-APPLICATION-to-INFRA-MQBROKER` synthesis (PRODUCES/CONSUMES/CALLS, `field: endpoint ← server.address`) already targets `AWSMQBROKER`; this change only broadens the candidate's `tagKeys`, so there is no rule conflict.
- **EXT-SERVICE** — the merged #3105 contains no `EXT-SERVICE-to-AWSHTTPENDPOINT` rule; none added here. Existing `EXT-SERVICE-to-INFRA-{ES,REDSHIFT}` rules are OTel-only (ARN / `api.traces.otlp`) — no overlap.

The production `DATABASE.yml` base differs from the staging `.stg.yml` (production carries GCP types/tags), so only the semantic delta was applied — GCP support is preserved.

## Validation

`cd validator && npm run check` passes (schema + relationship-synthesis-rules + candidate cross-check).

Staging counterpart: #3105
