### PR TITLE
NR-604722 Add OCI Cache, Kafka, Media Streams, Recovery Service, Vault Secrets entity definitions

### DIFF
--- a/entity-types/infra-ocikafka/definition.yml
+++ b/entity-types/infra-ocikafka/definition.yml
@@ -1,0 +1,30 @@
+domain: INFRA
+type: OCIKAFKA
+goldenTags:
+- oci.compartmentId
+- oci.displayName
+- oci.lifecycleState
+- oci.region
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
+      multiValue: false
+  rules:
+  - ruleName: infra_ocikafka_oci_resourceId
+    identifier: oci.resourceId
+    name: oci.resourceName
+    legacyFeatures:
+      overrideGuidType: true
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: oci.resourceId
+      prefix: "ocid1.kafkacluster"
+    - attribute: oci.namespace
+      value: "oci_kafka"
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-ocikafka/golden_metrics.yml
+++ b/entity-types/infra-ocikafka/golden_metrics.yml
@@ -1,0 +1,39 @@
+brokerCpuUsage:
+  title: Broker CPU Usage
+  unit: PERCENTAGE
+  queries:
+    oci:
+      select: average(`oci.kafka.broker.cpu.usage`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+
+brokerAvailableDiskSpace:
+  title: Broker Available Disk Space
+  unit: PERCENTAGE
+  queries:
+    oci:
+      select: average(`oci.kafka.broker.available.disk.space`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+
+brokerMemoryUsed:
+  title: Broker Memory Used
+  unit: PERCENTAGE
+  queries:
+    oci:
+      select: average(`oci.kafka.broker.memory.used`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+
+brokerUnderReplicatedPartitions:
+  title: Broker Under Replicated Partitions
+  unit: COUNT
+  queries:
+    oci:
+      select: sum(`oci.kafka.broker.under.replicated.partitions`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-ocikafka/summary_metrics.yml
+++ b/entity-types/infra-ocikafka/summary_metrics.yml
@@ -1,0 +1,20 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: OCI account
+  unit: STRING
+
+brokerCpuUsage:
+  goldenMetric: brokerCpuUsage
+  unit: PERCENTAGE
+  title: Broker CPU Usage
+
+brokerAvailableDiskSpace:
+  goldenMetric: brokerAvailableDiskSpace
+  unit: PERCENTAGE
+  title: Broker Available Disk Space
+
+brokerUnderReplicatedPartitions:
+  goldenMetric: brokerUnderReplicatedPartitions
+  unit: COUNT
+  title: Broker Under Replicated Partitions

--- a/entity-types/infra-ocikafka/tests/Metric.json
+++ b/entity-types/infra-ocikafka/tests/Metric.json
@@ -1,0 +1,25 @@
+[
+  {
+    "oci.compartmentId": "ocid1.compartment.oc1..aaaaaaaabbbbbbccccccccdddddddeeeeeeefffffffgggggggghhhhhhhhiiiiiiiiijjjjjjjj",
+    "oci.namespace": "oci_kafka",
+    "oci.region": "us-ashburn-1",
+    "oci.resourceId": "ocid1.kafkacluster.oc1.iad.aaaaaaaabbbbbbccccccccdddddddeeeeeeefffffffgggggggghhhhhhhhiiiiiiiiijjjjjjjj",
+    "oci.resourceName": "my-kafka-cluster",
+    "oci.displayName": "my-kafka-cluster",
+    "oci.lifecycleState": "ACTIVE",
+    "collector.name": "oci-monitor",
+    "collector.version": "release-007",
+    "displayName": "my-kafka-cluster",
+    "endTimestamp": 1746680903,
+    "instrumentation.provider": "oci",
+    "metricName": "oci.kafka.broker.cpu.usage",
+    "newrelic.cloudIntegrations.integrationId": "1",
+    "newrelic.cloudIntegrations.integrationName": "OCI Monitor metrics",
+    "newrelic.cloudIntegrations.providerAccountId": "1",
+    "newrelic.cloudIntegrations.providerAccountName": "oci-dev-all-metrics",
+    "newrelic.cloudIntegrations.providerExternalId": "9bcb5134-f0a6-11ed-a05b-0242ac120003",
+    "newrelic.source": "metricAPI",
+    "nr.entity.id": "-2281987194047346713",
+    "timestamp": 1746680903
+  }
+]

--- a/entity-types/infra-ocimediastreams/definition.yml
+++ b/entity-types/infra-ocimediastreams/definition.yml
@@ -1,0 +1,30 @@
+domain: INFRA
+type: OCIMEDIASTREAMS
+goldenTags:
+- oci.compartmentId
+- oci.displayName
+- oci.lifecycleState
+- oci.region
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
+      multiValue: false
+  rules:
+  - ruleName: infra_ocimediastreams_oci_resourceId
+    identifier: oci.resourceId
+    name: oci.resourceName
+    legacyFeatures:
+      overrideGuidType: true
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: oci.resourceId
+      prefix: "ocid1.mediastreamsdistributionchannel"
+    - attribute: oci.namespace
+      value: "oci_mediastreams"
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-ocimediastreams/golden_metrics.yml
+++ b/entity-types/infra-ocimediastreams/golden_metrics.yml
@@ -1,0 +1,19 @@
+egressBytes:
+  title: Egress Data
+  unit: BYTES
+  queries:
+    oci:
+      select: sum(`oci.mediastreams.egress.bytes`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+
+requestCount:
+  title: Request Count
+  unit: COUNT
+  queries:
+    oci:
+      select: sum(`oci.mediastreams.request.count`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-ocimediastreams/summary_metrics.yml
+++ b/entity-types/infra-ocimediastreams/summary_metrics.yml
@@ -1,0 +1,15 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: OCI account
+  unit: STRING
+
+egressBytes:
+  goldenMetric: egressBytes
+  unit: BYTES
+  title: Egress Data
+
+requestCount:
+  goldenMetric: requestCount
+  unit: COUNT
+  title: Request Count

--- a/entity-types/infra-ocimediastreams/tests/Metric.json
+++ b/entity-types/infra-ocimediastreams/tests/Metric.json
@@ -1,0 +1,25 @@
+[
+  {
+    "oci.compartmentId": "ocid1.compartment.oc1..aaaaaaaabbbbbbccccccccdddddddeeeeeeefffffffgggggggghhhhhhhhiiiiiiiiijjjjjjjj",
+    "oci.namespace": "oci_mediastreams",
+    "oci.region": "us-ashburn-1",
+    "oci.resourceId": "ocid1.mediastreamsdistributionchannel.oc1.iad.aaaaaaaabbbbbbccccccccdddddddeeeeeeefffffffgggggggghhhhhhhhiiiiiiiiijjjjjjjj",
+    "oci.resourceName": "my-distribution-channel",
+    "oci.displayName": "my-distribution-channel",
+    "oci.lifecycleState": "ACTIVE",
+    "collector.name": "oci-monitor",
+    "collector.version": "release-007",
+    "displayName": "my-distribution-channel",
+    "endTimestamp": 1746680903,
+    "instrumentation.provider": "oci",
+    "metricName": "oci.mediastreams.egress.bytes",
+    "newrelic.cloudIntegrations.integrationId": "1",
+    "newrelic.cloudIntegrations.integrationName": "OCI Monitor metrics",
+    "newrelic.cloudIntegrations.providerAccountId": "1",
+    "newrelic.cloudIntegrations.providerAccountName": "oci-dev-all-metrics",
+    "newrelic.cloudIntegrations.providerExternalId": "9bcb5134-f0a6-11ed-a05b-0242ac120003",
+    "newrelic.source": "metricAPI",
+    "nr.entity.id": "-2281987194047346713",
+    "timestamp": 1746680903
+  }
+]

--- a/entity-types/infra-ocirecoveryservice/definition.yml
+++ b/entity-types/infra-ocirecoveryservice/definition.yml
@@ -1,0 +1,30 @@
+domain: INFRA
+type: OCIRECOVERYSERVICE
+goldenTags:
+- oci.compartmentId
+- oci.displayName
+- oci.lifecycleState
+- oci.region
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
+      multiValue: false
+  rules:
+  - ruleName: infra_ocirecoveryservice_oci_resourceId
+    identifier: oci.resourceId
+    name: oci.resourceName
+    legacyFeatures:
+      overrideGuidType: true
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: oci.resourceId
+      prefix: "ocid1.protecteddatabase"
+    - attribute: oci.namespace
+      value: "oci_recovery_service"
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-ocirecoveryservice/golden_metrics.yml
+++ b/entity-types/infra-ocirecoveryservice/golden_metrics.yml
@@ -1,0 +1,39 @@
+protectedDatabaseHealth:
+  title: Protected Database Health
+  unit: COUNT
+  queries:
+    oci:
+      select: max(`oci.recovery.service.protected.database.health`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+
+dataLossExposure:
+  title: Data Loss Exposure
+  unit: SECONDS
+  queries:
+    oci:
+      select: average(`oci.recovery.service.data.loss.exposure`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+
+spaceUsedForRecoveryWindow:
+  title: Space Used for Recovery Window
+  unit: BYTES
+  queries:
+    oci:
+      select: max(`oci.recovery.service.space.used.for.recovery.window`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+
+protectedDatabaseSize:
+  title: Protected Database Size
+  unit: BYTES
+  queries:
+    oci:
+      select: max(`oci.recovery.service.protected.database.size`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-ocirecoveryservice/summary_metrics.yml
+++ b/entity-types/infra-ocirecoveryservice/summary_metrics.yml
@@ -1,0 +1,20 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: OCI account
+  unit: STRING
+
+protectedDatabaseHealth:
+  goldenMetric: protectedDatabaseHealth
+  unit: COUNT
+  title: Protected Database Health
+
+dataLossExposure:
+  goldenMetric: dataLossExposure
+  unit: SECONDS
+  title: Data Loss Exposure
+
+spaceUsedForRecoveryWindow:
+  goldenMetric: spaceUsedForRecoveryWindow
+  unit: BYTES
+  title: Space Used for Recovery Window

--- a/entity-types/infra-ocirecoveryservice/tests/Metric.json
+++ b/entity-types/infra-ocirecoveryservice/tests/Metric.json
@@ -1,0 +1,25 @@
+[
+  {
+    "oci.compartmentId": "ocid1.compartment.oc1..aaaaaaaabbbbbbccccccccdddddddeeeeeeefffffffgggggggghhhhhhhhiiiiiiiiijjjjjjjj",
+    "oci.namespace": "oci_recovery_service",
+    "oci.region": "us-ashburn-1",
+    "oci.resourceId": "ocid1.protecteddatabase.oc1.iad.aaaaaaaabbbbbbccccccccdddddddeeeeeeefffffffgggggggghhhhhhhhiiiiiiiiijjjjjjjj",
+    "oci.resourceName": "my-protected-database",
+    "oci.displayName": "my-protected-database",
+    "oci.lifecycleState": "ACTIVE",
+    "collector.name": "oci-monitor",
+    "collector.version": "release-007",
+    "displayName": "my-protected-database",
+    "endTimestamp": 1746680903,
+    "instrumentation.provider": "oci",
+    "metricName": "oci.recovery.service.protected.database.health",
+    "newrelic.cloudIntegrations.integrationId": "1",
+    "newrelic.cloudIntegrations.integrationName": "OCI Monitor metrics",
+    "newrelic.cloudIntegrations.providerAccountId": "1",
+    "newrelic.cloudIntegrations.providerAccountName": "oci-dev-all-metrics",
+    "newrelic.cloudIntegrations.providerExternalId": "9bcb5134-f0a6-11ed-a05b-0242ac120003",
+    "newrelic.source": "metricAPI",
+    "nr.entity.id": "-2281987194047346713",
+    "timestamp": 1746680903
+  }
+]

--- a/entity-types/infra-ociredis/definition.yml
+++ b/entity-types/infra-ociredis/definition.yml
@@ -1,0 +1,30 @@
+domain: INFRA
+type: OCIREDIS
+goldenTags:
+- oci.compartmentId
+- oci.displayName
+- oci.lifecycleState
+- oci.region
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
+      multiValue: false
+  rules:
+  - ruleName: infra_ociredis_oci_resourceId
+    identifier: oci.resourceId
+    name: oci.resourceName
+    legacyFeatures:
+      overrideGuidType: true
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: oci.resourceId
+      prefix: "ocid1.rediscluster"
+    - attribute: oci.namespace
+      value: "oci_redis"
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-ociredis/golden_metrics.yml
+++ b/entity-types/infra-ociredis/golden_metrics.yml
@@ -1,0 +1,39 @@
+cpuUtilization:
+  title: CPU Utilization
+  unit: PERCENTAGE
+  queries:
+    oci:
+      select: average(`oci.redis.cpu.utilization`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+
+memoryUtilization:
+  title: Memory Utilization
+  unit: PERCENTAGE
+  queries:
+    oci:
+      select: average(`oci.redis.memory.utilization`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+
+connectedClients:
+  title: Connected Clients
+  unit: COUNT
+  queries:
+    oci:
+      select: average(`oci.redis.connected.clients`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+
+keyspaceHits:
+  title: Keyspace Hits
+  unit: COUNT
+  queries:
+    oci:
+      select: sum(`oci.redis.keyspace.hits`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-ociredis/summary_metrics.yml
+++ b/entity-types/infra-ociredis/summary_metrics.yml
@@ -1,0 +1,20 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: OCI account
+  unit: STRING
+
+cpuUtilization:
+  goldenMetric: cpuUtilization
+  unit: PERCENTAGE
+  title: CPU Utilization
+
+memoryUtilization:
+  goldenMetric: memoryUtilization
+  unit: PERCENTAGE
+  title: Memory Utilization
+
+connectedClients:
+  goldenMetric: connectedClients
+  unit: COUNT
+  title: Connected Clients

--- a/entity-types/infra-ociredis/tests/Metric.json
+++ b/entity-types/infra-ociredis/tests/Metric.json
@@ -1,0 +1,25 @@
+[
+  {
+    "oci.compartmentId": "ocid1.compartment.oc1..aaaaaaaabbbbbbccccccccdddddddeeeeeeefffffffgggggggghhhhhhhhiiiiiiiiijjjjjjjj",
+    "oci.namespace": "oci_redis",
+    "oci.region": "us-ashburn-1",
+    "oci.resourceId": "ocid1.rediscluster.oc1.iad.aaaaaaaabbbbbbccccccccdddddddeeeeeeefffffffgggggggghhhhhhhhiiiiiiiiijjjjjjjj",
+    "oci.resourceName": "my-redis-cluster",
+    "oci.displayName": "my-redis-cluster",
+    "oci.lifecycleState": "ACTIVE",
+    "collector.name": "oci-monitor",
+    "collector.version": "release-007",
+    "displayName": "my-redis-cluster",
+    "endTimestamp": 1746680903,
+    "instrumentation.provider": "oci",
+    "metricName": "oci.redis.cpu.utilization",
+    "newrelic.cloudIntegrations.integrationId": "1",
+    "newrelic.cloudIntegrations.integrationName": "OCI Monitor metrics",
+    "newrelic.cloudIntegrations.providerAccountId": "1",
+    "newrelic.cloudIntegrations.providerAccountName": "oci-dev-all-metrics",
+    "newrelic.cloudIntegrations.providerExternalId": "9bcb5134-f0a6-11ed-a05b-0242ac120003",
+    "newrelic.source": "metricAPI",
+    "nr.entity.id": "-2281987194047346713",
+    "timestamp": 1746680903
+  }
+]

--- a/entity-types/infra-ocisecrets/definition.yml
+++ b/entity-types/infra-ocisecrets/definition.yml
@@ -1,0 +1,30 @@
+domain: INFRA
+type: OCISECRETS
+goldenTags:
+- oci.compartmentId
+- oci.displayName
+- oci.lifecycleState
+- oci.region
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
+      multiValue: false
+  rules:
+  - ruleName: infra_ocisecrets_oci_resourceId
+    identifier: oci.resourceId
+    name: oci.resourceName
+    legacyFeatures:
+      overrideGuidType: true
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: oci.resourceId
+      prefix: "ocid1.secret"
+    - attribute: oci.namespace
+      value: "oci_secrets"
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-ocisecrets/golden_metrics.yml
+++ b/entity-types/infra-ocisecrets/golden_metrics.yml
@@ -1,0 +1,39 @@
+createSecret:
+  title: Create Secret
+  unit: COUNT
+  queries:
+    oci:
+      select: sum(`oci.secrets.create.secret`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+
+getSecretBundle:
+  title: Get Secret Bundle
+  unit: COUNT
+  queries:
+    oci:
+      select: sum(`oci.secrets.get.secret.bundle`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+
+updateSecret:
+  title: Update Secret
+  unit: COUNT
+  queries:
+    oci:
+      select: sum(`oci.secrets.update.secret`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+
+listSecretBundleVersions:
+  title: List Secret Bundle Versions
+  unit: COUNT
+  queries:
+    oci:
+      select: sum(`oci.secrets.list.secret.bundle.versions`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-ocisecrets/summary_metrics.yml
+++ b/entity-types/infra-ocisecrets/summary_metrics.yml
@@ -1,0 +1,20 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: OCI account
+  unit: STRING
+
+createSecret:
+  goldenMetric: createSecret
+  unit: COUNT
+  title: Create Secret
+
+getSecretBundle:
+  goldenMetric: getSecretBundle
+  unit: COUNT
+  title: Get Secret Bundle
+
+updateSecret:
+  goldenMetric: updateSecret
+  unit: COUNT
+  title: Update Secret

--- a/entity-types/infra-ocisecrets/tests/Metric.json
+++ b/entity-types/infra-ocisecrets/tests/Metric.json
@@ -1,0 +1,25 @@
+[
+  {
+    "oci.compartmentId": "ocid1.compartment.oc1..aaaaaaaabbbbbbccccccccdddddddeeeeeeefffffffgggggggghhhhhhhhiiiiiiiiijjjjjjjj",
+    "oci.namespace": "oci_secrets",
+    "oci.region": "us-ashburn-1",
+    "oci.resourceId": "ocid1.secret.oc1.iad.aaaaaaaabbbbbbccccccccdddddddeeeeeeefffffffgggggggghhhhhhhhiiiiiiiiijjjjjjjj",
+    "oci.resourceName": "my-vault-secret",
+    "oci.displayName": "my-vault-secret",
+    "oci.lifecycleState": "ACTIVE",
+    "collector.name": "oci-monitor",
+    "collector.version": "release-007",
+    "displayName": "my-vault-secret",
+    "endTimestamp": 1746680903,
+    "instrumentation.provider": "oci",
+    "metricName": "oci.secrets.create.secret",
+    "newrelic.cloudIntegrations.integrationId": "1",
+    "newrelic.cloudIntegrations.integrationName": "OCI Monitor metrics",
+    "newrelic.cloudIntegrations.providerAccountId": "1",
+    "newrelic.cloudIntegrations.providerAccountName": "oci-dev-all-metrics",
+    "newrelic.cloudIntegrations.providerExternalId": "9bcb5134-f0a6-11ed-a05b-0242ac120003",
+    "newrelic.source": "metricAPI",
+    "nr.entity.id": "-2281987194047346713",
+    "timestamp": 1746680903
+  }
+]


### PR DESCRIPTION
## Summary

Add entity definitions for 5 new OCI services:
- **OCI Cache** (OCIREDIS)
- **OCI Streaming with Apache Kafka** (OCIKAFKA)
- **OCI Media Streams** (OCIMEDIASTREAMS)
- **OCI Recovery Service** (OCIRECOVERYSERVICE)
- **OCI Vault Secrets** (OCISECRETS)

Each entity includes synthesis rules, golden metrics, and summary metrics.

##  ARB
Approved — https://newrelic.atlassian.net/browse/NR-577618 (OCI - Entities creation)

## Related PRs
- entity-type-ui-definitions-service: feat/oci-new-entities
- beyond-workers: feat/oci-new-entities (source.datanerd.us/beyond/beyond-workers/pull/866)
- beyond-oci-metrics-stream-processor: feat/oci-new-entities (source.datanerd.us/beyond/beyond-oci-metrics-stream-processor/pull/141)
- papers-java-manifest: feat/oci-new-sdk-modules