### PR TITLE
Add synthesis rule for AZUREVIRTUALNETWORKSROUTETABLE

### DIFF
--- a/entity-types/infra-azurevirtualnetworksroutetable/definition.yml
+++ b/entity-types/infra-azurevirtualnetworksroutetable/definition.yml
@@ -3,6 +3,20 @@ type: AZUREVIRTUALNETWORKSROUTETABLE
 configuration:
   entityExpirationTime: DAILY
   alertable: false
+synthesis:
+  tags:
+    newrelic.cloudIntegrations.providerAccountName:
+      entityTagNames: [newrelic.cloudIntegrations.providerAccountName, providerAccountName]
+  rules:
+    - ruleName: infra_azurevirtualnetworksroutetable_azure_resourceId
+      identifier: azure.resourceId
+      name: displayName
+      legacyFeatures:
+        overrideGuidType: true
+      encodeIdentifierInGUID: true
+      conditions:
+        - attribute: azure.resourceType
+          value: microsoft.network/routetables
 
 ownership:
   primaryOwner:


### PR DESCRIPTION
### Relevant information

The `AZUREVIRTUALNETWORKSROUTETABLE` entity type (`entity-types/infra-azurevirtualnetworksroutetable/`) is registered - domain, type, and ownership are set - but has no `synthesis` block. As a result, no entity of this type has ever been materialized: `azure.resourceType == microsoft.network/routetables` matches no rule anywhere in this repo, and a live entity search across the whole platform confirms zero `AZUREVIRTUALNETWORKSROUTETABLE` entities exist today, for any account.

This adds a single synthesis rule matching `azure.resourceType == microsoft.network/routetables`, following the exact pattern already used by the sibling `AZURENATGATEWAY` and `AZUREBASTIONHOST` definitions (both owned by the same team, Cloud Monitoring Platform).

This unblocks the `auto-discover` entity synthesis path, which already scans all Azure resource types via Resource Graph with no allowlist - it just had nothing to match route tables against. It's needed so that new AKS <-> Route Table relationships (NR-589545, in `beyond/azure-configuration-fetcher`) have a real entity on the Route Table side to point at.

Validated locally with this repo's own validator (`npm run validate-definition` and the full jest suite) - both pass.

#### Api Review Board (ARB)

ARB Jira ticket:
https://new-relic.atlassian.net/browse/NR-551510

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. (`azure.resourceId`, same identifier pattern as every other Azure network resource type in this repo.)
* [x] I've confirmed that my entity type wasn't already defined. It was defined (domain/type/ownership) but had no synthesis rule - that's the gap this PR closes.
* [ ] I've linked an ARB ticket & received approval from API Review Board in order to make these changes. (Ticket linked above; approval pending.)