### PR TITLE
Split Confluent Cloud PrivateLink synthesis rule 

### DIFF
--- a/relationships/candidates/KAFKATOPIC.stg.yml
+++ b/relationships/candidates/KAFKATOPIC.stg.yml
@@ -18,7 +18,11 @@ lookups:
       uninstrumented:
         type: KAFKATOPIC
 
-  # Tier 1: bootstrapServers match (public/Basic/Standard clusters).
+  # bootstrapServers match (public/Basic/Standard clusters). Synthesis now emits this as its
+  # own candidate carrying only bootstrapServers+topic (never clusterId), so this tier is
+  # terminal in practice: the clusterId tier below is structurally skipped for it (missing
+  # field), never reached as a fallback. onMiss must create the uninstrumented placeholder
+  # here directly, matching production's unmodified single-tier behavior.
   - entityTypes:
       - INFRA-CONFLUENTCLOUDKAFKATOPIC
     tags:
@@ -31,9 +35,13 @@ lookups:
     onMatch:
       onMultipleMatches: RELATE_ALL
     onMiss:
-      action: NO_OP
+      action: CREATE_UNINSTRUMENTED
+      uninstrumented:
+        type: KAFKATOPIC
 
-  # Tier 2 (final fallback): clusterId match, for private-networked (PrivateLink/PSC) clusters.
+  # clusterId match, for private-networked (PrivateLink/PSC) clusters — synthesized as its own
+  # candidate carrying only clusterId+topic (never bootstrapServers), so this tier never
+  # overlaps with the one above.
   - entityTypes:
       - INFRA-CONFLUENTCLOUDKAFKATOPIC
     tags:

--- a/relationships/candidates/KAFKATOPIC.stg.yml
+++ b/relationships/candidates/KAFKATOPIC.stg.yml
@@ -18,11 +18,7 @@ lookups:
       uninstrumented:
         type: KAFKATOPIC
 
-  # bootstrapServers match (public/Basic/Standard clusters). Synthesis now emits this as its
-  # own candidate carrying only bootstrapServers+topic (never clusterId), so this tier is
-  # terminal in practice: the clusterId tier below is structurally skipped for it (missing
-  # field), never reached as a fallback. onMiss must create the uninstrumented placeholder
-  # here directly, matching production's unmodified single-tier behavior.
+  # bootstrapServers match (public/Basic/Standard clusters).
   - entityTypes:
       - INFRA-CONFLUENTCLOUDKAFKATOPIC
     tags:
@@ -39,9 +35,7 @@ lookups:
       uninstrumented:
         type: KAFKATOPIC
 
-  # clusterId match, for private-networked (PrivateLink/PSC) clusters — synthesized as its own
-  # candidate carrying only clusterId+topic (never bootstrapServers), so this tier never
-  # overlaps with the one above.
+  # clusterId match, for private-networked (PrivateLink/PSC) clusters.
   - entityTypes:
       - INFRA-CONFLUENTCLOUDKAFKATOPIC
     tags:

--- a/relationships/synthesis/APM-APPLICATION-to-KAFKATOPIC.stg.yml
+++ b/relationships/synthesis/APM-APPLICATION-to-KAFKATOPIC.stg.yml
@@ -99,11 +99,7 @@ relationships:
             - field: topic
               attribute: metricName__6
 
-  # Fallback for private-networked (PrivateLink/PSC) clusters, whose bootstrap DNS starts with
-  # the cluster ID and never matches bootstrapServers above. Kept as its own rule: a capture
-  # field that fails to regex-match aborts synthesis for the whole rule
-  # (GuidToLookupMaterializer.extractFields), so it can't share a rule with bootstrapServers,
-  # which always succeeds and would otherwise be aborted along with it for every public cluster.
+  # Fallback for private-networked (PrivateLink/PSC) clusters.
   - name: apmProducesConfluentCloudKafkaTopicPrivateLinkStgOverride
     version: "1"
     origins:

--- a/relationships/synthesis/APM-APPLICATION-to-KAFKATOPIC.stg.yml
+++ b/relationships/synthesis/APM-APPLICATION-to-KAFKATOPIC.stg.yml
@@ -61,7 +61,7 @@ relationships:
       - APM Metrics
     conditions:
       - attribute: metricName
-        regex: "^MessageBroker/Kafka/Nodes/.*.confluent.cloud:9[0-9]+/Produce/.+"
+        regex: "^MessageBroker/Kafka/Nodes/(?!lkc-)[^/]*\\.confluent\\.cloud:9[0-9]+/Produce/.+"
     relationship:
       expires: PT75M
       relationshipType: PRODUCES
@@ -83,7 +83,7 @@ relationships:
       - APM Metrics
     conditions:
       - attribute: metricName
-        regex: "^MessageBroker/Kafka/Nodes/.*.confluent.cloud:9[0-9]+/Consume/.+"
+        regex: "^MessageBroker/Kafka/Nodes/(?!lkc-)[^/]*\\.confluent\\.cloud:9[0-9]+/Consume/.+"
     relationship:
       expires: PT75M
       relationshipType: CONSUMES

--- a/relationships/synthesis/APM-APPLICATION-to-KAFKATOPIC.stg.yml
+++ b/relationships/synthesis/APM-APPLICATION-to-KAFKATOPIC.stg.yml
@@ -74,11 +74,6 @@ relationships:
           fields:
             - field: bootstrapServers
               attribute: metricName__4
-            # Fallback for private-networked clusters, which never match bootstrapServers above.
-            - field: clusterId
-              capture:
-                attribute: metricName__4
-                regex: "^(lkc-[a-zA-Z0-9]+)"
             - field: topic
               attribute: metricName__6
 
@@ -101,7 +96,56 @@ relationships:
           fields:
             - field: bootstrapServers
               attribute: metricName__4
-            # See apmProducesConfluentCloudKafkaTopicStgOverride above.
+            - field: topic
+              attribute: metricName__6
+
+  # Fallback for private-networked (PrivateLink/PSC) clusters, whose bootstrap DNS starts with
+  # the cluster ID and never matches bootstrapServers above. Kept as its own rule: a capture
+  # field that fails to regex-match aborts synthesis for the whole rule
+  # (GuidToLookupMaterializer.extractFields), so it can't share a rule with bootstrapServers,
+  # which always succeeds and would otherwise be aborted along with it for every public cluster.
+  - name: apmProducesConfluentCloudKafkaTopicPrivateLinkStgOverride
+    version: "1"
+    origins:
+      - APM Metrics
+    conditions:
+      - attribute: metricName
+        regex: "^MessageBroker/Kafka/Nodes/lkc-[a-zA-Z0-9]+[^/]*\\.confluent\\.cloud:9[0-9]+/Produce/.+"
+    relationship:
+      expires: PT75M
+      relationshipType: PRODUCES
+      source:
+        extractGuid:
+          attribute: entity.guid
+      target:
+        lookupGuid:
+          candidateCategory: KAFKATOPIC
+          fields:
+            - field: clusterId
+              capture:
+                attribute: metricName__4
+                regex: "^(lkc-[a-zA-Z0-9]+)"
+            - field: topic
+              attribute: metricName__6
+
+  # See apmProducesConfluentCloudKafkaTopicPrivateLinkStgOverride above.
+  - name: apmConsumesConfluentCloudKafkaTopicPrivateLinkStgOverride
+    version: "1"
+    origins:
+      - APM Metrics
+    conditions:
+      - attribute: metricName
+        regex: "^MessageBroker/Kafka/Nodes/lkc-[a-zA-Z0-9]+[^/]*\\.confluent\\.cloud:9[0-9]+/Consume/.+"
+    relationship:
+      expires: PT75M
+      relationshipType: CONSUMES
+      source:
+        extractGuid:
+          attribute: entity.guid
+      target:
+        lookupGuid:
+          candidateCategory: KAFKATOPIC
+          fields:
             - field: clusterId
               capture:
                 attribute: metricName__4


### PR DESCRIPTION
Fixes a regression from #3173. Adding a `clusterId` capture field to the Confluent Cloud synthesis rule broke relationship creation for every public cluster, not just the private ones it was meant to add.

`GuidToLookupMaterializer.extractFields()` aborts the whole rule if any `capture` field fails to regex-match — no optional-field semantics at synthesis time. `clusterId`'s regex only matches PrivateLink hosts (`lkc-*`), so it always failed on public clusters (`pkc-*`), killing the candidate before `candidate-relationship-matcher` ever saw it.

**Synthesis file**: split the combined rule into two — `bootstrapServers`+`topic` (public) and `clusterId`+`topic` (PrivateLink). Their conditions are mutually exclusive (`(?!lkc-)` on the public rule, `lkc-` prefix required on the PrivateLink rule) — verified against a real customer's private cluster, where APM's PrivateLink accesspoint DNS (`lkc-17z27z-ap4ggyrk...`) never matches the entity's real `confluent.clusterBootstrapServers` tag (`lkc-17z27z.eu-west-2.aws.private...`), but `confluent.clusterId` does match on both sides. Without the exclusion, both rules fired for the same private-cluster metric and produced a phantom uninstrumented entity alongside the correct relationship.

**Candidate file**: the bootstrapServers tier's `onMiss` was `NO_OP`, which only made sense when one candidate could fall through to the clusterId tier. Now that the two are disjoint candidates, that fallthrough never happens, so changed it to `CREATE_UNINSTRUMENTED` to match production's original behavior.

Assisted-by: Claude Sonnet 5