### PR TITLE
fix broken infra relationships depending on nr.entityType

### DIFF
--- a/relationships/synthesis/INFRA-CONTAINER-to-INFRA-KAFKABROKER.stg.yml
+++ b/relationships/synthesis/INFRA-CONTAINER-to-INFRA-KAFKABROKER.stg.yml
@@ -7,7 +7,7 @@ relationships:
     conditions:
       - attribute: eventType
         anyOf: ["KafkaBrokerSample"]
-      - attribute: nr.entityType
+      - attribute: entityType
         anyOf: ["KafkaBroker", "KAFKABROKER"]
       - attribute: clusterName
         present: true

--- a/relationships/synthesis/INFRA-CONTAINER-to-INFRA-KAFKABROKER.yml
+++ b/relationships/synthesis/INFRA-CONTAINER-to-INFRA-KAFKABROKER.yml
@@ -7,7 +7,7 @@ relationships:
     conditions: 
       - attribute: eventType
         anyOf: [ "KafkaBrokerSample" ]
-      - attribute: nr.entityType
+      - attribute: entityType
         anyOf: ["KafkaBroker","KAFKABROKER"]
       - attribute: clusterName
         present: true

--- a/relationships/synthesis/INFRA-CONTAINER-to-INFRA-MEMCACHEDINSTANCE.stg.yml
+++ b/relationships/synthesis/INFRA-CONTAINER-to-INFRA-MEMCACHEDINSTANCE.stg.yml
@@ -7,7 +7,7 @@ relationships:
     conditions: 
       - attribute: eventType
         anyOf: [ "MemcachedSample" ]
-      - attribute: nr.entityType
+      - attribute: entityType
         anyOf: ["MemcachedInstance","MEMCACHEDINSTANCE"]
       - attribute: clusterName
         present: true

--- a/relationships/synthesis/INFRA-CONTAINER-to-INFRA-RABBITMQNODE.stg.yml
+++ b/relationships/synthesis/INFRA-CONTAINER-to-INFRA-RABBITMQNODE.stg.yml
@@ -7,7 +7,7 @@ relationships:
     conditions: 
       - attribute: eventType
         anyOf: [ "RabbitmqNodeSample" ]
-      - attribute: nr.entityType
+      - attribute: entityType
         anyOf: ["RabbitmqNode","RABBITMQNODE"]
       - attribute: clusterName
         present: true

--- a/relationships/synthesis/INFRA-HOST-to-INFRA-KAFKABROKER.stg.yml
+++ b/relationships/synthesis/INFRA-HOST-to-INFRA-KAFKABROKER.stg.yml
@@ -7,7 +7,7 @@ relationships:
     conditions:
       - attribute: eventType
         anyOf: ["KafkaBrokerSample"]
-      - attribute: nr.entityType
+      - attribute: entityType
         anyOf: ["KAFKABROKER"]
       - attribute: hostname
         present: true
@@ -44,7 +44,7 @@ relationships:
     conditions:
       - attribute: eventType
         anyOf: ["KafkaBrokerSample"]
-      - attribute: nr.entityType
+      - attribute: entityType
         anyOf: ["KAFKABROKER"]
       - attribute: hostname
         present: true
@@ -82,7 +82,7 @@ relationships:
     conditions:
       - attribute: eventType
         anyOf: ["KafkaBrokerSample"]
-      - attribute: nr.entityType
+      - attribute: entityType
         anyOf: ["KAFKABROKER"]
       - attribute: hostname
         present: true
@@ -116,7 +116,7 @@ relationships:
     conditions:
       - attribute: eventType
         anyOf: ["KafkaBrokerSample"]
-      - attribute: nr.entityType
+      - attribute: entityType
         anyOf: ["KAFKABROKER"]
       - attribute: hostname
         present: true

--- a/relationships/synthesis/INFRA-HOST-to-INFRA-KAFKABROKER.yml
+++ b/relationships/synthesis/INFRA-HOST-to-INFRA-KAFKABROKER.yml
@@ -7,7 +7,7 @@ relationships:
     conditions:
       - attribute: eventType
         anyOf: ["KafkaBrokerSample"]
-      - attribute: nr.entityType
+      - attribute: entityType
         anyOf: ["KAFKABROKER"]
       - attribute: hostname
         present: true
@@ -44,7 +44,7 @@ relationships:
     conditions:
       - attribute: eventType
         anyOf: ["KafkaBrokerSample"]
-      - attribute: nr.entityType
+      - attribute: entityType
         anyOf: ["KAFKABROKER"]
       - attribute: hostname
         present: true
@@ -82,7 +82,7 @@ relationships:
     conditions:
       - attribute: eventType
         anyOf: ["KafkaBrokerSample"]
-      - attribute: nr.entityType
+      - attribute: entityType
         anyOf: ["KAFKABROKER"]
       - attribute: hostname
         present: true
@@ -116,7 +116,7 @@ relationships:
     conditions:
       - attribute: eventType
         anyOf: ["KafkaBrokerSample"]
-      - attribute: nr.entityType
+      - attribute: entityType
         anyOf: ["KAFKABROKER"]
       - attribute: hostname
         present: true

--- a/relationships/synthesis/INFRA-HOST-to-INFRA-KAFKACLUSTER.stg.yml
+++ b/relationships/synthesis/INFRA-HOST-to-INFRA-KAFKACLUSTER.stg.yml
@@ -8,7 +8,7 @@ relationships:
     conditions:
       - attribute: eventType
         anyOf: ["KafkaClusterSample"]
-      - attribute: nr.entityType
+      - attribute: entityType
         anyOf: ["KafkaCluster"]
       - attribute: clusterName
         present: true
@@ -52,7 +52,7 @@ relationships:
     conditions:
       - attribute: eventType
         anyOf: ["KafkaClusterSample"]
-      - attribute: nr.entityType
+      - attribute: entityType
         anyOf: ["KafkaCluster"]
       - attribute: clusterName
         present: true

--- a/relationships/synthesis/INFRA-HOST-to-INFRA-MEMCACHEDINSTANCE.stg.yml
+++ b/relationships/synthesis/INFRA-HOST-to-INFRA-MEMCACHEDINSTANCE.stg.yml
@@ -7,7 +7,7 @@ relationships:
     conditions:
       - attribute: eventType
         anyOf: ["MemcachedSample"]
-      - attribute: nr.entityType
+      - attribute: entityType
         anyOf: ["MemcachedInstance","MEMCACHEDINSTANCE"]
       - attribute: hostname
         present: true
@@ -44,7 +44,7 @@ relationships:
     conditions:
       - attribute: eventType
         anyOf: ["MemcachedSample"]
-      - attribute: nr.entityType
+      - attribute: entityType
         anyOf: ["MemcachedInstance","MEMCACHEDINSTANCE"]
       - attribute: hostname
         present: true
@@ -82,7 +82,7 @@ relationships:
     conditions:
       - attribute: eventType
         anyOf: ["MemcachedSample"]
-      - attribute: nr.entityType
+      - attribute: entityType
         anyOf: ["MemcachedInstance","MEMCACHEDINSTANCE"]
       - attribute: hostname
         present: true
@@ -118,7 +118,7 @@ relationships:
     conditions:
       - attribute: eventType
         anyOf: ["MemcachedSample"]
-      - attribute: nr.entityType
+      - attribute: entityType
         anyOf: ["MemcachedInstance","MEMCACHEDINSTANCE"]
       - attribute: hostname
         present: true

--- a/relationships/synthesis/INFRA-HOST-to-INFRA-RABBITMQNODE.stg.yml
+++ b/relationships/synthesis/INFRA-HOST-to-INFRA-RABBITMQNODE.stg.yml
@@ -7,7 +7,7 @@ relationships:
     conditions:
       - attribute: eventType
         anyOf: ["RabbitmqNodeSample"]
-      - attribute: nr.entityType
+      - attribute: entityType
         anyOf: ["RABBITMQNODE"]
       - attribute: hostname
         present: true
@@ -45,7 +45,7 @@ relationships:
     conditions:
       - attribute: eventType
         anyOf: ["RabbitmqNodeSample"]
-      - attribute: nr.entityType
+      - attribute: entityType
         anyOf: ["RABBITMQNODE"]
       - attribute: hostname
         present: true
@@ -83,7 +83,7 @@ relationships:
     conditions:
       - attribute: eventType
         anyOf: ["RabbitmqNodeSample"]
-      - attribute: nr.entityType
+      - attribute: entityType
         anyOf: ["RABBITMQNODE"]
       - attribute: hostname
         present: true
@@ -121,7 +121,7 @@ relationships:
     conditions:
       - attribute: eventType
         anyOf: ["RabbitmqNodeSample"]
-      - attribute: nr.entityType
+      - attribute: entityType
         anyOf: ["RABBITMQNODE"]
       - attribute: hostname
         present: true

--- a/relationships/synthesis/INFRA-KAFKACLUSTER-to-INFRA-KAFKABROKER.stg.yml
+++ b/relationships/synthesis/INFRA-KAFKACLUSTER-to-INFRA-KAFKABROKER.stg.yml
@@ -6,7 +6,7 @@ relationships:
     conditions:
       - attribute: event_type
         anyOf: [ "KafkaBrokerSample" ]
-      - attribute: nr.entityType
+      - attribute: entityType
         anyOf: [ "KafkaBroker" ]
     relationship:
       expires: PT75M
@@ -27,7 +27,7 @@ relationships:
         extractGuid:
           attribute: entityGuid
           entityType:
-            attribute: nr.entityType
+            attribute: entityType
 
   - name: otelKafkaClusterContainsKafkaBrokerStgOverride1
     version: "1"

--- a/relationships/synthesis/INFRA-RABBITMQNODE-to-INFRA-RABBITMQQUEUE.stg.yml
+++ b/relationships/synthesis/INFRA-RABBITMQNODE-to-INFRA-RABBITMQQUEUE.stg.yml
@@ -52,7 +52,7 @@ relationships:
     conditions:
       - attribute: eventType
         anyOf: [ "RabbitmqQueueSample" ]
-      - attribute: nr.entityType
+      - attribute: entityType
         anyOf: [ "RabbitmqQueue","RABBITMQQUEUE" ]
       - attribute: entityKey
         regex: ".*:clustername=([^:]+)"


### PR DESCRIPTION
### Relevant information

Infra data pipleine is migrating indexation of entityTypes to Entity Synthesis.
During the process, we rename nr.entityType to entityType.
This affects relationships and we didn't notice it.
This PR is meant to fix only entities that has being migrated


### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid.
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
* [ ] I've linked an ARB ticket & received approval from API Review Board in order to make these changes
