### PR TITLE
fix: promote #3207's corrected Confluent Cloud PrivateLink fix to production

### DIFF
--- a/relationships/candidates/KAFKATOPIC.yml
+++ b/relationships/candidates/KAFKATOPIC.yml
@@ -18,7 +18,7 @@ lookups:
       uninstrumented:
         type: KAFKATOPIC
   
-  # Tier 1: bootstrapServers match (public/Basic/Standard clusters).
+  # bootstrapServers match (public/Basic/Standard clusters).
   - entityTypes:
     - INFRA-CONFLUENTCLOUDKAFKATOPIC
     tags:
@@ -31,9 +31,11 @@ lookups:
     onMatch:
       onMultipleMatches: RELATE_ALL
     onMiss:
-      action: NO_OP
+      action: CREATE_UNINSTRUMENTED
+      uninstrumented:
+        type: KAFKATOPIC
 
-  # Tier 2 (final fallback): clusterId match, for private-networked (PrivateLink/PSC) clusters.
+  # clusterId match, for private-networked (PrivateLink/PSC) clusters.
   - entityTypes:
     - INFRA-CONFLUENTCLOUDKAFKATOPIC
     tags:

--- a/relationships/synthesis/APM-APPLICATION-to-KAFKATOPIC.yml
+++ b/relationships/synthesis/APM-APPLICATION-to-KAFKATOPIC.yml
@@ -105,7 +105,7 @@ relationships:
       - APM Metrics
     conditions:
       - attribute: metricName
-        regex: "^MessageBroker/Kafka/Nodes/.*.confluent.cloud:9[0-9]+/Produce/.+"
+        regex: "^MessageBroker/Kafka/Nodes/(?!lkc-)[^/]*\\.confluent\\.cloud:9[0-9]+/Produce/.+"
     relationship:
       expires: PT75M
       relationshipType: PRODUCES
@@ -118,11 +118,6 @@ relationships:
           fields:
             - field: bootstrapServers
               attribute: metricName__4
-            # Fallback for private-networked clusters, which never match bootstrapServers above.
-            - field: clusterId
-              capture:
-                attribute: metricName__4
-                regex: "^(lkc-[a-zA-Z0-9]+)"
             - field: topic
               attribute: metricName__6
 
@@ -132,7 +127,7 @@ relationships:
       - APM Metrics
     conditions:
       - attribute: metricName
-        regex: "^MessageBroker/Kafka/Nodes/.*.confluent.cloud:9[0-9]+/Consume/.+"
+        regex: "^MessageBroker/Kafka/Nodes/(?!lkc-)[^/]*\\.confluent\\.cloud:9[0-9]+/Consume/.+"
     relationship:
       expires: PT75M
       relationshipType: CONSUMES
@@ -145,7 +140,52 @@ relationships:
           fields:
             - field: bootstrapServers
               attribute: metricName__4
-            # See apmProducesConfluentCloudKafkaTopic above.
+            - field: topic
+              attribute: metricName__6
+
+  # Fallback for private-networked (PrivateLink/PSC) clusters.
+  - name: apmProducesConfluentCloudKafkaTopicPrivateLink
+    version: "1"
+    origins:
+      - APM Metrics
+    conditions:
+      - attribute: metricName
+        regex: "^MessageBroker/Kafka/Nodes/lkc-[a-zA-Z0-9]+[^/]*\\.confluent\\.cloud:9[0-9]+/Produce/.+"
+    relationship:
+      expires: PT75M
+      relationshipType: PRODUCES
+      source:
+        extractGuid:
+          attribute: entity.guid
+      target:
+        lookupGuid:
+          candidateCategory: KAFKATOPIC
+          fields:
+            - field: clusterId
+              capture:
+                attribute: metricName__4
+                regex: "^(lkc-[a-zA-Z0-9]+)"
+            - field: topic
+              attribute: metricName__6
+
+  # See apmProducesConfluentCloudKafkaTopicPrivateLink above.
+  - name: apmConsumesConfluentCloudKafkaTopicPrivateLink
+    version: "1"
+    origins:
+      - APM Metrics
+    conditions:
+      - attribute: metricName
+        regex: "^MessageBroker/Kafka/Nodes/lkc-[a-zA-Z0-9]+[^/]*\\.confluent\\.cloud:9[0-9]+/Consume/.+"
+    relationship:
+      expires: PT75M
+      relationshipType: CONSUMES
+      source:
+        extractGuid:
+          attribute: entity.guid
+      target:
+        lookupGuid:
+          candidateCategory: KAFKATOPIC
+          fields:
             - field: clusterId
               capture:
                 attribute: metricName__4


### PR DESCRIPTION
## What happened

#3197 was meant to promote the NR-607184 fix (Confluent Cloud PrivateLink clusters not getting APM relationships) to production, but it copied the pre-#3207 diff instead of the corrected one. That version combines `bootstrapServers` and a `clusterId` capture field in a single synthesis rule, which breaks relationship creation for **public** Confluent Cloud clusters too, not just the private ones it was meant to help — `clusterId`'s regex only matches PrivateLink hosts (`lkc-*`), so it fails to capture on public hosts (`pkc-*`) and takes the whole candidate down with it.

This PR applies #3207's already-reviewed fix to the production files instead: split into two independent rules, one for public clusters (`bootstrapServers`+`topic`) and one for PrivateLink clusters (`clusterId`+`topic`), with mutually exclusive conditions so only one ever fires per metric.

## Changes

* `relationships/synthesis/APM-APPLICATION-to-KAFKATOPIC.yml` — split `apmProduces/ConsumesConfluentCloudKafkaTopic` into a public rule and a new `...PrivateLink` rule.
* `relationships/candidates/KAFKATOPIC.yml` — `bootstrapServers` tier's `onMiss` reverts to `CREATE_UNINSTRUMENTED` (matching original production behavior; no more fallthrough needed now that the candidates are disjoint).

## Verification

* `npm run check` passes.
* Regex-tested the new conditions against every broker URL form we could find or reason about — public (AWS/GCP/Azure) and private (direct-networking and PrivateLink/multi-cloud access point, all three clouds) — confirmed public never matches, private always matches exactly one of the Produce/Consume rules.
* Confirmed against a real customer's PrivateLink cluster that `clusterId` matches on both sides even when `bootstrapServers` never will.
* Confirmed on a live production test that public clusters are unaffected by this change (they already worked, and still do).

Same classification as #3173/#3197/#3207 — no new identifiers or entity types.