### PR TITLE
Bump uninstrumented-kubernetescluster entityExpirationTime FOUR_HOURS…

### DIFF
--- a/entity-types/uninstrumented-kubernetescluster/definition.yml
+++ b/entity-types/uninstrumented-kubernetescluster/definition.yml
@@ -2,7 +2,7 @@ domain: UNINSTRUMENTED
 type: KUBERNETESCLUSTER
 
 configuration:
-  entityExpirationTime: FOUR_HOURS
+  entityExpirationTime: DAILY
   alertable: false
 
 synthesis:


### PR DESCRIPTION
## Summary
Bump `entityExpirationTime` on `uninstrumented-kubernetescluster` from `FOUR_HOURS` to `DAILY` to match the cadence at which cross-cloud Configuration Fetchers drive candidate resolution to `INFRA-KUBERNETESCLUSTER`.

## Why
- Cloud Monitoring's Azure/AWS/GCP Configuration Fetchers scan customer cloud accounts on an **8/12/16-hour cadence** in production. Each scan re-emits the candidate relationship that acts as the keepalive for any uninstrumented placeholder synthesized on the platform side.
- With `FOUR_HOURS`, placeholders die **4–12 hours** before the next scan re-emits them. Customers whose AKS/EKS/GKE clusters don't yet have the k8s agent installed see the cluster + its neighbor relationships flicker in and out of the Cloud360 infrastructure map every scan cycle.
- `DAILY` gives comfortable headroom above the slowest fetcher cadence and covers deploy windows + transient Kafka delays.

## Alignment with existing patterns
- **67 of the 71** `uninstrumented-*` entities in this repo use `DAILY` today, including every Azure and AWS uninstrumented type.
- The 3 other `FOUR_HOURS` holdouts (`uninstrumented-container`, `uninstrumented-host`, `uninstrumented-httpservice`) are k8s-agent-native cases where a fast expiry makes sense — agent goes silent, drop the placeholder quickly.
- `uninstrumented-kubernetescluster` is the odd one out: it's the placeholder target for cross-cloud config fetchers (ACF/AWS-CF/GCP-CF), not just for k8s-agent-native flows. `DAILY` is a better fit for that use case.

## Related work
- Cloud360 → INFRA-KUBERNETESCLUSTER migration: [NR-604226](https://new-relic.atlassian.net/browse/NR-604226)
- Predicate PR (already merged): [#3191](https://github.com/newrelic/entity-definitions/pull/3191)

## Test plan
- [ ] K8s Agents team review — confirm no k8s-agent-native flow relies on the 4-hour lifetime for this entity
- [ ] Merge → deploy to entity platform → verify new placeholders live 24h

[NR-604226]: https://new-relic.atlassian.net/browse/NR-604226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ