### PR TITLE
Add azure.resourceId / cloud.resource_id predicate to KUBERNETESCLUSTER candidate resolution

### DIFF
--- a/relationships/candidates/KUBERNETESCLUSTER.yml
+++ b/relationships/candidates/KUBERNETESCLUSTER.yml
@@ -8,7 +8,7 @@ lookups:
         - tagKeys: [ "displayname", "k8s.cluster.name", "k8s.clusterName" ]
           field: cluster.name
         - tagKeys: [ "cloud.resource_id" ]
-          field: resourceId
+          field: cloud.resource_id
     onMatch:
       onMultipleMatches: RELATE_ALL
     onMiss:

--- a/relationships/candidates/KUBERNETESCLUSTER.yml
+++ b/relationships/candidates/KUBERNETESCLUSTER.yml
@@ -7,6 +7,8 @@ lookups:
       predicates:
         - tagKeys: [ "displayname", "k8s.cluster.name", "k8s.clusterName" ]
           field: cluster.name
+        - tagKeys: [ "cloud.resource_id", "azure.resourceId" ]
+          field: azureResourceId
     onMatch:
       onMultipleMatches: RELATE_ALL
     onMiss:

--- a/relationships/candidates/KUBERNETESCLUSTER.yml
+++ b/relationships/candidates/KUBERNETESCLUSTER.yml
@@ -7,8 +7,8 @@ lookups:
       predicates:
         - tagKeys: [ "displayname", "k8s.cluster.name", "k8s.clusterName" ]
           field: cluster.name
-        - tagKeys: [ "cloud.resource_id", "azure.resourceId" ]
-          field: azureResourceId
+        - tagKeys: [ "cloud.resource_id" ]
+          field: resourceId
     onMatch:
       onMultipleMatches: RELATE_ALL
     onMiss:


### PR DESCRIPTION
## Summary

Adds one predicate to `relationships/candidates/KUBERNETESCLUSTER.yml` so Azure 360 side emits can resolve alongside the existing `k8s.cluster.name` path.

## Change

Purely additive — one new predicate entry alongside the existing one. Existing predicate untouched.

## Rationale

Cloud Monitoring Platform is working on [NR-604226](https://new-relic.atlassian.net/browse/NR-604226) (_Azure 360 - Infra-Kubernetes - Migrate AKS entity and relationships_). AKS-neighbor Azure entities emit candidate relationships targeting `INFRA-KUBERNETESCLUSTER` so the Azure-side and k8s-side graphs converge on one cluster entity. Our emits carry `field: azureResourceId` with the AKS `azure.resourceId` as the value.

Predicate tag-key rationale:
- **`cloud.resource_id`** — OTel semantic convention. Per the K8s Agents team's Cloud360 CDDs ([1](https://newrelic.atlassian.net/wiki/spaces/TDP/pages/5743214765), [2](https://newrelic.atlassian.net/wiki/spaces/TDP/pages/5851906632)), both otel-kubernetes and nri-kubernetes integrations will emit this tag on `INFRA-KUBERNETESCLUSTER` entities with the underlying cloud resource id as the value.
- **`azure.resourceId`** — transitional coverage for the window where Azure-side tags reach the entity via other pathways before the agent-side `cloud.resource_id` change ships.

## Behavior

- `matchingMode: ANY` (unchanged) — either predicate matching counts as a hit.
- Existing `k8s.cluster.name` resolution path is completely untouched.
- `onMiss: CREATE_UNINSTRUMENTED` (unchanged).

## Cross-team context

Coordination thread: [#tmp-k8s-integration-cloud360](https://newrelic.slack.com/archives/C0B6E9ZMVNJ/p1787295346393949).

Requesting review from the K8s Agents team (primaryOwner of `entity-types/infra-kubernetescluster/definition.yml`).

[NR-604226]: https://new-relic.atlassian.net/browse/NR-604226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ