### PR TITLE
fix: cloudgenix cpu golden metric

### DIFF
--- a/entity-types/ext-sd_wan/golden_metrics.yml
+++ b/entity-types/ext-sd_wan/golden_metrics.yml
@@ -4,7 +4,7 @@ cpuUtilization:
  queries:
   # Cloudgenix SD-WAN
   kentik/cloudgenix:
-    select: ((rate(average(kentik.snmp.ssCpuRawUser), 1 second) + rate(average(kentik.snmp.ssCpuRawSystem), 1 second) + rate(average(kentik.snmp.ssCpuRawWait), 1 second)) / (rate(average(kentik.snmp.ssCpuRawUser), 1 second) + rate(average(kentik.snmp.ssCpuRawSystem), 1 second) + rate(average(kentik.snmp.ssCpuRawIdle), 1 second) + rate(average(kentik.snmp.ssCpuRawWait), 1 second))) * 100
+    select: 100 * (sum(kentik.snmp.ssCpuRawUser) + sum(kentik.snmp.ssCpuRawSystem) + sum(kentik.snmp.ssCpuRawWait)) / (sum(kentik.snmp.ssCpuRawUser) + sum(kentik.snmp.ssCpuRawSystem) + sum(kentik.snmp.ssCpuRawIdle) + sum(kentik.snmp.ssCpuRawWait))
     from: Metric
     eventId: entity.guid
 


### PR DESCRIPTION
### ARB
This change falls under the previously raised [ARB](https://new-relic.atlassian.net/browse/NR-596622) for the CloudGenix entity.
Related PR - [PR](https://github.com/newrelic/entity-definitions/pull/3167)

### Problem

The cpuUtilization golden metric for ext-sd_wan (CloudGenix) was silently failing to populate. The metric appeared valid in dashboards but never showed up as a golden metric on the entity.

### Root cause (confirmed in [#golden-signals-platform](https://newrelic.slack.com/archives/C0343J3T0DV/p1787036435704319?thread_ts=1786986847.806639&cid=C0343J3T0DV)): 


the select expression used average() across 3+ terms, which fails at pipeline preparation time 

### Fix
Replaced rate(average(...), 1 second) with sum() across all terms, as recommended by the Golden Signals Platform team. 

### Validation

- Submitted the updated select expression to the ephemeral-golden-metrics-service — pipeline accepted it with metricKind: **GENERALIZED_AVERAGE** 
```
dkumarheerakari@GXW6VGXR22 ~ % curl -X PUT "https://ephemeral-golden-metrics-service.vip.cf.nr-ops.net/ephemeral" \
  -H "Content-Type: application/json" \
  -d '{
    "owner": "dkumarheerakari",
    "entityType": {"domain": "EXT", "type": "SD_WAN"},
    "goldenMetric": {
      "title": "CPU Utilization (%)",
      "unit": "PERCENTAGE",
      "metricName": "cpuUtilization",
      "queries": {
        "kentik/cloudgenix": {
          "select": "100 * (sum(kentik.snmp.ssCpuRawUser) + sum(kentik.snmp.ssCpuRawSystem) + sum(kentik.snmp.ssCpuRawWait)) / (sum(kentik.snmp.ssCpuRawUser) + sum(kentik.snmp.ssCpuRawSystem) + sum(kentik.snmp.ssCpuRawIdle) + sum(kentik.snmp.ssCpuRawWait))",
          "from": "Metric",
          "eventId": "entity.guid"
        }
      }
    }
  }'
{"metricKind":"GENERALIZED_AVERAGE","id":4417754633324482443}%                                                                                                                dkumarheerakari@GXW6VGXR22 ~ % curl "https://ephemeral-golden-metrics-service.vip.cf.nr-ops.net/ephemeral/4417754633324482443/kind"
dkumarheerakari@GXW6VGXR22 ~ % curl "https://ephemeral-golden-metrics-service.vip.cf.nr-ops.net/ephemeral/4417754633324482443/kind"
{"metricKind":"GENERALIZED_AVERAGE","id":4417754633324482443}%  
```
<img width="1673" height="668" alt="image" src="https://github.com/user-attachments/assets/a8795723-e316-45b7-8f4a-a973aa7df91e" />


### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid.
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
* [ ] I've linked an ARB ticket & received approval from API Review Board in order to make these changes
